### PR TITLE
Bumped dependencies down to support Python 3.7

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,11 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@main
+      uses: actions/checkout@${{ github.ref_name }}
       with:
           fetch-depth: 0
-    - name: Branch name
-      run: echo running on branch ${GITHUB_REF##*/}
     - name: Set up Python 3.7 (minimum supported python version for deltaCAT)
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,8 +11,6 @@ jobs:
       uses: actions/checkout@main
       with:
           fetch-depth: 0
-    - name: Branch name
-      run: echo running on branch ${GITHUB_REF##*/}
     - name: Set up Python 3.7 (minimum supported python version for deltaCAT)
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,10 +11,10 @@ jobs:
       uses: actions/checkout@main
       with:
           fetch-depth: 0
-    - name: Set up Python 3.10
+    - name: Set up Python 3.7
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.7"
     - name: Install pypa/build
       run: >-
         python -m
@@ -33,11 +33,7 @@ jobs:
       run: echo ${{ github.ref_name }}
     - name: Build a binary wheel and a source tarball
       run: >-
-        python -m
-        build
-        --sdist
-        --wheel
-        --outdir dist/
+        python setup.py sdist bdist_wheel
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,9 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@${{ github.ref_name }}
+      uses: actions/checkout@main
       with:
           fetch-depth: 0
+    - name: Branch name
+      run: echo running on branch ${GITHUB_REF##*/}
     - name: Set up Python 3.7 (minimum supported python version for deltaCAT)
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,7 +11,9 @@ jobs:
       uses: actions/checkout@main
       with:
           fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Branch name
+      run: echo running on branch ${GITHUB_REF##*/}
+    - name: Set up Python 3.7 (minimum supported python version for deltaCAT)
       uses: actions/setup-python@v3
       with:
         python-version: "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # setup.py install_requires
 # any changes here should also be reflected in setup.py "install_requires"
-boto3 == 1.24.59
-numpy == 1.23.4
-pandas == 1.5.2
+boto3 == 1.20.24
+numpy == 1.21.5
+pandas == 1.3.5
 pyarrow == 10.0.1
 pydantic == 1.10.4
 ray[default] == 2.0.0
-s3fs == 2022.11.0
+s3fs == 2022.2.0
 tenacity == 8.1.0
 typing-extensions == 4.4.0

--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,13 @@ with open(os.path.join(ROOT_DIR, "README.md"), "r", encoding="utf-8") as fh:
 
 
 setuptools.setup(
-    name="deltacat-fork",
+    name="deltacat",
     version=find_version("deltacat", "__init__.py"),
     author="Ray Team",
     description="A scalable, fast, ACID-compliant Data Catalog powered by Ray.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/ray-project/deltacat-fork",
+    url="https://github.com/ray-project/deltacat",
     packages=setuptools.find_packages(where=".", include="deltacat*"),
     install_requires=[
         # any changes here should also be reflected in requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -25,24 +25,24 @@ with open(os.path.join(ROOT_DIR, "README.md"), "r", encoding="utf-8") as fh:
 
 
 setuptools.setup(
-    name="deltacat",
+    name="deltacat-fork",
     version=find_version("deltacat", "__init__.py"),
     author="Ray Team",
     description="A scalable, fast, ACID-compliant Data Catalog powered by Ray.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/ray-project/deltacat",
+    url="https://github.com/ray-project/deltacat-fork",
     packages=setuptools.find_packages(where=".", include="deltacat*"),
     install_requires=[
         # any changes here should also be reflected in requirements.txt
-        "s3fs == 2022.1.0",
-        "tenacity == 8.1.0",
-        "ray[default] == 2.0.0",
-        "pandas == 1.5.2",
+        "boto3 == 1.20.24",
+        "numpy == 1.21.5",
+        "pandas == 1.3.5",
         "pyarrow == 10.0.1",
         "pydantic == 1.10.4",
-        "numpy == 1.23.4",
-        "boto3 == 1.24.59",
+        "ray[default] == 2.0.0",
+        "s3fs == 2022.2.0",
+        "tenacity == 8.1.0",
         "typing-extensions == 4.4.0",
     ],
     setup_requires=["wheel"],


### PR DESCRIPTION
## Why 
In #26  we pinned some dependency versions which pinned us to py38+ even though we've explicitly stated we are supporting py37 and above