### PR TITLE
[metrics]Add customized CloudWatch metrics support; Enable straggler detection

### DIFF
--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -6,6 +6,8 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import ray
+import time
+import datetime
 from ray import cloudpickle
 from ray.types import ObjectRef
 
@@ -29,12 +31,12 @@ from deltacat.compute.compactor import SortKey, SortOrder, \
 from deltacat.compute.compactor.utils import system_columns as sc, \
     primary_key_index as pki
 from deltacat.utils.performance import timed_invocation
+from deltacat.utils.metrics import emit_timer_metrics, MetricsConfig
 
 from typing import Any, Dict, List, Optional, Tuple
 from deltacat.utils.pyarrow import ReadKwargsProviderPyArrowSchemaOverride
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
-
 
 MaterializeBucketIndex = int
 DeltaFileLocatorToRecords = Dict[DeltaFileLocator, np.ndarray]
@@ -52,7 +54,6 @@ def _union_primary_key_indices(
         round_completion_info: RoundCompletionInfo,
         hash_bucket_index: int,
         df_envelopes_list: List[List[DeltaFileEnvelope]]) -> pa.Table:
-
     logger.info(f"[Hash bucket index {hash_bucket_index}] Reading dedupe input for "
                 f"{len(df_envelopes_list)} delta file envelope lists...")
     # read compacted input parquet files first
@@ -95,8 +96,8 @@ def _drop_duplicates_by_primary_key_hash(table: pa.Table) -> pa.Table:
     op_type_np = sc.delta_type_column_np(table)
 
     assert len(pk_hash_np) == len(op_type_np), \
-            f"Primary key digest column length ({len(pk_hash_np)}) doesn't " \
-            f"match delta type column length ({len(op_type_np)})."
+        f"Primary key digest column length ({len(pk_hash_np)}) doesn't " \
+        f"match delta type column length ({len(op_type_np)})."
 
     # TODO(raghumdani): move the dedupe to C++ using arrow methods or similar. 
     row_idx = 0
@@ -122,7 +123,6 @@ def _write_new_primary_key_index(
         max_rows_per_index_file: int,
         dedupe_task_index: int,
         deduped_tables: List[Tuple[int, pa.Table]]) -> PyArrowWriteResult:
-
     logger.info(f"[Dedupe task index {dedupe_task_index}] Writing new deduped primary key index: "
                 f"{new_primary_key_index_version_locator}")
 
