### PR TITLE
[metrics] Add customized CloudWatch metrics support

### DIFF
--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -445,7 +445,7 @@ def _execute_compaction_round(
         num_materialize_buckets=num_materialize_buckets,
         delete_old_primary_key_index=delete_prev_primary_key_index,
         enable_profiler=enable_profiler,
-        metrics_config=metrics_config
+        metrics_config=metrics_config,
     )
     logger.info(f"Getting {len(dd_tasks_pending)} dedupe results...")
     dd_results = ray.get([t[0] for t in dd_tasks_pending])

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -34,6 +34,7 @@ from deltacat.utils.ray_utils.concurrency import (
     round_robin_options_provider,
 )
 from deltacat.utils.ray_utils.runtime import live_node_resource_keys
+from deltacat.utils.metrics import MetricsConfig
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
@@ -93,6 +94,7 @@ def compact_partition(
     rebase_source_partition_locator: Optional[PartitionLocator] = None,
     rebase_source_partition_high_watermark: Optional[int] = None,
     enable_profiler: Optional[bool] = False,
+    metrics_config: Optional[MetricsConfig] = None,
     deltacat_storage=unimplemented_deltacat_storage,
 ) -> Optional[str]:
 
@@ -131,6 +133,7 @@ def compact_partition(
                 rebase_source_partition_locator,
                 rebase_source_partition_high_watermark,
                 enable_profiler,
+                metrics_config,
                 deltacat_storage,
             )
             if new_partition:
@@ -175,6 +178,7 @@ def _execute_compaction_round(
     rebase_source_partition_locator: Optional[PartitionLocator],
     rebase_source_partition_high_watermark: Optional[int],
     enable_profiler: Optional[bool],
+    metrics_config: Optional[MetricsConfig],
     deltacat_storage=unimplemented_deltacat_storage,
 ) -> Tuple[bool, Optional[Partition], Optional[RoundCompletionInfo], Optional[str]]:
 
@@ -365,6 +369,7 @@ def _execute_compaction_round(
         num_buckets=hash_bucket_count,
         num_groups=max_parallelism,
         enable_profiler=enable_profiler,
+        metrics_config=metrics_config,
         deltacat_storage=deltacat_storage,
     )
     logger.info(f"Getting {len(hb_tasks_pending)} hash bucket results...")
@@ -440,6 +445,7 @@ def _execute_compaction_round(
         num_materialize_buckets=num_materialize_buckets,
         delete_old_primary_key_index=delete_prev_primary_key_index,
         enable_profiler=enable_profiler,
+        metrics_config=metrics_config
     )
     logger.info(f"Getting {len(dd_tasks_pending)} dedupe results...")
     dd_results = ray.get([t[0] for t in dd_tasks_pending])
@@ -486,6 +492,7 @@ def _execute_compaction_round(
         max_records_per_output_file=records_per_compacted_file,
         compacted_file_content_type=compacted_file_content_type,
         enable_profiler=enable_profiler,
+        metrics_config=metrics_config,
         deltacat_storage=deltacat_storage,
     )
     logger.info(f"Getting {len(mat_tasks_pending)} materialize result(s)...")

