### PR TITLE
[compaction] Enable compaction based on compacted source partition; Add support for primary key index building

### DIFF
--- a/deltacat/compute/compactor/utils/system_columns.py
+++ b/deltacat/compute/compactor/utils/system_columns.py
@@ -64,6 +64,11 @@ _IS_SOURCE_COLUMN_FIELD = pa.field(
 )
 
 
+def if_stream_position_column_exists(obj) -> bool:
+    return True if _PARTITION_STREAM_POSITION_COLUMN_NAME\
+                   in obj.column_names else False
+
+
 def get_pk_hash_column_array(obj) -> Union[pa.Array, pa.ChunkedArray]:
     return pa.array(
         obj,


### PR DESCRIPTION
This PR adds support for compaction based on compacted source partition locator by:
1. Building initial primary key indices on compacted source partition locator.
2. Producing round completion file containing all initial primary key indices and stats about primary key indices.
3. In subsequent compaction run, reading high watermark from round completion file and discover new deltas.
4. In subsequent compaction run, consuming all primary key indices during dedupe correctly.

Testing:
For correctness check, tested with the following scenario:
delta 1: 100 rows, building primary key indices on.
delta 2: 40 rows, 20 distinct rows. 40 rows having primary keys same as in delta 1.
delta 3: 200 rows, 200 distinct rows. 100 rows having primary keys same as in delta 1.

Scenario 1: Build primary key indices on delta 1 first, subsequent compaction on delta 2. Compaction dedupe step taking 140 rows as input, producing 100 rows as output.
Scenario 2: Build primary key indices on delta 1 first, subsequent compaction on delta 2 and delta 3. Compaction dedupe step taking 340 rows as input, producing 200 rows as output.




