### PR TITLE
adding kwargs to all invocations of _discover_deltas

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -43,7 +43,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"
 
 
 __all__ = [

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -233,7 +233,7 @@ def _execute_compaction_round(
         )
         if not round_completion_info:
             logger.info(
-                f"Both rebase partition and round completion file not found. Performing a entire backfill on source."
+                f"Both rebase partition and round completion file not found. Performing an entire backfill on source."
             )
         logger.info(f"Round completion file: {round_completion_info}")
 

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -259,7 +259,7 @@ def _execute_compaction_round(
         rebase_source_partition_locator,
         rebase_source_partition_high_watermark,
         deltacat_storage,
-        **list_deltas_kwargs
+        **list_deltas_kwargs,
     )
 
     if not input_deltas:

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -233,10 +233,8 @@ def _execute_compaction_round(
         )
         if not round_completion_info:
             logger.info(
-                f"Need rebase source to run initial rebase, otherwise provide round completion file for incremental "
-                f"compaction"
+                f"Both rebase partition and round completion file not found. Performing a entire backfill on source."
             )
-            return None, None, None
         logger.info(f"Round completion file: {round_completion_info}")
 
     # discover input delta files

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -31,7 +31,7 @@ from deltacat.compute.compactor.utils import round_completion_file as rcf
 
 from deltacat.types.media import ContentType
 from deltacat.utils.placement import PlacementGroupConfig
-from typing import List, Set, Optional, Tuple, Dict
+from typing import List, Set, Optional, Tuple, Dict, Any
 from collections import defaultdict
 from deltacat.utils.metrics import MetricsConfig
 
@@ -93,6 +93,7 @@ def compact_partition(
     rebase_source_partition_high_watermark: Optional[int] = None,
     enable_profiler: Optional[bool] = False,
     metrics_config: Optional[MetricsConfig] = None,
+    list_deltas_kwargs: Optional[Dict[str, Any]] = None,
     deltacat_storage=unimplemented_deltacat_storage,
     **kwargs,
 ) -> Optional[str]:
@@ -126,6 +127,7 @@ def compact_partition(
             rebase_source_partition_high_watermark,
             enable_profiler,
             metrics_config,
+            list_deltas_kwargs,
             deltacat_storage,
             **kwargs,
         )
@@ -161,6 +163,7 @@ def _execute_compaction_round(
     rebase_source_partition_high_watermark: Optional[int],
     enable_profiler: Optional[bool],
     metrics_config: Optional[MetricsConfig],
+    list_deltas_kwargs=Optional[Dict[str, Any]],
     deltacat_storage=unimplemented_deltacat_storage,
     **kwargs,
 ) -> Tuple[Optional[Partition], Optional[RoundCompletionInfo], Optional[str]]:
@@ -258,6 +261,7 @@ def _execute_compaction_round(
         rebase_source_partition_locator,
         rebase_source_partition_high_watermark,
         deltacat_storage,
+        **list_deltas_kwargs
     )
 
     if not input_deltas:

--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -24,7 +24,7 @@ def discover_deltas(
     rebase_source_partition_locator: Optional[PartitionLocator],
     rebase_source_partition_high_watermark: Optional[int],
     deltacat_storage=unimplemented_deltacat_storage,
-    **kwargs
+    **kwargs,
 ) -> Tuple[List[Delta], int]:
 
     # Source One: new deltas from uncompacted table for incremental compaction or deltas from compacted table for rebase
@@ -40,7 +40,7 @@ def discover_deltas(
             source_partition_locator.partition_values,
         ).stream_position,
         deltacat_storage,
-        **kwargs
+        **kwargs,
     )
 
     # Source Two: delta from compacted table for incremental compaction or new deltas from uncompacted table for rebase
@@ -87,7 +87,7 @@ def _discover_deltas(
     start_position_exclusive: Optional[int],
     end_position_inclusive: int,
     deltacat_storage=unimplemented_deltacat_storage,
-    **kwargs
+    **kwargs,
 ) -> List[Delta]:
     stream_locator = source_partition_locator.stream_locator
     namespace = stream_locator.namespace
@@ -102,7 +102,7 @@ def _discover_deltas(
         first_stream_position=start_position_exclusive,
         last_stream_position=end_position_inclusive,
         include_manifest=True,
-        **kwargs
+        **kwargs,
     )
     deltas = deltas_list_result.all_items()
     if not deltas:

--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -60,6 +60,7 @@ def discover_deltas(
                 None,
                 previous_last_stream_position_compacted,
                 deltacat_storage,
+                **kwargs,
             )
         logger.info(
             f"Length of input deltas from uncompacted table {len(input_deltas)} up to {last_stream_position_to_compact},"
@@ -72,6 +73,7 @@ def discover_deltas(
             rebase_source_partition_high_watermark,
             last_stream_position_to_compact,
             deltacat_storage,
+            **kwargs,
         )
         logger.info(
             f"Length of input deltas from uncompacted table {len(input_deltas_new)} up to {last_stream_position_to_compact},"

--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -24,6 +24,7 @@ def discover_deltas(
     rebase_source_partition_locator: Optional[PartitionLocator],
     rebase_source_partition_high_watermark: Optional[int],
     deltacat_storage=unimplemented_deltacat_storage,
+    **kwargs
 ) -> Tuple[List[Delta], int]:
 
     # Source One: new deltas from uncompacted table for incremental compaction or deltas from compacted table for rebase
@@ -39,6 +40,7 @@ def discover_deltas(
             source_partition_locator.partition_values,
         ).stream_position,
         deltacat_storage,
+        **kwargs
     )
 
     # Source Two: delta from compacted table for incremental compaction or new deltas from uncompacted table for rebase
@@ -85,6 +87,7 @@ def _discover_deltas(
     start_position_exclusive: Optional[int],
     end_position_inclusive: int,
     deltacat_storage=unimplemented_deltacat_storage,
+    **kwargs
 ) -> List[Delta]:
     stream_locator = source_partition_locator.stream_locator
     namespace = stream_locator.namespace
@@ -92,13 +95,14 @@ def _discover_deltas(
     table_version = stream_locator.table_version
     partition_values = source_partition_locator.partition_values
     deltas_list_result = deltacat_storage.list_deltas(
-        namespace,
-        table_name,
-        partition_values,
-        table_version,
-        start_position_exclusive,
-        end_position_inclusive,
-        True,
+        namespace=namespace,
+        table_name=table_name,
+        partition_values=partition_values,
+        table_version=table_version,
+        first_stream_position=start_position_exclusive,
+        last_stream_position=end_position_inclusive,
+        include_manifest=True,
+        **kwargs
     )
     deltas = deltas_list_result.all_items()
     if not deltas:


### PR DESCRIPTION
All invocations of `_discover_deltas` will require the `equivalent_table_types` arg to be passed to disable resolving an appropriate table type. Earlier only one of the `_discover_deltas` had kwargs. Hence, the invocation that did not have this kwargs failed. 