### PR TITLE
deltacat version bump and support for graviton

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -43,7 +43,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"
 
 
 __all__ = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # setup.py install_requires
 # any changes here should also be reflected in setup.py "install_requires"
-boto3 == 1.20.24
+boto3 ~= 1.20
 numpy == 1.21.5
 pandas == 1.3.5
 pyarrow == 10.0.1
 pydantic == 1.10.4
-ray[default] == 2.0.0
+ray[default] ~= 2.0
 s3fs == 2022.2.0
 tenacity == 8.1.0
 typing-extensions == 4.4.0

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,12 @@ setuptools.setup(
     packages=setuptools.find_packages(where=".", include="deltacat*"),
     install_requires=[
         # any changes here should also be reflected in requirements.txt
-        "boto3 == 1.20.24",
+        "boto3 ~= 1.20",
         "numpy == 1.21.5",
         "pandas == 1.3.5",
         "pyarrow == 10.0.1",
         "pydantic == 1.10.4",
-        "ray[default] == 2.0.0",
+        "ray[default] ~= 2.0",
         "s3fs == 2022.2.0",
         "tenacity == 8.1.0",
         "typing-extensions == 4.4.0",


### PR DESCRIPTION
This commit bumps up the version and allows ray 2.3.0 to be used along with boto3 that latest version of boto3. 