### PR TITLE
[Storage] API Updates to add Ray Options Provider

### DIFF
--- a/deltacat/storage/interface.py
+++ b/deltacat/storage/interface.py
@@ -6,7 +6,7 @@ from deltacat.storage import Delta, DeltaLocator, Partition, \
     LocalTable, LocalDataset, DistributedDataset, Manifest, ManifestAuthor
 from deltacat.types.media import ContentType
 from deltacat.types.media import TableType, StorageType
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 
 def list_namespaces(
@@ -161,6 +161,7 @@ def download_delta(
         max_parallelism: Optional[int] = None,
         columns: Optional[List[str]] = None,
         file_reader_kwargs: Optional[Dict[str, Any]] = None,
+        ray_options_provider: Callable[[int, Any], Dict[str, Any]] = None,
         *args,
         **kwargs) -> Union[LocalDataset, DistributedDataset]:
     """

--- a/deltacat/storage/model/stream.py
+++ b/deltacat/storage/model/stream.py
@@ -123,8 +123,8 @@ class Stream(dict):
         num_values = len(partition_values) if partition_values else 0
         if num_values != num_keys:
             raise ValueError(
-                f"Found {num_values} partition values but only "
-                f"{num_keys} keys: {self}")
+                f"Found {num_values} partition values but "
+                f"{num_keys} partition keys: {self}")
 
 
 class StreamLocator(Locator, dict):

--- a/deltacat/utils/ray_utils/concurrency.py
+++ b/deltacat/utils/ray_utils/concurrency.py
@@ -1,4 +1,4 @@
-from typing import Collection, Callable, List
+from typing import Any, Collection, Callable, Dict, List
 
 import ray
 from ray.types import ObjectRef
@@ -7,8 +7,9 @@ from ray.types import ObjectRef
 def invoke_parallel(
         items: Collection,
         ray_task: Callable,
-        max_parallelism: int = 1000,
         *args,
+        max_parallelism: int = 1000,
+        options_provider: Callable[[int, Any], Dict[str, Any]] = None,
         **kwargs) -> List[ObjectRef]:
     """
     Creates a limited number of parallel remote invocations of the given ray
@@ -21,18 +22,23 @@ def invoke_parallel(
         items (Collection): Collection of items to iterate over (in-order), and
         provide as the first input argument to the given ray task.
         ray_task (Callable): Ray task to invoke.
-        max_parallelism (int): Maximum parallel remote invocations. Defaults to
-        1000.
         *args: Ordered input arguments to the Ray task to invoke (provided
         immediately after the input item).
+        max_parallelism (int): Maximum parallel remote invocations. Defaults to
+        1000.
+        options_provider (Callable): Callback that takes the current item
+        index and item as input and returns `ray.remote` options as output.
         **kwargs: Keyword arguments to the Ray task to invoke.
     Returns:
-        pending_ids (List[ObjectRef]): List of ready Ray object references.
+        pending_ids (List[ObjectRef]): List of Ray object references.
     """
     pending_ids = []
     for i, item in enumerate(items):
         if len(pending_ids) > max_parallelism:
             ray.wait(pending_ids, num_returns=i - max_parallelism)
-        pending_id = ray_task.remote(item, *args, **kwargs)
+        opt = {}
+        if options_provider:
+            opt = options_provider(i, item)
+        pending_id = ray_task.options(**opt).remote(item, *args, **kwargs)
         pending_ids.append(pending_id)
     return pending_ids


### PR DESCRIPTION
This PR changes existing APIs to inject `ray.remote` options providers when invoking storage APIs that will subsequently invoke concurrent Ray tasks for all blocks of a dataset.