### PR TITLE
[ci][linting] Updated pre-commit repository mapping to be compatible with Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
-            python-version: 3.8
+            python-version: 3.7
       - name: Linting
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,15 +24,11 @@ repos:
     rev: v2.1.2
     hooks:
     -   id: pycln
--   repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-    -   id: isort
 -   repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:
       - id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 5.0.0
     hooks:
     -   id: flake8

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -99,7 +99,7 @@ def compact_partition(
     logger.info(f"Starting compaction session for: {source_partition_locator}")
     # memray official documentation link: https://bloomberg.github.io/memray/getting_started.html
     with memray.Tracker(
-            f"compaction_partition.bin"
+        f"compaction_partition.bin"
     ) if enable_profiler else nullcontext():
         partition = None
         compaction_rounds_executed = 0
@@ -139,7 +139,9 @@ def compact_partition(
                 compaction_rounds_executed += 1
             # Take new primary key index sizes into account for subsequent compaction rounds and their dedupe steps
             if new_rci:
-                min_pk_index_pa_bytes = new_rci.pk_index_pyarrow_write_result.pyarrow_bytes
+                min_pk_index_pa_bytes = (
+                    new_rci.pk_index_pyarrow_write_result.pyarrow_bytes
+                )
 
         logger.info(
             f"Partition-{source_partition_locator.partition_values}-> Compaction session data processing completed in "


### PR DESCRIPTION
- The isort utility has dependency on 3.8+ (isort) - https://pypi.org/project/isort/ 
-  Flake8 6.0.0 is not compatible with 3.7
- [black linting compaction_session.py so lint job passes](https://github.com/ray-project/deltacat/pull/98/commits/fdaedf72c271c7b972664941da2971ec855c6736)