### PR TITLE
Hotfix: removed ambiguous redirect

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -30,7 +30,7 @@ jobs:
       run: >-
         python -m pytest
     - name: Echo release tag
-      run: echo ${{ github.ref_name }} >> $RELEASE_TAG
+      run: echo ${{ github.ref_name }}
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m


### PR DESCRIPTION
Echo tag step is throwing this error 
```
Run echo 0.1.11 >> $RELEASE_TAG
/home/runner/work/_temp/8[7](https://github.com/pfaraone/deltacat/actions/runs/3876493599/jobs/6610396785#step:9:8)564d[8](https://github.com/pfaraone/deltacat/actions/runs/3876493599/jobs/6610396785#step:9:9)8-5c28-4a45-843a-b33a4816a362.sh: line 1: $RELEASE_TAG: ambiguous redirect
Error: Process completed with exit code 1.
```