--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -24,7 +24,7 @@ from deltacat.compute.compactor import (
 from deltacat.compute.compactor.utils import primary_key_index as pki
 from deltacat.compute.compactor.utils import system_columns as sc
 from deltacat.compute.compactor.utils.system_columns import get_minimal_hb_schema
-from deltacat.utils.performance import timed_invocation
+
 from deltacat.utils.pyarrow import ReadKwargsProviderPyArrowSchemaOverride
 from deltacat.utils.ray_utils.runtime import (
     get_current_ray_task_id,
@@ -47,10 +47,10 @@ DedupeResult = Tuple[
 
 
 def _union_primary_key_indices(
-        s3_bucket: str,
-        round_completion_info: RoundCompletionInfo,
-        hash_bucket_index: int,
-        df_envelopes_list: List[List[DeltaFileEnvelope]],
+    s3_bucket: str,
+    round_completion_info: RoundCompletionInfo,
+    hash_bucket_index: int,
+    df_envelopes_list: List[List[DeltaFileEnvelope]],
 ) -> pa.Table:
     logger.info(
         f"[Hash bucket index {hash_bucket_index}] Reading dedupe input for "
@@ -125,11 +125,11 @@ def _drop_duplicates_by_primary_key_hash(table: pa.Table) -> pa.Table:
 
 
 def _write_new_primary_key_index(
-        s3_bucket: str,
-        new_primary_key_index_version_locator: PrimaryKeyIndexVersionLocator,
-        max_rows_per_index_file: int,
-        dedupe_task_index: int,
-        deduped_tables: List[Tuple[int, pa.Table]],
+    s3_bucket: str,
+    new_primary_key_index_version_locator: PrimaryKeyIndexVersionLocator,
+    max_rows_per_index_file: int,
+    dedupe_task_index: int,
+    deduped_tables: List[Tuple[int, pa.Table]],
 ) -> PyArrowWriteResult:
     logger.info(
         f"[Dedupe task index {dedupe_task_index}] Writing new deduped primary key index: "
@@ -156,26 +156,28 @@ def _write_new_primary_key_index(
 
 
 def delta_file_locator_to_mat_bucket_index(
-        df_locator: DeltaFileLocator, materialize_bucket_count: int
+    df_locator: DeltaFileLocator, materialize_bucket_count: int
 ) -> int:
     digest = df_locator.digest()
     return int.from_bytes(digest, "big") % materialize_bucket_count
 
 
-def _timed_dedupe(compaction_artifact_s3_bucket: str,
-                  round_completion_info: Optional[RoundCompletionInfo],
-                  new_primary_key_index_version_locator: PrimaryKeyIndexVersionLocator,
-                  object_ids: List[Any],
-                  sort_keys: List[SortKey],
-                  max_records_per_index_file: int,
-                  num_materialize_buckets: int,
-                  dedupe_task_index: int,
-                  delete_old_primary_key_index: bool,
-                  enable_profiler: bool, ):
+def _timed_dedupe(
+    compaction_artifact_s3_bucket: str,
+    round_completion_info: Optional[RoundCompletionInfo],
+    new_primary_key_index_version_locator: PrimaryKeyIndexVersionLocator,
+    object_ids: List[Any],
+    sort_keys: List[SortKey],
+    max_records_per_index_file: int,
+    num_materialize_buckets: int,
+    dedupe_task_index: int,
+    delete_old_primary_key_index: bool,
+    enable_profiler: bool,
+):
     task_id = get_current_ray_task_id()
     worker_id = get_current_ray_worker_id()
     with memray.Tracker(
-            f"dedupe_{worker_id}_{task_id}.bin"
+        f"dedupe_{worker_id}_{task_id}.bin"
     ) if enable_profiler else nullcontext():
         # TODO (pdames): mitigate risk of running out of memory here in cases of
         #  severe skew of primary key updates in deltas
@@ -315,20 +317,20 @@ def _timed_dedupe(compaction_artifact_s3_bucket: str,
 
 @ray.remote(num_returns=3)
 def dedupe(
-        compaction_artifact_s3_bucket: str,
-        round_completion_info: Optional[RoundCompletionInfo],
-        new_primary_key_index_version_locator: PrimaryKeyIndexVersionLocator,
-        object_ids: List[Any],
-        sort_keys: List[SortKey],
-        max_records_per_index_file: int,
-        num_materialize_buckets: int,
-        dedupe_task_index: int,
-        delete_old_primary_key_index: bool,
-        enable_profiler: bool,
-        metrics_config: MetricsConfig,
+    compaction_artifact_s3_bucket: str,
+    round_completion_info: Optional[RoundCompletionInfo],
+    new_primary_key_index_version_locator: PrimaryKeyIndexVersionLocator,
+    object_ids: List[Any],
+    sort_keys: List[SortKey],
+    max_records_per_index_file: int,
+    num_materialize_buckets: int,
+    dedupe_task_index: int,
+    delete_old_primary_key_index: bool,
+    enable_profiler: bool,
+    metrics_config: MetricsConfig,
 ) -> DedupeResult:
     logger.info(f"[Dedupe task {dedupe_task_index}] Starting dedupe task...")
-    res, duration = timed_invocation(
+    dedupe_res, duration = timed_invocation(
         func=_timed_dedupe,
         compaction_artifact_s3_bucket=compaction_artifact_s3_bucket,
         round_completion_info=round_completion_info,
@@ -342,11 +344,14 @@ def dedupe(
         enable_profiler=enable_profiler,
     )
     if metrics_config:
-        emit_timer_metrics(metrics_name="dedupe",
-                           value=duration,
-                           metrics_config=metrics_config)
-    mat_bucket_to_dd_idx_obj_id, src_file_records_obj_refs, \
-    write_pki_result = res
+        emit_timer_metrics(
+            metrics_name="dedupe", value=duration, metrics_config=metrics_config
+        )
+
+    (
+        mat_bucket_to_dd_idx_obj_id,
+        src_file_records_obj_refs,
+        write_pki_result,
+    ) = dedupe_res
     logger.info(f"[Dedupe task index {dedupe_task_index}] Finished dedupe task...")
-    return mat_bucket_to_dd_idx_obj_id, \
-           src_file_records_obj_refs, write_pki_result
+    return mat_bucket_to_dd_idx_obj_id, src_file_records_obj_refs, write_pki_result

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -34,6 +34,7 @@ from deltacat.utils.ray_utils.runtime import (
     get_current_ray_task_id,
     get_current_ray_worker_id,
 )
+from deltacat.utils.metrics import emit_timer_metrics, MetricsConfig
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
@@ -48,6 +49,7 @@ def materialize(
     max_records_per_output_file: int,
     compacted_file_content_type: ContentType,
     enable_profiler: bool,
+    metrics_config: MetricsConfig,
     schema: Optional[pa.Schema] = None,
     deltacat_storage=unimplemented_deltacat_storage,
 ) -> MaterializeResult:
@@ -214,5 +216,10 @@ def materialize(
         )
         logger.info(f"Finished materialize task...")
         end = time.time()
+        duration = end - start
+        if metrics_config:
+            emit_timer_metrics(metrics_name="materialize",
+                               value=duration,
+                               metrics_config=metrics_config)
         logger.info(f"Materialize task ended in {end - start}s")
         return merged_materialize_result

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -214,12 +214,15 @@ def materialize(
                 [mr.pyarrow_write_result for mr in materialized_results]
             ),
         )
+
         logger.info(f"Finished materialize task...")
         end = time.time()
         duration = end - start
         if metrics_config:
-            emit_timer_metrics(metrics_name="materialize",
-                               value=duration,
-                               metrics_config=metrics_config)
+            emit_timer_metrics(
+                metrics_name="materialize",
+                value=duration,
+                metrics_config=metrics_config,
+            )
         logger.info(f"Materialize task ended in {end - start}s")
         return merged_materialize_result

--- a/deltacat/utils/metrics.py
+++ b/deltacat/utils/metrics.py
@@ -1,0 +1,111 @@
+import ray
+import logging
+
+from deltacat import logs
+from enum import Enum
+from typing import Dict, Any, List, Callable
+from deltacat.aws.clients import resource_cache
+from datetime import datetime
+
+from botocore.exceptions import ClientError
+from ray._private.services import get_node_ip_address
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
+
+DEFAULT_DELTACAT_METRICS_NAMESPACE = "ray-deltacat-profiling"
+
+
+class MetricsConfig:
+    def __init__(self, region: str, job_run_id: str):
+        self.region = region
+        self.job_run_id = job_run_id
+
+
+class MetricsType(str, Enum):
+    TIMER = "timer"
+
+
+class MetricsDimensionType(str, Enum):
+    NODE_IP = "node_ip"
+    RAY_TASK_ID = "task_id"
+    RAY_WORKER_ID = "worker_id"
+
+
+def _build_metrics_name(metrics_type: Enum, metrics_name: str) -> str:
+    metrics_name_with_type = f"{metrics_name}_{metrics_type}"
+    return metrics_name_with_type
+
+
+def _get_current_node_ip() -> str:
+    current_node_ip = get_node_ip_address()
+    return {"Name": f"node_ip",
+            "Value": f"{current_node_ip}"
+            }
+
+
+def _get_current_task_id() -> Dict[str, Any]:
+    return {"Name": f"ray_task_id",
+            "Value": f"{ray.get_runtime_context().get_task_id()}"
+            }
+
+
+def _get_current_worker_id() -> Dict[str, Any]:
+    return {"Name": f"ray_worker_id",
+            "Value": f"{ray.get_runtime_context().worker.core_worker.get_worker_id()}"
+            }
+
+
+METRICS_DIMENSION_TYPE_TO_VALUE_DICT: Dict[
+            str, Callable] = {
+            MetricsDimensionType.NODE_IP.value: _get_current_node_ip,
+            MetricsDimensionType.RAY_TASK_ID.value: _get_current_task_id,
+            MetricsDimensionType.RAY_WORKER_ID.value: _get_current_worker_id,
+        }
+
+
+def _build_cloudwatch_metrics(metrics_name: str, metrics_type: Enum, value: str, dimension_types: List[Enum], timestamp: datetime, **kwargs) -> Dict[str, Any]:
+    metrics_name_with_type = _build_metrics_name(metrics_type, metrics_name)
+    dimensions = []
+    for dimension_type in dimension_types:
+        dimensions.append(METRICS_DIMENSION_TYPE_TO_VALUE_DICT.get(dimension_type.value)())
+    return [
+        {
+            "MetricName": f"{metrics_name_with_type}",
+            "Dimensions": dimensions,
+            "Timestamp": timestamp,
+            "Value": value,
+            **kwargs
+        }
+    ]
+
+
+def _emit_metrics(metrics_name: str, metrics_type: Enum, metrics_config: MetricsConfig, value: str, dimension_types: List[Enum], **kwargs) -> None:
+    ct = datetime.now()
+    current_instance_region = metrics_config.region
+    cloudwatch_resource = resource_cache("cloudwatch", current_instance_region)
+    cloudwatch_client = cloudwatch_resource.meta.client
+    metrics_data = _build_cloudwatch_metrics(metrics_name,
+                                             metrics_type,
+                                             value,
+                                             dimension_types,
+                                             ct,
+                                             **kwargs)
+    job_run_id = metrics_config.job_run_id
+    try:
+        response = cloudwatch_client.put_metric_data(
+            Namespace=f"{DEFAULT_DELTACAT_METRICS_NAMESPACE}_{job_run_id}",
+            MetricData=metrics_data)
+    except Exception as e:
+        logger.warning(f"Failed to publish Cloudwatch metrics with name: {metrics_name}, "
+                       f"type: {metrics_type}, with exception: {e}")
+
+
+def emit_timer_metrics(metrics_name, value, metrics_config, **kwargs):
+    metrics_dimension_type = [MetricsDimensionType.NODE_IP, MetricsDimensionType.RAY_TASK_ID,
+                              MetricsDimensionType.RAY_WORKER_ID]
+    _emit_metrics(metrics_name=metrics_name,
+                  metrics_type=MetricsType.TIMER,
+                  metrics_config=metrics_config,
+                  value=value,
+                  dimension_types=metrics_dimension_type,
+                  **kwargs)

--- a/deltacat/utils/metrics.py
+++ b/deltacat/utils/metrics.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import ray
 import logging
 
@@ -7,18 +9,23 @@ from typing import Dict, Any, List, Callable
 from deltacat.aws.clients import resource_cache
 from datetime import datetime
 
-from botocore.exceptions import ClientError
 from ray._private.services import get_node_ip_address
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-DEFAULT_DELTACAT_METRICS_NAMESPACE = "ray-deltacat-profiling"
+DEFAULT_DELTACAT_METRICS_NAMESPACE = "ray-deltacat-metrics"
 
 
+class MetricsTarget(str, Enum):
+    CLOUDWATCH = "cloudwatch"
+
+
+@dataclass
 class MetricsConfig:
-    def __init__(self, region: str, job_run_id: str):
+    def __init__(self, region: str, job_run_id: str, metrics_target: MetricsTarget):
         self.region = region
         self.job_run_id = job_run_id
+        self.metrics_target = metrics_target
 
 
 class MetricsType(str, Enum):
@@ -38,74 +45,119 @@ def _build_metrics_name(metrics_type: Enum, metrics_name: str) -> str:
 
 def _get_current_node_ip() -> str:
     current_node_ip = get_node_ip_address()
-    return {"Name": f"node_ip",
-            "Value": f"{current_node_ip}"
-            }
+    return {"Name": f"node_ip", "Value": f"{current_node_ip}"}
 
 
 def _get_current_task_id() -> Dict[str, Any]:
-    return {"Name": f"ray_task_id",
-            "Value": f"{ray.get_runtime_context().get_task_id()}"
-            }
+    return {
+        "Name": f"ray_task_id",
+        "Value": f"{ray.get_runtime_context().get_task_id()}",
+    }
 
 
 def _get_current_worker_id() -> Dict[str, Any]:
-    return {"Name": f"ray_worker_id",
-            "Value": f"{ray.get_runtime_context().worker.core_worker.get_worker_id()}"
-            }
+    return {
+        "Name": f"ray_worker_id",
+        "Value": f"{ray.get_runtime_context().worker.core_worker.get_worker_id()}",
+    }
 
 
-METRICS_DIMENSION_TYPE_TO_VALUE_DICT: Dict[
-            str, Callable] = {
-            MetricsDimensionType.NODE_IP.value: _get_current_node_ip,
-            MetricsDimensionType.RAY_TASK_ID.value: _get_current_task_id,
-            MetricsDimensionType.RAY_WORKER_ID.value: _get_current_worker_id,
-        }
+METRICS_DIMENSION_TYPE_TO_VALUE_DICT: Dict[str, Callable] = {
+    MetricsDimensionType.NODE_IP.value: _get_current_node_ip,
+    MetricsDimensionType.RAY_TASK_ID.value: _get_current_task_id,
+    MetricsDimensionType.RAY_WORKER_ID.value: _get_current_worker_id,
+}
 
 
-def _build_cloudwatch_metrics(metrics_name: str, metrics_type: Enum, value: str, dimension_types: List[Enum], timestamp: datetime, **kwargs) -> Dict[str, Any]:
+def _build_cloudwatch_metrics(
+    metrics_name: str,
+    metrics_type: Enum,
+    value: str,
+    dimension_types: List[Enum],
+    timestamp: datetime,
+    **kwargs,
+) -> Dict[str, Any]:
     metrics_name_with_type = _build_metrics_name(metrics_type, metrics_name)
     dimensions = []
     for dimension_type in dimension_types:
-        dimensions.append(METRICS_DIMENSION_TYPE_TO_VALUE_DICT.get(dimension_type.value)())
+        dimensions.append(
+            METRICS_DIMENSION_TYPE_TO_VALUE_DICT.get(dimension_type.value)()
+        )
     return [
         {
             "MetricName": f"{metrics_name_with_type}",
             "Dimensions": dimensions,
             "Timestamp": timestamp,
             "Value": value,
-            **kwargs
+            **kwargs,
         }
     ]
 
 
-def _emit_metrics(metrics_name: str, metrics_type: Enum, metrics_config: MetricsConfig, value: str, dimension_types: List[Enum], **kwargs) -> None:
+def _emit_metrics(
+    metrics_name: str,
+    metrics_type: Enum,
+    metrics_config: MetricsConfig,
+    value: str,
+    dimension_types: List[Enum],
+    **kwargs,
+) -> None:
+    metrics_target = metrics_config.metrics_target
+    assert isinstance(
+        metrics_target, MetricsTarget
+    ), f"{metrics_target} is not a valid supported metrics target type! "
+    if metrics_target == MetricsTarget.CLOUDWATCH:
+        _emit_cloudwatch_metrics(
+            metrics_name=metrics_name,
+            metrics_type=metrics_type,
+            metrics_config=metrics_config,
+            value=value,
+            dimension_types=dimension_types,
+            **kwargs,
+        )
+    else:
+        logger.warning(f"{metrics_target} is not a supported metrics target type.")
+
+
+def _emit_cloudwatch_metrics(
+    metrics_name: str,
+    metrics_type: Enum,
+    metrics_config: MetricsConfig,
+    value: str,
+    dimension_types: List[Enum],
+    **kwargs,
+) -> None:
     ct = datetime.now()
     current_instance_region = metrics_config.region
     cloudwatch_resource = resource_cache("cloudwatch", current_instance_region)
     cloudwatch_client = cloudwatch_resource.meta.client
-    metrics_data = _build_cloudwatch_metrics(metrics_name,
-                                             metrics_type,
-                                             value,
-                                             dimension_types,
-                                             ct,
-                                             **kwargs)
+    metrics_data = _build_cloudwatch_metrics(
+        metrics_name, metrics_type, value, dimension_types, ct, **kwargs
+    )
     job_run_id = metrics_config.job_run_id
     try:
         response = cloudwatch_client.put_metric_data(
             Namespace=f"{DEFAULT_DELTACAT_METRICS_NAMESPACE}_{job_run_id}",
-            MetricData=metrics_data)
+            MetricData=metrics_data,
+        )
     except Exception as e:
-        logger.warning(f"Failed to publish Cloudwatch metrics with name: {metrics_name}, "
-                       f"type: {metrics_type}, with exception: {e}")
+        logger.warning(
+            f"Failed to publish Cloudwatch metrics with name: {metrics_name}, "
+            f"type: {metrics_type}, with exception: {e}, response: {response}"
+        )
 
 
 def emit_timer_metrics(metrics_name, value, metrics_config, **kwargs):
-    metrics_dimension_type = [MetricsDimensionType.NODE_IP, MetricsDimensionType.RAY_TASK_ID,
-                              MetricsDimensionType.RAY_WORKER_ID]
-    _emit_metrics(metrics_name=metrics_name,
-                  metrics_type=MetricsType.TIMER,
-                  metrics_config=metrics_config,
-                  value=value,
-                  dimension_types=metrics_dimension_type,
-                  **kwargs)
+    metrics_dimension_type = [
+        MetricsDimensionType.NODE_IP,
+        MetricsDimensionType.RAY_TASK_ID,
+        MetricsDimensionType.RAY_WORKER_ID,
+    ]
+    _emit_metrics(
+        metrics_name=metrics_name,
+        metrics_type=MetricsType.TIMER,
+        metrics_config=metrics_config,
+        value=value,
+        dimension_types=metrics_dimension_type,
+        **kwargs,
+    )


### PR DESCRIPTION
This PR adds support for emitting customized CloudWatch metrics.
Currently, it's main purpose is for runtime profiling and to detect stragglers during each step of compaction.
Closes: #57 