### PR TITLE
Optimized the dedupe step and writing primary key index

### DIFF
--- a/deltacat/aws/s3u.py
+++ b/deltacat/aws/s3u.py
@@ -35,8 +35,6 @@ from typing import Any, Callable, Dict, List, Optional, Generator, Union
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-
-@ray.remote
 class CapturedBlockWritePaths:
     def __init__(self):
         self._write_paths: List[str] = []
@@ -70,14 +68,14 @@ class UuidBlockWritePathProvider(BlockWritePathProvider):
     """Block write path provider implementation that writes each
     dataset block out to a file of the form: {base_path}/{uuid}
     """
-    def __init__(self, capture_actor: CapturedBlockWritePaths):
+    def __init__(self, capture_object: CapturedBlockWritePaths):
         self.write_paths: List[str] = []
         self.block_refs: List[ObjectRef[Block]] = []
-        self.capture_actor = capture_actor
+        self.capture_object = capture_object
 
     def __del__(self):
         if self.write_paths or self.block_refs:
-            self.capture_actor.extend.remote(
+            self.capture_object.extend(
                 self.write_paths,
                 self.block_refs,
             )
@@ -357,8 +355,8 @@ def upload_table(
     if s3_table_writer_kwargs is None:
         s3_table_writer_kwargs = {}
 
-    capture_actor = CapturedBlockWritePaths.remote()
-    block_write_path_provider = UuidBlockWritePathProvider(capture_actor)
+    capture_object = CapturedBlockWritePaths()
+    block_write_path_provider = UuidBlockWritePathProvider(capture_object)
     s3_table_writer_func(
         table,
         s3_base_url,
@@ -369,8 +367,8 @@ def upload_table(
     )
     # TODO: Add a proper fix for block_refs and write_paths not persisting in Ray actors
     del block_write_path_provider
-    block_refs = ray.get(capture_actor.block_refs.remote())
-    write_paths = ray.get(capture_actor.write_paths.remote())
+    block_refs = capture_object.block_refs()
+    write_paths = capture_object.write_paths()
     metadata = _get_metadata(table, write_paths, block_refs)
     manifest_entries = ManifestEntryList()
     for block_idx, s3_url in enumerate(write_paths):

--- a/deltacat/aws/s3u.py
+++ b/deltacat/aws/s3u.py
@@ -35,6 +35,8 @@ from typing import Any, Callable, Dict, List, Optional, Generator, Union
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
+# TODO(raghumdani): refactor redshift datasource to reuse the 
+# same module for writing output files.
 class CapturedBlockWritePaths:
     def __init__(self):
         self._write_paths: List[str] = []

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -1,5 +1,4 @@
 import logging
-import time
 import functools
 import ray
 
@@ -22,13 +21,11 @@ from deltacat.compute.compactor.utils import round_completion_file as rcf, io, \
     primary_key_index as pki
 from deltacat.types.media import ContentType
 
-from typing import List, Set, Optional, Tuple, Dict, Union, Any
+from typing import List, Set, Optional, Tuple, Dict, Any
 
 import pyarrow as pa
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-_SORT_KEY_NAME_INDEX: int = 0
-_SORT_KEY_ORDER_INDEX: int = 1
 _PRIMARY_KEY_INDEX_ALGORITHM_VERSION: str = "1.0"
 
 
@@ -172,13 +169,6 @@ def _execute_compaction_round(
     # sort primary keys to produce the same pk digest regardless of input order
     primary_keys = sorted(primary_keys)
 
-    # collect cluster resource stats
-    # cluster_resources = ray.cluster_resources()
-    # logger.info(f"Total cluster resources: {cluster_resources}")
-    # logger.info(f"Available cluster resources: {ray.available_resources()}")
-    # cluster_cpus = int(cluster_resources["CPU"])
-    # logger.info(f"Total cluster CPUs: {cluster_cpus}")
-
     # collect node group resources
 
     cluster_resources = ray.cluster_resources()
@@ -234,11 +224,14 @@ def _execute_compaction_round(
     # a compatible primary key index
     round_completion_info = None
     if read_round_completion:
+        logger.info(f"Reading round completion file for compatible "
+                    f"primary key index root path {compatible_primary_key_index_root_path}")
         round_completion_info = rcf.read_round_completion_file(
             compaction_artifact_s3_bucket,
             source_partition_locator,
             compatible_primary_key_index_root_path,
         )
+        logger.info(f"Round completion file: {round_completion_info}")
 
     # read the previous compaction round's hash bucket count, if any
     old_hash_bucket_count = None
@@ -289,12 +282,13 @@ def _execute_compaction_round(
         f"is invalid."
 
     # rehash the primary key index if necessary
-    round_completion_info = None
     if round_completion_info:
         logger.info(f"Round completion file contents: {round_completion_info}")
         # the previous primary key index is compatible with the current, but
         # will need to be rehashed if the hash bucket count has changed
         if hash_bucket_count != old_hash_bucket_count:
+            # TODO(draghave): manually test the path after prior primary key 
+            # index was already built 
             round_completion_info = pki.rehash(
                 round_robin_opt_provider,
                 compaction_artifact_s3_bucket,
@@ -377,8 +371,6 @@ def _execute_compaction_round(
     # identify the index of records to keep or drop based on sort keys
     num_materialize_buckets = max_parallelism
     logger.info(f"Materialize Bucket Count: {num_materialize_buckets}")
-    record_counts_pending_materialize = \
-        dd.RecordCountsPendingMaterialize.remote(dedupe_task_count)
     dd_tasks_pending = invoke_parallel(
         items=all_hash_group_idx_to_obj_id.values(),
         ray_task=dd.dedupe,
@@ -391,10 +383,8 @@ def _execute_compaction_round(
         new_primary_key_index_version_locator=new_pki_version_locator,
         sort_keys=sort_keys,
         max_records_per_index_file=records_per_primary_key_index_file,
-        max_records_per_materialized_file=records_per_compacted_file,
         num_materialize_buckets=num_materialize_buckets,
-        delete_old_primary_key_index=delete_prev_primary_key_index,
-        record_counts_pending_materialize=record_counts_pending_materialize,
+        delete_old_primary_key_index=delete_prev_primary_key_index
     )
     logger.info(f"Getting {len(dd_tasks_pending)} dedupe results...")
     dd_results = ray.get([t[0] for t in dd_tasks_pending])
@@ -470,7 +460,6 @@ def _execute_compaction_round(
         new_primary_key_index_root_path,
         round_completion_info,
     )
-    time_mat_e = time.time()
     logger.info(f"partition-{source_partition_locator.partition_values},compacted at:{last_stream_position_compacted}, last position:{last_stream_position_to_compact}")
     return \
         (last_stream_position_compacted < last_stream_position_to_compact), \

--- a/deltacat/compute/compactor/steps/hash_bucket.py
+++ b/deltacat/compute/compactor/steps/hash_bucket.py
@@ -28,7 +28,7 @@ HashBucketGroupToObjectId = np.ndarray
 HashBucketResult = Tuple[HashBucketGroupToObjectId, List[ObjectRef[DeltaFileEnvelopeGroups]]]
 
 
-def group_by_pk_hash_bucket(
+def _group_by_pk_hash_bucket(
         table: pa.Table,
         num_buckets: int,
         primary_keys: List[str]) -> np.ndarray:
@@ -39,7 +39,7 @@ def group_by_pk_hash_bucket(
         # casting a primary key column to numpy also ensures no nulls exist
         column_fields = table[pk_name].to_numpy()
         all_pk_column_fields.append(column_fields)
-    hash_column_generator = hash_pk_bytes_generator(all_pk_column_fields)
+    hash_column_generator = _hash_pk_bytes_generator(all_pk_column_fields)
     table = sc.append_pk_hash_column(table, hash_column_generator)
 
     # drop primary key columns to free up memory
@@ -62,7 +62,7 @@ def group_by_pk_hash_bucket(
     return hash_bucket_to_table
 
 
-def hash_pk_bytes_generator(all_column_fields) -> Generator[bytes, None, None]:
+def _hash_pk_bytes_generator(all_column_fields) -> Generator[bytes, None, None]:
     for field_index in range(len(all_column_fields[0])):
         bytes_to_join = []
         for column_fields in all_column_fields:
@@ -72,7 +72,7 @@ def hash_pk_bytes_generator(all_column_fields) -> Generator[bytes, None, None]:
         yield sha1_digest(_PK_BYTES_DELIMITER.join(bytes_to_join))
 
 
-def group_file_records_by_pk_hash_bucket(
+def _group_file_records_by_pk_hash_bucket(
         annotated_delta: DeltaAnnotated,
         num_hash_buckets: int,
         primary_keys: List[str],
@@ -81,7 +81,7 @@ def group_file_records_by_pk_hash_bucket(
         -> Optional[DeltaFileEnvelopeGroups]:
 
     # read input parquet s3 objects into a list of delta file envelopes
-    delta_file_envelopes = read_delta_file_envelopes(
+    delta_file_envelopes = _read_delta_file_envelopes(
         annotated_delta,
         primary_keys,
         sort_key_names,
@@ -93,7 +93,7 @@ def group_file_records_by_pk_hash_bucket(
     # group the data by primary key hash value
     hb_to_delta_file_envelopes = np.empty([num_hash_buckets], dtype="object")
     for dfe in delta_file_envelopes:
-        hash_bucket_to_table = group_by_pk_hash_bucket(
+        hash_bucket_to_table = _group_by_pk_hash_bucket(
             dfe.table,
             num_hash_buckets,
             primary_keys,
@@ -110,8 +110,7 @@ def group_file_records_by_pk_hash_bucket(
                         table))
     return hb_to_delta_file_envelopes
 
-
-def read_delta_file_envelopes(
+def _read_delta_file_envelopes(
         annotated_delta: DeltaAnnotated,
         primary_keys: List[str],
         sort_key_names: List[str],
@@ -145,7 +144,7 @@ def read_delta_file_envelopes(
     return delta_file_envelopes
 
 
-@ray.remote(num_cpus=0.5, num_returns=2)
+@ray.remote(num_returns=2)
 def hash_bucket(
         annotated_delta: DeltaAnnotated,
         primary_keys: List[str],
@@ -156,7 +155,7 @@ def hash_bucket(
 
     logger.info(f"Starting hash bucket task...")
     sort_key_names = [key.key_name for key in sort_keys]
-    delta_file_envelope_groups = group_file_records_by_pk_hash_bucket(
+    delta_file_envelope_groups = _group_file_records_by_pk_hash_bucket(
         annotated_delta,
         num_buckets,
         primary_keys,

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -157,6 +157,8 @@ def materialize(
         record_count = len(pa_table)
         mask_pylist = list(repeat(False, record_count))
         record_numbers = chain.from_iterable(record_numbers_tpl)
+        # TODO(raghumdani): reference the same file URIs while writing the files
+        # instead of copying the data over and creating new files. 
         for record_number in record_numbers:
             mask_pylist[record_number] = True
         mask = pa.array(mask_pylist)
@@ -180,6 +182,8 @@ def materialize(
         )
 
         # Write manifests up to max_records_per_output_file
+        # TODO(raghumdani): Write exactly the same number of records into each file to
+        # produce a read-optimized view of the tables.
         if compacted_tables and \
                 total_record_count + record_count > max_records_per_output_file:
             materialized_results.append(_materialize(compacted_tables, total_record_count))

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -1,4 +1,7 @@
 import logging
+import ray
+import pyarrow as pa
+
 from collections import defaultdict
 from itertools import chain, repeat
 from typing import List, Optional, Tuple
@@ -31,7 +34,7 @@ from deltacat.utils.pyarrow import (
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
-@ray.remote(num_cpus=0.5)
+@ray.remote
 def materialize(
         source_partition_locator: PartitionLocator,
         round_completion_info: Optional[RoundCompletionInfo],
@@ -114,7 +117,7 @@ def materialize(
     compacted_tables = []
     materialized_results: List[MaterializeResult] = []
     total_record_count = 0
-    for src_dfl in enumerate(sorted(all_src_file_records.keys())):
+    for src_dfl in sorted(all_src_file_records.keys()):
         record_numbers_dd_task_idx_tpl_list: List[Tuple[DeltaFileLocatorToRecords, repeat]] = \
             all_src_file_records[src_dfl]
         record_numbers_tpl, dedupe_task_idx_iter_tpl = zip(
@@ -152,11 +155,6 @@ def materialize(
             file_reader_kwargs_provider=read_kwargs_provider,
         )
         record_count = len(pa_table)
-        if record_count > max_records_per_output_file:
-            raise ValueError(f"'max_records_per_output_file' is set to '{max_records_per_output_file}' "
-                             f"but record count of manifest entry id: {src_file_idx_np.item()}, "
-                             f"of delta locator: {delta_locator}, is '{record_count}'. "
-                             f"Please increase your 'max_records_per_output_file'")
         mask_pylist = list(repeat(False, record_count))
         record_numbers = chain.from_iterable(record_numbers_tpl)
         for record_number in record_numbers:

--- a/deltacat/compute/compactor/utils/primary_key_index.py
+++ b/deltacat/compute/compactor/utils/primary_key_index.py
@@ -259,6 +259,8 @@ def write_primary_key_index_files(
     specified S3 bucket at the path identified by the given primary key index
     version locator. Output is written as 1 or more Parquet files with the
     given maximum number of records per file.
+
+    TODO(raghumdani): Support writing primary key index to any data catalog
     """
     logger.info(f"Writing primary key index files for hash bucket {hb_index}. "
                 f"Primary key index version locator: "

--- a/deltacat/compute/compactor/utils/primary_key_index.py
+++ b/deltacat/compute/compactor/utils/primary_key_index.py
@@ -8,8 +8,14 @@ import pyarrow as pa
 import ray
 import s3fs
 from ray import cloudpickle
+from deltacat.constants import PRIMARY_KEY_INDEX_WRITE_BOTO3_CONFIG
 from ray.types import ObjectRef
 
+from deltacat.storage import Manifest, PartitionLocator
+from deltacat.utils.ray_utils.concurrency import invoke_parallel
+from deltacat.compute.compactor import PyArrowWriteResult, \
+    RoundCompletionInfo, PrimaryKeyIndexMeta, PrimaryKeyIndexLocator, \
+    PrimaryKeyIndexVersionMeta, PrimaryKeyIndexVersionLocator
 from deltacat import logs
 from deltacat.aws import s3u
 from deltacat.compute.compactor import (
@@ -29,8 +35,7 @@ from deltacat.types.media import ContentEncoding, ContentType
 from deltacat.types.tables import get_table_slicer, get_table_writer
 from deltacat.utils.common import ReadKwargsProvider
 from deltacat.utils.ray_utils.concurrency import (
-    invoke_parallel,
-    round_robin_options_provider,
+    invoke_parallel
 )
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
@@ -194,6 +199,9 @@ def group_hash_bucket_indices(
         hash_bucket_object_groups: np.ndarray,
         num_buckets: int,
         num_groups: int) -> Tuple[np.ndarray, List[ObjectRef]]:
+    """
+    Groups all the ObjectRef that belongs to a particular hash bucket group and hash bucket index. 
+    """
 
     object_refs = []
     hash_bucket_group_to_obj_id = np.empty([num_groups], dtype="object")
@@ -232,6 +240,10 @@ def group_hash_bucket_indices(
 def pk_digest_to_hash_bucket_index(
         digest,
         num_buckets: int) -> int:
+    """
+    Deterministically get the hash bucket a particular digest belongs to
+    based on number of total hash buckets.
+    """
 
     return int.from_bytes(digest, "big") % num_buckets
 
@@ -256,7 +268,8 @@ def write_primary_key_index_files(
         s3_additional_kwargs={
             "ContentType": ContentType.PARQUET.value,
             "ContentEncoding": ContentEncoding.IDENTITY.value,
-        }
+        },
+        config_kwargs=PRIMARY_KEY_INDEX_WRITE_BOTO3_CONFIG
     )
     pkiv_hb_index_s3_url_base = primary_key_index_version_locator\
         .get_pkiv_hb_index_s3_url_base(s3_bucket, hb_index)

--- a/deltacat/compute/compactor/utils/system_columns.py
+++ b/deltacat/compute/compactor/utils/system_columns.py
@@ -270,5 +270,8 @@ def get_minimal_hb_schema() -> pa.schema:
     return pa.schema([
         _PK_HASH_COLUMN_FIELD,
         _ORDERED_RECORD_IDX_COLUMN_FIELD,
-        _ORDERED_FILE_IDX_COLUMN_FIELD
+        _ORDERED_FILE_IDX_COLUMN_FIELD,
+        _PARTITION_STREAM_POSITION_COLUMN_FIELD,
+        _DELTA_TYPE_COLUMN_FIELD,
+        _IS_SOURCE_COLUMN_FIELD
     ])

--- a/deltacat/constants.py
+++ b/deltacat/constants.py
@@ -25,7 +25,14 @@ BYTES_PER_PEBIBYTE = 2**50
 # a primary key SHA1 digest and sort key columns (which could be all columns
 # of the table in the worst case, but here we're assuming that they
 # represent no more than ~1/4th of the total table bytes)
-PYARROW_INFLATION_MULTIPLIER = 1.5
+PYARROW_INFLATION_MULTIPLIER = 2.5
 
 # Inflation multiplier from snappy-compressed parquet to pyarrow for all columns.
 PYARROW_INFLATION_MULTIPLIER_ALL_COLUMNS = 6
+
+PRIMARY_KEY_INDEX_WRITE_BOTO3_CONFIG = {
+   "retries": {
+      'max_attempts': 25,
+      'mode': 'standard'
+   }
+}


### PR DESCRIPTION
The actor RecordCountsPendingMaterialize takes up huge memory on a node. Moreover, it takes forever to process additional record counts after a certain threshold. This commit gets rid of the actor. A separate PR will introduce rebuilding primary key index that can be leveraged by the current compaction round. Also fixed the materialize to process dedupe results. Tested on two different tables. 