### PR TITLE
Fix key type

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -43,7 +43,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"
 
 
 __all__ = [

--- a/deltacat/compute/compactor/__init__.py
+++ b/deltacat/compute/compactor/__init__.py
@@ -9,7 +9,10 @@ from deltacat.compute.compactor.model.primary_key_index import (
     PrimaryKeyIndexVersionMeta,
 )
 from deltacat.compute.compactor.model.pyarrow_write_result import PyArrowWriteResult
-from deltacat.compute.compactor.model.round_completion_info import RoundCompletionInfo
+from deltacat.compute.compactor.model.round_completion_info import (
+    RoundCompletionInfo,
+    HighWatermark,
+)
 from deltacat.compute.compactor.model.sort_key import SortKey, SortOrder
 
 __all__ = [
@@ -23,6 +26,7 @@ __all__ = [
     "PrimaryKeyIndexVersionMeta",
     "PyArrowWriteResult",
     "RoundCompletionInfo",
+    "HighWatermark",
     "SortKey",
     "SortOrder",
 ]

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -441,13 +441,11 @@ def _execute_compaction_round(
         rcf_source_partition_locator,
         new_round_completion_info,
     )
-    if last_stream_position_compacted[
-        source_partition_locator.canonical_string()
-    ] < last_stream_position_to_compact or (
+    if last_stream_position_compacted.get(
+        source_partition_locator
+    ) < last_stream_position_to_compact or (
         not rebase_source_partition_locator
-        and last_stream_position_compacted[
-            destination_partition_locator.canonical_string()
-        ]
+        and last_stream_position_compacted.get(destination_partition_locator)
         < previous_last_stream_position_compacted_on_destination_table
     ):
         logger.info(

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -442,10 +442,12 @@ def _execute_compaction_round(
         new_round_completion_info,
     )
     if last_stream_position_compacted[
-        source_partition_locator
+        source_partition_locator.canonical_string()
     ] < last_stream_position_to_compact or (
         not rebase_source_partition_locator
-        and last_stream_position_compacted[destination_partition_locator]
+        and last_stream_position_compacted[
+            destination_partition_locator.canonical_string()
+        ]
         < previous_last_stream_position_compacted_on_destination_table
     ):
         logger.info(

--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -15,7 +15,7 @@ class RoundCompletionInfo(dict):
 
     @staticmethod
     def of(
-        high_watermark: Union[Dict[PartitionLocator, int], int],
+        high_watermark: Union[Dict[str, int], int],
         compacted_delta_locator: DeltaLocator,
         compacted_pyarrow_write_result: PyArrowWriteResult,
         sort_keys_bit_width: int,
@@ -31,7 +31,7 @@ class RoundCompletionInfo(dict):
         return rci
 
     @property
-    def high_watermark(self) -> Union[Dict[PartitionLocator, int], int]:
+    def high_watermark(self) -> Union[Dict[str, int], int]:
         return self["highWatermark"]
 
     @property

--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from deltacat.storage import DeltaLocator, PartitionLocator
 from deltacat.compute.compactor.model.pyarrow_write_result import PyArrowWriteResult
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 
 class HighWatermark(dict):
@@ -13,7 +13,10 @@ class HighWatermark(dict):
     """
 
     def set(self, partition_locator: PartitionLocator, delta_stream_position: int):
-        self[partition_locator.canonical_string()] = (partition_locator, delta_stream_position)
+        self[partition_locator.canonical_string()] = (
+            partition_locator,
+            delta_stream_position,
+        )
 
     def get(self, partition_locator: PartitionLocator) -> int:
         val = self.get(partition_locator.canonical_string())
@@ -31,7 +34,7 @@ class RoundCompletionInfo(dict):
 
     @staticmethod
     def of(
-        high_watermark: Union[HighWatermark, int],
+        high_watermark: HighWatermark,
         compacted_delta_locator: DeltaLocator,
         compacted_pyarrow_write_result: PyArrowWriteResult,
         sort_keys_bit_width: int,

--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -6,14 +6,14 @@ from deltacat.compute.compactor.model.pyarrow_write_result import PyArrowWriteRe
 from typing import Any, Dict, Optional, Union
 
 
-class HighWaterMark(dict):
+class HighWatermark(dict):
     """
     Inherit from dict to make it easy for serialization/deserialization.
     Keep both partition locator and high watermark as a tuple to be persisted in the rcf
     """
 
-    def append(self, partition_locator: PartitionLocator, high_watermark: int):
-        self[partition_locator.canonical_string()] = (partition_locator, high_watermark)
+    def set(self, partition_locator: PartitionLocator, delta_stream_position: int):
+        self[partition_locator.canonical_string()] = (partition_locator, delta_stream_position)
 
     def get(self, partition_locator: PartitionLocator) -> int:
         val = self.get(partition_locator.canonical_string())
@@ -31,7 +31,7 @@ class RoundCompletionInfo(dict):
 
     @staticmethod
     def of(
-        high_watermark: Union[HighWaterMark, int],
+        high_watermark: Union[HighWatermark, int],
         compacted_delta_locator: DeltaLocator,
         compacted_pyarrow_write_result: PyArrowWriteResult,
         sort_keys_bit_width: int,
@@ -47,7 +47,7 @@ class RoundCompletionInfo(dict):
         return rci
 
     @property
-    def high_watermark(self) -> Union[HighWaterMark, int]:
+    def high_watermark(self) -> HighWatermark:
         return self["highWatermark"]
 
     @property

--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -19,9 +19,8 @@ class HighWatermark(dict):
         )
 
     def get(self, partition_locator: PartitionLocator) -> int:
-        val = self.get(partition_locator.canonical_string())
-        if val is not None:
-            return val[1]
+        if partition_locator.canonical_string() in self:
+            return self[partition_locator.canonical_string()][1]
         return 0
 
 

--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -100,7 +100,6 @@ def delta_file_locator_to_mat_bucket_index(
 
 
 def _timed_dedupe(
-    compaction_artifact_s3_bucket: str,
     object_ids: List[Any],
     sort_keys: List[SortKey],
     num_materialize_buckets: int,
@@ -141,7 +140,6 @@ def _timed_dedupe(
 
             table, union_time = timed_invocation(
                 func=_union_primary_key_indices,
-                s3_bucket=compaction_artifact_s3_bucket,
                 hash_bucket_index=hb_idx,
                 df_envelopes_list=dfe_list,
             )
@@ -234,10 +232,8 @@ def _timed_dedupe(
 
 @ray.remote
 def dedupe(
-    compaction_artifact_s3_bucket: str,
     object_ids: List[Any],
     sort_keys: List[SortKey],
-    max_records_per_index_file: int,
     num_materialize_buckets: int,
     dedupe_task_index: int,
     enable_profiler: bool,
@@ -246,10 +242,8 @@ def dedupe(
     logger.info(f"[Dedupe task {dedupe_task_index}] Starting dedupe task...")
     mat_bucket_to_dd_idx_obj_id, duration = timed_invocation(
         func=_timed_dedupe,
-        compaction_artifact_s3_bucket=compaction_artifact_s3_bucket,
         object_ids=object_ids,
         sort_keys=sort_keys,
-        max_records_per_index_file=max_records_per_index_file,
         num_materialize_buckets=num_materialize_buckets,
         dedupe_task_index=dedupe_task_index,
         enable_profiler=enable_profiler,

--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -10,15 +10,18 @@ from deltacat.storage import (
 )
 from deltacat import logs
 from deltacat.compute.compactor import DeltaAnnotated
-from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, Union
+from deltacat.compute.compactor import HighWaterMark
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
+
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
 def discover_deltas(
     source_partition_locator: PartitionLocator,
-    high_watermark: Union[dict, int],
+    high_watermark: Union[HighWaterMark, int],
     last_stream_position_to_compact: int,
     compacted_partition_locator: Optional[PartitionLocator],
     rebase_source_partition_locator: Optional[PartitionLocator],
@@ -29,7 +32,7 @@ def discover_deltas(
     # Source One: new deltas from uncompacted table for incremental compaction or deltas from compacted table for rebase
     input_deltas = _discover_deltas(
         source_partition_locator,
-        high_watermark[source_partition_locator.canonical_string()]
+        high_watermark.get(source_partition_locator)
         if isinstance(high_watermark, dict)
         else high_watermark,
         last_stream_position_to_compact
@@ -132,7 +135,7 @@ def limit_input_deltas(
     user_hash_bucket_chunk_size: int,
     input_deltas_stats: Dict[int, DeltaStats],
     deltacat_storage=unimplemented_deltacat_storage,
-) -> Tuple[List[DeltaAnnotated], int, dict]:
+) -> Tuple[List[DeltaAnnotated], int, HighWaterMark]:
     # TODO (pdames): when row counts are available in metadata, use them
     #  instead of bytes - memory consumption depends more on number of
     #  input delta records than bytes.
@@ -155,8 +158,8 @@ def limit_input_deltas(
     delta_bytes = 0
     delta_bytes_pyarrow = 0
     delta_manifest_entries = 0
-    latest_stream_position = defaultdict(
-        lambda: -1
+    latest_stream_position = (
+        HighWaterMark()
     )  # tracks the latest stream position for each partition locator
     limited_input_da_list = []
 
@@ -187,11 +190,9 @@ def limit_input_deltas(
             delta_bytes += entry.meta.content_length
             if not delta_stats:
                 delta_bytes_pyarrow = delta_bytes * PYARROW_INFLATION_MULTIPLIER
-        latest_stream_position[
-            delta.locator.partition_locator.canonical_string()
-        ] = max(
-            position,
-            latest_stream_position[delta.locator.partition_locator.canonical_string()],
+        latest_stream_position.append(
+            delta.locator.partition_locator,
+            max(position, latest_stream_position.get(delta.locator.partition_locator)),
         )
         if delta_bytes_pyarrow > worker_obj_store_mem:
             logger.info(

--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -187,8 +187,11 @@ def limit_input_deltas(
             delta_bytes += entry.meta.content_length
             if not delta_stats:
                 delta_bytes_pyarrow = delta_bytes * PYARROW_INFLATION_MULTIPLIER
-        latest_stream_position[delta.locator.partition_locator] = max(
-            position, latest_stream_position[delta.locator.partition_locator]
+        latest_stream_position[
+            delta.locator.partition_locator.canonical_string()
+        ] = max(
+            position,
+            latest_stream_position[delta.locator.partition_locator.canonical_string()],
         )
         if delta_bytes_pyarrow > worker_obj_store_mem:
             logger.info(

--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -16,9 +16,6 @@ from deltacat.compute.compactor import HighWatermark
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
-logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
-
-
 def discover_deltas(
     source_partition_locator: PartitionLocator,
     high_watermark: Union[HighWatermark, int],

--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -159,7 +159,7 @@ def limit_input_deltas(
     delta_bytes_pyarrow = 0
     delta_manifest_entries = 0
     # tracks the latest stream position for each partition locator
-    high_watermark = HighWatermark() 
+    high_watermark = HighWatermark()
     limited_input_da_list = []
 
     if input_deltas_stats is None:
@@ -191,7 +191,7 @@ def limit_input_deltas(
                 delta_bytes_pyarrow = delta_bytes * PYARROW_INFLATION_MULTIPLIER
         high_watermark.set(
             delta.locator.partition_locator,
-            max(position, latest_stream_position.get(delta.locator.partition_locator)),
+            max(position, high_watermark.get(delta.locator.partition_locator)),
         )
         if delta_bytes_pyarrow > worker_obj_store_mem:
             logger.info(
@@ -206,7 +206,7 @@ def limit_input_deltas(
     logger.info(f"Input deltas to compact this round: " f"{len(limited_input_da_list)}")
     logger.info(f"Input delta bytes to compact: {delta_bytes}")
     logger.info(f"Input delta files to compact: {delta_manifest_entries}")
-    logger.info(f"Latest input delta stream position: {latest_stream_position}")
+    logger.info(f"Latest input delta stream position: {high_watermark}")
 
     if not limited_input_da_list:
         raise RuntimeError("No input deltas to compact!")
@@ -278,4 +278,4 @@ def limit_input_deltas(
     logger.info(f"Hash bucket count: {hash_bucket_count}")
     logger.info(f"Input uniform delta count: {len(rebatched_da_list)}")
 
-    return rebatched_da_list, hash_bucket_count, latest_stream_position
+    return rebatched_da_list, hash_bucket_count, high_watermark

--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -11,7 +11,7 @@ from deltacat.storage import (
 from deltacat import logs
 from deltacat.compute.compactor import DeltaAnnotated
 from typing import Dict, List, Optional, Tuple, Union
-from deltacat.compute.compactor import HighWaterMark
+from deltacat.compute.compactor import HighWatermark
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
@@ -21,7 +21,7 @@ logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 def discover_deltas(
     source_partition_locator: PartitionLocator,
-    high_watermark: Union[HighWaterMark, int],
+    high_watermark: Union[HighWatermark, int],
     last_stream_position_to_compact: int,
     compacted_partition_locator: Optional[PartitionLocator],
     rebase_source_partition_locator: Optional[PartitionLocator],
@@ -135,7 +135,7 @@ def limit_input_deltas(
     user_hash_bucket_chunk_size: int,
     input_deltas_stats: Dict[int, DeltaStats],
     deltacat_storage=unimplemented_deltacat_storage,
-) -> Tuple[List[DeltaAnnotated], int, HighWaterMark]:
+) -> Tuple[List[DeltaAnnotated], int, HighWatermark]:
     # TODO (pdames): when row counts are available in metadata, use them
     #  instead of bytes - memory consumption depends more on number of
     #  input delta records than bytes.
@@ -158,9 +158,8 @@ def limit_input_deltas(
     delta_bytes = 0
     delta_bytes_pyarrow = 0
     delta_manifest_entries = 0
-    latest_stream_position = (
-        HighWaterMark()
-    )  # tracks the latest stream position for each partition locator
+    # tracks the latest stream position for each partition locator
+    high_watermark = HighWatermark() 
     limited_input_da_list = []
 
     if input_deltas_stats is None:
@@ -190,7 +189,7 @@ def limit_input_deltas(
             delta_bytes += entry.meta.content_length
             if not delta_stats:
                 delta_bytes_pyarrow = delta_bytes * PYARROW_INFLATION_MULTIPLIER
-        latest_stream_position.append(
+        high_watermark.set(
             delta.locator.partition_locator,
             max(position, latest_stream_position.get(delta.locator.partition_locator)),
         )


### PR DESCRIPTION
`PartitionLocator` is not hashable when using with dict as key. Revert it to string type. 
Remove un-used function parameters for compaction with no pki