@@ -149,19 +149,16 @@ def delta_file_locator_to_mat_bucket_index(
     digest = df_locator.digest()
     return int.from_bytes(digest, "big") % materialize_bucket_count
 
-@ray.remote(num_returns=3)
-def dedupe(
-        compaction_artifact_s3_bucket: str,
-        round_completion_info: Optional[RoundCompletionInfo],
-        new_primary_key_index_version_locator: PrimaryKeyIndexVersionLocator,
-        object_ids: List[Any],
-        sort_keys: List[SortKey],
-        max_records_per_index_file: int,
-        num_materialize_buckets: int,
-        dedupe_task_index: int,
-        delete_old_primary_key_index: bool) -> DedupeResult:
 
-    logger.info(f"[Dedupe task {dedupe_task_index}] Starting dedupe task...")
+def _timed_dedupe(compaction_artifact_s3_bucket: str,
+                  round_completion_info: Optional[RoundCompletionInfo],
+                  new_primary_key_index_version_locator: PrimaryKeyIndexVersionLocator,
+                  object_ids: List[Any],
+                  sort_keys: List[SortKey],
+                  max_records_per_index_file: int,
+                  num_materialize_buckets: int,
+                  dedupe_task_index: int,
+                  delete_old_primary_key_index: bool):
     # TODO (pdames): mitigate risk of running out of memory here in cases of
     #  severe skew of primary key updates in deltas
     src_file_records_obj_refs = [
@@ -271,7 +268,41 @@ def dedupe(
             compaction_artifact_s3_bucket,
             round_completion_info.primary_key_index_version_locator,
         )
+    return mat_bucket_to_dd_idx_obj_id, \
+           src_file_records_obj_refs, \
+           write_pki_result
+
+
+@ray.remote(num_returns=3)
+def dedupe(
+        compaction_artifact_s3_bucket: str,
+        round_completion_info: Optional[RoundCompletionInfo],
+        new_primary_key_index_version_locator: PrimaryKeyIndexVersionLocator,
+        object_ids: List[Any],
+        sort_keys: List[SortKey],
+        max_records_per_index_file: int,
+        num_materialize_buckets: int,
+        dedupe_task_index: int,
+        delete_old_primary_key_index: bool,
+        metrics_config: MetricsConfig) -> DedupeResult:
+    logger.info(f"[Dedupe task {dedupe_task_index}] Starting dedupe task...")
+    duration, mat_bucket_to_dd_idx_obj_id, src_file_records_obj_refs, \
+    write_pki_result = timed_invocation(
+        func=_timed_dedupe,
+        compaction_artifact_s3_bucket=compaction_artifact_s3_bucket,
+        round_completion_info=round_completion_info,
+        new_primary_key_index_version_locator=new_primary_key_index_version_locator,
+        object_ids=object_ids,
+        sort_keys=sort_keys,
+        max_records_per_index_file=max_records_per_index_file,
+        num_materialize_buckets=num_materialize_buckets,
+        dedupe_task_index=dedupe_task_index,
+        delete_old_primary_key_index=delete_old_primary_key_index
+    )
+    emit_timer_metrics(metrics_name="dedupe",
+                       value=duration,
+                       metrics_config=metrics_config)
     logger.info(f"[Dedupe task index {dedupe_task_index}] Finished dedupe task...")
     return mat_bucket_to_dd_idx_obj_id, \
-        src_file_records_obj_refs, \
-        write_pki_result
+           src_file_records_obj_refs, \
+           write_pki_result

--- a/deltacat/utils/metrics.py
+++ b/deltacat/utils/metrics.py
@@ -1,0 +1,128 @@
+import ray
+import urllib
+import logging
+import yaml
+
+from deltacat import logs
+from enum import Enum
+from typing import Dict, Any, List, Callable
+from deltacat.aws.clients import resource_cache
+from datetime import datetime
+
+from botocore.exceptions import ClientError
+from ray._private.services import get_node_ip_address
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
+
+DEFAULT_DELTACAT_METRICS_NAMESPACE = "ray-deltacat-profiling"
+
+
+class MetricsConfig:
+    def __init__(self, region: str, job_run_id: str):
+        self.region = region
+        self.job_run_id = job_run_id
+
+
+class MetricsType(str, Enum):
+    TIMER = "timer"
+
+
+class MetricsDimensionType(str, Enum):
+    NODE_IP = "node_ip"
+    RAY_TASK_ID = "task_id"
+    RAY_WORKER_ID = "worker_id"
+
+
+def _build_metrics_name(metrics_type: Enum, metrics_name: str) -> str:
+    metrics_name_with_type = f"{metrics_name}_{metrics_type}"
+    return metrics_name_with_type
+
+
+def _get_current_node_ip() -> str:
+    # current_node_ip = urllib.request.urlopen(
+    #     "http://169.254.169.254/latest/meta-data/local-ipv4"
+    # ).read().decode("utf-8")
+    current_node_ip = get_node_ip_address()
+    return {"Name": f"node_ip",
+            "Value": f"{current_node_ip}"
+            }
+
+
+def _get_current_task_id() -> Dict[str, Any]:
+    return {"Name": f"ray_task_id",
+            "Value": f"{ray.get_runtime_context().get_task_id()}"
+            }
+
+
+def _get_current_worker_id() -> Dict[str, Any]:
+    return {"Name": f"ray_worker_id",
+            "Value": f"{ray.get_runtime_context().worker.core_worker.get_worker_id()}"
+            }
+
+
+METRICS_DIMENSION_TYPE_TO_VALUE_DICT: Dict[
+            str, Callable] = {
+            MetricsDimensionType.NODE_IP.value: _get_current_node_ip,
+            MetricsDimensionType.RAY_TASK_ID.value: _get_current_task_id,
+            MetricsDimensionType.RAY_WORKER_ID.value: _get_current_worker_id,
+        }
+
+# def _get_current_instance_region() -> str:
+#     current_instance_region = urllib.request.urlopen(
+#         "http://169.254.169.254/latest/meta-data/placement/region"
+#     ).read().decode("utf-8")
+#     return current_instance_region
+
+
+# def _get_current_cluster_name() -> str:
+#     with open("/home/ubuntu/ray_bootstrap_config.yaml", "r") as f:
+#         cluster_config = yaml.load(f)
+#     return cluster_config["cluster_name"]
+
+
+def _build_cloudwatch_metrics(metrics_name: str, metrics_type: Enum, value: str, dimension_types: List[Enum], timestamp: datetime, **kwargs) -> Dict[str, Any]:
+    metrics_name_with_type = _build_metrics_name(metrics_type, metrics_name)
+    dimensions = []
+    for dimension_type in dimension_types:
+        dimensions.append(METRICS_DIMENSION_TYPE_TO_VALUE_DICT.get(dimension_type.value)())
+    return [
+        {
+            "MetricName": f"{metrics_name_with_type}",
+            "Dimensions": dimensions,
+            "Timestamp": timestamp,
+            "Value": value,
+            **kwargs
+        }
+    ]
+
+
+def _emit_metrics(metrics_name: str, metrics_type: Enum, metrics_config: MetricsConfig, value: str, dimension_types: List[Enum], **kwargs) -> None:
+    ct = datetime.datetime.now()
+    current_instance_region = metrics_config.region
+    cloudwatch_resource = resource_cache("cloudwatch", current_instance_region)
+    cloudwatch_client = cloudwatch_resource.meta.client
+    metrics_data = _build_cloudwatch_metrics(metrics_name,
+                                             metrics_type,
+                                             value,
+                                             dimension_types,
+                                             ct,
+                                             **kwargs)
+    job_run_id = metrics_config.job_run_id
+    try:
+        response = cloudwatch_client.put_metric_data(
+            Namespace=f"DEFAULT_DELTACAT_METRICS_NAMESPACE_{job_run_id}",
+            MetricData=metrics_data)
+    except ClientError as e:
+        logger.warning(f"Failed to publish Cloudwatch metrics with name: {metrics_name}, "
+                       f"type: {metrics_type}, with botocore client exception: {e}")
+
+
+def emit_timer_metrics(metrics_name, value, metrics_config, **kwargs):
+    metrics_dimension_type = [MetricsDimensionType.NODE_IP, MetricsDimensionType.RAY_TASK_ID,
+                              MetricsDimensionType.RAY_WORKER_ID]
+    _emit_metrics(metrics_name=metrics_name,
+                  metrics_type=MetricsType.TIMER,
+                  metrics_config=metrics_config,
+                  value=value,
+                  dimension_types=metrics_dimension_type,
+                  **kwargs)


### PR DESCRIPTION
This PR adds support for emitting customized CloudWatch metrics. 
Currently, it's main purpose is for runtime profiling and to detect stragglers during each step of compaction. 
Issues: part of #57 