### PR TITLE
Enhance logging observability with Ray Runtime Context and Process ID

### DIFF
--- a/deltacat/logs.py
+++ b/deltacat/logs.py
@@ -47,6 +47,7 @@ class RayRuntimeContextLoggerAdapter(logging.LoggerAdapter):
 
         """
         runtime_context_dict = self.runtime_context.get()
+        runtime_context_dict["worker_id"] = self.runtime_context.worker.core_worker.get_worker_id()
         if self.runtime_context.get_task_id() or self.runtime_context.get_actor_id():
             runtime_context_dict["pg_id"] = self.runtime_context.get_placement_group_id()
             runtime_context_dict["assigned_resources"] = self.runtime_context.get_assigned_resources()

--- a/deltacat/logs.py
+++ b/deltacat/logs.py
@@ -1,12 +1,17 @@
 import os
 import logging
 import pathlib
-from logging import handlers, Logger, Handler, FileHandler
+from logging import handlers, Logger, Handler, FileHandler, LoggerAdapter
+from typing import Union
+
+import ray
+from ray.runtime_context import RuntimeContext
+
 from deltacat.constants import DELTACAT_LOG_LEVEL, APPLICATION_LOG_LEVEL
 
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_LOG_FORMAT = \
-    "%(asctime)s\t%(levelname)s %(filename)s:%(lineno)s -- %(message)s"
+    "%(asctime)s\t%(levelname)s pid=%(process)d %(filename)s:%(lineno)s -- %(message)s"
 DEFAULT_MAX_BYTES_PER_LOG = 2 ^ 20 * 256  # 256 MiB
 DEFAULT_BACKUP_COUNT = 0
 
@@ -17,6 +22,45 @@ DEFAULT_DEBUG_APPLICATION_LOG_BASE_FILE_NAME = "application.debug.log"
 DEFAULT_DELTACAT_LOG_DIR = "/tmp/deltacat/var/output/logs/"
 DEFAULT_DELTACAT_LOG_BASE_FILE_NAME = "deltacat-python.info.log"
 DEFAULT_DEBUG_DELTACAT_LOG_BASE_FILE_NAME = "deltacat-python.debug.log"
+
+
+class RayRuntimeContextLoggerAdapter(logging.LoggerAdapter):
+    """
+    Logger Adapter for injecting Ray Runtime Context into logging messages.
+    """
+    def __init__(self, logger: Logger, runtime_context: RuntimeContext):
+        super().__init__(logger, {})
+        self.runtime_context = runtime_context
+
+    def process(self, msg, kwargs):
+        """
+        Injects Ray Runtime Context details into each log message.
+
+        This may include information such as the raylet node ID, task/actor ID, job ID,
+        placement group ID of the worker, and assigned resources to the task/actor.
+
+        Args:
+            msg: The original log message
+            kwargs: Keyword arguments for the log message
+
+        Returns: A log message with Ray Runtime Context details
+
+        """
+        runtime_context_dict = self.runtime_context.get()
+        if self.runtime_context.get_task_id() or self.runtime_context.get_actor_id():
+            runtime_context_dict["pg_id"] = self.runtime_context.get_placement_group_id()
+            runtime_context_dict["assigned_resources"] = self.runtime_context.get_assigned_resources()
+
+        return "(ray_runtime_context=%s) -- %s" % (runtime_context_dict, msg), kwargs
+
+    def __reduce__(self):
+        """
+        Used to unpickle the class during Ray object store transfer.
+        """
+        def deserializer(*args):
+            return RayRuntimeContextLoggerAdapter(args[0], ray.get_runtime_context())
+
+        return deserializer, (self.logger,)
 
 
 def _add_logger_handler(
@@ -40,7 +84,6 @@ def _create_rotating_file_handler(
         logging_level = logging.getLevelName(logging_level.upper())
     assert log_base_file_name, "log file name is required"
     assert log_directory, "log directory is required"
-
     log_dir_path = pathlib.Path(log_directory)
     log_dir_path.mkdir(parents=True, exist_ok=True)
     handler = logging.handlers.RotatingFileHandler(
@@ -74,8 +117,7 @@ def _configure_logger(
         log_level: str,
         log_dir: str,
         log_base_file_name: str,
-        debug_log_base_file_name: str) -> Logger:
-
+        debug_log_base_file_name: str) -> Union[Logger, LoggerAdapter]:
     primary_log_level = log_level
     logger.propagate = False
     if log_level.upper() == "DEBUG":
@@ -83,7 +125,7 @@ def _configure_logger(
             handler = _create_rotating_file_handler(
                 log_dir,
                 debug_log_base_file_name,
-                "DEBUG",
+                "DEBUG"
             )
             _add_logger_handler(logger, handler)
             primary_log_level = "INFO"
@@ -91,13 +133,17 @@ def _configure_logger(
         handler = _create_rotating_file_handler(
             log_dir,
             log_base_file_name,
-            primary_log_level,
+            primary_log_level
         )
         _add_logger_handler(logger, handler)
+    ray_runtime_ctx = ray.get_runtime_context()
+    if ray_runtime_ctx.worker.connected:
+        logger = RayRuntimeContextLoggerAdapter(logger, ray_runtime_ctx)
+
     return logger
 
 
-def configure_deltacat_logger(logger: Logger) -> Logger:
+def configure_deltacat_logger(logger: Logger) -> Union[Logger, LoggerAdapter]:
     return _configure_logger(
         logger,
         DELTACAT_LOG_LEVEL,
@@ -107,7 +153,7 @@ def configure_deltacat_logger(logger: Logger) -> Logger:
     )
 
 
-def configure_application_logger(logger: Logger) -> Logger:
+def configure_application_logger(logger: Logger) -> Union[Logger, LoggerAdapter]:
     return _configure_logger(
         logger,
         APPLICATION_LOG_LEVEL,


### PR DESCRIPTION
Issues: #55, #62 

Example log output taken from CloudWatch:
```
2023-02-15 06:15:13,435	INFO pid=1777 hash_bucket.py:170 -- (ray_runtime_context={'job_id': JobID(01000000), 'node_id': NodeID(93fe7173180d4b441a970c1a0a40c5c7f17d8870daa365e008cc5590), 'namespace': '3b627167-2f9f-4294-9696-785d43e2ffcb', 'task_id': TaskID(ed588515c5b6ec3bffffffffffffffffffffffff01000000), 'pg_id': None, 'assigned_resources': {'CPU': 1.0, 'node:172.31.35.247': 0.0001}}) -- Finished hash bucket task...

2023-02-15 06:16:08,111	INFO pid=1777 dedupe.py:168 -- (ray_runtime_context={'job_id': JobID(01000000), 'node_id': NodeID(93fe7173180d4b441a970c1a0a40c5c7f17d8870daa365e008cc5590), 'namespace': '3b627167-2f9f-4294-9696-785d43e2ffcb', 'task_id': TaskID(a816bd897febbb3fffffffffffffffffffffffff01000000), 'pg_id': None, 'assigned_resources': {'CPU': 1.0, 'node:172.31.35.247': 0.0001}}) -- [Dedupe task 104] Getting delta file envelope groups for 188 object refs...

2023-02-15 06:16:45,071	INFO pid=1777 materialize.py:196 -- (ray_runtime_context={'job_id': JobID(01000000), 'node_id': NodeID(93fe7173180d4b441a970c1a0a40c5c7f17d8870daa365e008cc5590), 'namespace': '3b627167-2f9f-4294-9696-785d43e2ffcb', 'task_id': TaskID(c6b30fd921557f1effffffffffffffffffffffff01000000), 'pg_id': None, 'assigned_resources': {'CPU': 1.0, 'node:172.31.35.247': 0.0001}}) -- Finished materialize task...

2023-02-16 01:19:31,941	INFO pid=26532 delta_annotated.py:96 -- (ray_runtime_context={'job_id': JobID(01000000), 'node_id': NodeID(15e67b66ed272e4be06c1774dd0c256b5deb7a40a012955c199fa102), 'namespace': 'ec51764d-2c9c-4234-8d08-3585c5364532', 'task_id': TaskID(c8ef45ccd0112571ffffffffffffffffffffffff01000000), 'worker_id': WorkerID(63f451a9b229c92c7944a3c4275b5540bdb161449467b0471d8ccb3e), 'pg_id': None, 'assigned_resources': {'CPU': 0.01}}) -- Appending group of 4 elements and 951715273 bytes to meet file size limit
```