### PR TITLE
Fix dedupe when iterchunks() doesn't return equal length chunks across columns

### DIFF
--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -95,11 +95,12 @@ def _drop_duplicates_by_primary_key_hash(table: pa.Table) -> pa.Table:
     op_type_np = sc.delta_type_column_np(table)
 
     assert len(pk_hash_np) == len(op_type_np), \
-            f"Primary key digest column length ({len(pk_hash_np)}) doesn't match delta type column length ({len(op_type_np)})."
+            f"Primary key digest column length ({len(pk_hash_np)}) doesn't " \
+            f"match delta type column length ({len(op_type_np)})."
 
-    for row_idx in range(len(pk_hash_np)):
-        pk_val = pk_hash_np[row_idx]
-        op_val = op_type_np[row_idx]
+    row_idx = 0
+    pk_op_val_iter = zip(pk_hash_np, op_type_np)
+    for (pk_val, op_val) in pk_op_val_iter:
 
         # operation type is True for `UPSERT` and False for `DELETE`
         if op_val:

--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -98,6 +98,7 @@ def _drop_duplicates_by_primary_key_hash(table: pa.Table) -> pa.Table:
             f"Primary key digest column length ({len(pk_hash_np)}) doesn't " \
             f"match delta type column length ({len(op_type_np)})."
 
+    # TODO(raghumdani): move the dedupe to C++ using arrow methods or similar. 
     row_idx = 0
     pk_op_val_iter = zip(pk_hash_np, op_type_np)
     for (pk_val, op_val) in pk_op_val_iter:

--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -1,7 +1,5 @@
 import logging
-import time
 from collections import defaultdict
-from itertools import repeat
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -10,7 +8,6 @@ import pyarrow.compute as pc
 import ray
 from ray import cloudpickle
 from ray.types import ObjectRef
-from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from deltacat import logs
 from deltacat.compute.compactor import (
@@ -93,25 +90,27 @@ def _union_primary_key_indices(
 
 def _drop_duplicates_by_primary_key_hash(table: pa.Table) -> pa.Table:
     value_to_last_row_idx = {}
-    row_idx = 0
-    pk_op_chunk_iter = zip(
-        sc.pk_hash_column(table).iterchunks(),
-        sc.delta_type_column(table).iterchunks(),
-    )
-    for (pk_chunk, op_chunk) in pk_op_chunk_iter:
-        pk_op_val_iter = zip(
-            pk_chunk.to_numpy(zero_copy_only=False),
-            op_chunk.to_numpy(zero_copy_only=False),
-        )
-        for (pk_val, op_val) in pk_op_val_iter:
-            # operation type is True for `UPSERT` and False for `DELETE`
-            if op_val:
-                # UPSERT this row
-                value_to_last_row_idx[pk_val] = row_idx
-            else:
-                # DELETE this row
-                value_to_last_row_idx.pop(pk_val, None)
-            row_idx += 1
+
+    pk_hash_np = sc.pk_hash_column_np(table)
+    op_type_np = sc.delta_type_column_np(table)
+
+    assert len(pk_hash_np) == len(op_type_np), \
+            "Both pk hash and delta type should have equal length"
+
+    for row_idx in range(len(pk_hash_np)):
+        pk_val = pk_hash_np[row_idx]
+        op_val = op_type_np[row_idx]
+
+        # operation type is True for `UPSERT` and False for `DELETE`
+        if op_val:
+            # UPSERT this row
+            value_to_last_row_idx[pk_val] = row_idx
+        else:
+            # DELETE this row
+            value_to_last_row_idx.pop(pk_val, None)
+
+        row_idx += 1
+
     return table.take(list(value_to_last_row_idx.values()))
 
 

--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -95,7 +95,7 @@ def _drop_duplicates_by_primary_key_hash(table: pa.Table) -> pa.Table:
     op_type_np = sc.delta_type_column_np(table)
 
     assert len(pk_hash_np) == len(op_type_np), \
-            "Both pk hash and delta type should have equal length"
+            f"Primary key digest column length ({len(pk_hash_np)}) doesn't match delta type column length ({len(op_type_np)})."
 
     for row_idx in range(len(pk_hash_np)):
         pk_val = pk_hash_np[row_idx]

--- a/deltacat/compute/compactor/utils/system_columns.py
+++ b/deltacat/compute/compactor/utils/system_columns.py
@@ -74,10 +74,11 @@ def get_pk_hash_column_array(obj) -> Union[pa.Array, pa.ChunkedArray]:
 def pk_hash_column_np(table: pa.Table) -> np.ndarray:
     return table[_PK_HASH_COLUMN_NAME].to_numpy()
 
-
 def pk_hash_column(table: pa.Table) -> pa.ChunkedArray:
     return table[_PK_HASH_COLUMN_NAME]
 
+def delta_type_column_np(table: pa.Table) -> np.ndarray:
+    return table[_DELTA_TYPE_COLUMN_NAME].to_numpy()
 
 def delta_type_column(table: pa.Table) -> pa.ChunkedArray:
     return table[_DELTA_TYPE_COLUMN_NAME]

--- a/deltacat/utils/pyarrow.py
+++ b/deltacat/utils/pyarrow.py
@@ -171,8 +171,21 @@ class ReadKwargsProviderPyArrowSchemaOverride(ContentTypeKwargsProvider):
     """ReadKwargsProvider impl that explicitly maps column names to column types when
     loading dataset files into a PyArrow table. Disables the default type inference
     behavior on the defined columns."""
-    def __init__(self, schema: Optional[pa.Schema] = None):
+    def __init__(self,
+                 schema: Optional[pa.Schema] = None,
+                 pq_coerce_int96_timestamp_unit: Optional[str] = None):
+        """
+
+        Args:
+            schema: The schema to use for reading the dataset.
+                If unspecified, the schema will be inferred from the source.
+            pq_coerce_int96_timestamp_unit: When reading from parquet files, cast timestamps that are stored in INT96
+                format to a particular resolution (e.g. 'ms'). Setting to None is equivalent to 'ms'
+                and therefore INT96 timestamps will be inferred as timestamps in milliseconds.
+
+        """
         self.schema = schema
+        self.pq_coerce_int96_timestamp_unit = pq_coerce_int96_timestamp_unit
 
     def _get_kwargs(
             self,
@@ -188,6 +201,10 @@ class ReadKwargsProviderPyArrowSchemaOverride(ContentTypeKwargsProvider):
             # Only supported in PyArrow 8.0.0+
             if self.schema:
                 kwargs["schema"] = self.schema
+
+            # Coerce deprecated int96 timestamp to millisecond if unspecified
+            kwargs["coerce_int96_timestamp_unit"] = self.pq_coerce_int96_timestamp_unit or "ms"
+
         return kwargs
 
 


### PR DESCRIPTION
It has been observed that iterchunks() method of pyarrow sometimes returns unequal length chunks that leads to incorrect dedupe. This could cause record loss downstream. 