### PR TITLE
Assign new group when locator is different

### DIFF
--- a/deltacat/compute/compactor/model/delta_annotated.py
+++ b/deltacat/compute/compactor/model/delta_annotated.py
@@ -80,6 +80,15 @@ class DeltaAnnotated(Delta):
                    f"({len(src_da_annotations)}) doesn't mach the length of "
                    f"delta manifest entries ({len(src_da_entries)}).")
             for i, src_entry in enumerate(src_da_entries):
+                # create a new da group if src and des has different delta locator
+                if new_da and src_da.locator != new_da.locator:  # new_da has kept some previous delta's entry
+                    groups.append(new_da)
+                    logger.info(
+                        f"Due to different delta locator, Appending group of {da_group_entry_count} elements "
+                        f"and {new_da_bytes} bytes")
+                    new_da = DeltaAnnotated()
+                    new_da_bytes = 0
+                    da_group_entry_count = 0
                 DeltaAnnotated._append_annotated_entry(
                     src_da,
                     new_da,


### PR DESCRIPTION
#82 , During rebatch, deltas are assigned to groups to form a balanced load for downstream processing. Each group has the same delta locator for all its entries. When delta locator is changed (e.g., from source A to compacted B or vice versa), this pr creates a new delta group `new_da`, and append what has been accumulated in da into final groups.  