### PR TITLE
Hotfix: Remove @ray.remote annotation in compaction session and zero_copy_only in materialize

### DIFF
--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -145,7 +145,6 @@ def compact_partition(
     return new_rcf_s3_url
 
 
-@ray.remote(num_cpus=0.1, num_returns=3)
 def _execute_compaction_round(
     source_partition_locator: PartitionLocator,
     compacted_partition_locator: PartitionLocator,

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -52,9 +52,7 @@ def materialize(
         if compacted_file_content_type in DELIMITED_TEXT_CONTENT_TYPES:
             # TODO (rkenmi): Investigate if we still need to convert this table to pandas DataFrame
             # TODO (pdames): compare performance to pandas-native materialize path
-            df = compacted_table.to_pandas(
-                split_blocks=True, self_destruct=True
-            )
+            df = compacted_table.to_pandas(split_blocks=True, self_destruct=True)
             compacted_table = df
         delta, stage_delta_time = timed_invocation(
             deltacat_storage.stage_delta,

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -53,7 +53,7 @@ def materialize(
             # TODO (rkenmi): Investigate if we still need to convert this table to pandas DataFrame
             # TODO (pdames): compare performance to pandas-native materialize path
             df = compacted_table.to_pandas(
-                split_blocks=True, self_destruct=True, zero_copy_only=True
+                split_blocks=True, self_destruct=True
             )
             compacted_table = df
         delta, stage_delta_time = timed_invocation(


### PR DESCRIPTION
1. https://github.com/ray-project/deltacat/commit/3dfa2a430486a08fcb12bb7bb8bf9377ae469b11 introduced an unintentional `@ray.remote` annotation on `_execute_compaction_round` which has been removed in earlier commits. This function is called as a normal function and not as a Ray remote task, causing the compactor to break
2. `table.to_pandas(zero_copy_only=True)` doesn't offer any additional performance benefits - if zero copy is possible, it will attempt to do so regardless of this flag being present. With this flag enabled, it throws an exception if zero copy isn't possible and enforces strictness. This causes integration tests and compaction itself to break when source files need to be compacted to delimited text output files, and a conversion to Pandas DataFrames with multiple columns is necessary. See:
    - https://github.com/apache/arrow/blob/1264e40918ba95f7c0b1725e296ada25b1385b3d/python/pyarrow/src/arrow/python/arrow_to_pandas.cc#L368
    - https://github.com/apache/arrow/blob/1264e40918ba95f7c0b1725e296ada25b1385b3d/python/pyarrow/src/arrow/python/arrow_to_pandas.cc#L403
    - https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas
 