### PR TITLE
Add assertions to fast fail compaction in case of a metadata/execution issue

### DIFF
--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -440,14 +440,18 @@ def _execute_compaction_round(
     mat_results = sorted(mat_results, key=lambda m: m.task_index)
     deltas = [m.delta for m in mat_results]
     merged_delta = Delta.merge_deltas(deltas)
+    record_info_msg = (
+        f"Hash bucket records: {total_hb_record_count},"
+        f" Deduped records: {total_dd_record_count}, "
+        f" Materialized records: {merged_delta.meta.record_count}"
+    )
+    logger.info(record_info_msg)
     assert (
         total_hb_record_count - total_dd_record_count == merged_delta.meta.record_count
     ), (
         f"Number of hash bucket records minus the number of deduped records"
         f" does not match number of materialized records.\n"
-        f" Hash bucket records: {total_hb_record_count},"
-        f" Deduped records: {total_dd_record_count}, "
-        f" Materialized records: {merged_delta.meta.record_count}"
+        f" {record_info_msg}"
     )
     compacted_delta = deltacat_storage.commit_delta(
         merged_delta, properties=kwargs.get("properties", {})

--- a/deltacat/compute/compactor/model/dedupe_result.py
+++ b/deltacat/compute/compactor/model/dedupe_result.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+
+@dataclass
+class DedupeResult:
+    mat_bucket_idx_to_obj_id: Dict[int, Tuple]
+    deduped_record_count: int

--- a/deltacat/compute/compactor/model/hash_bucket_result.py
+++ b/deltacat/compute/compactor/model/hash_bucket_result.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class HashBucketResult:
+    hash_bucket_group_to_obj_id: np.ndarray
+    hb_record_count: int

--- a/deltacat/compute/compactor/steps/hash_bucket.py
+++ b/deltacat/compute/compactor/steps/hash_bucket.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 from contextlib import nullcontext
 from itertools import chain
-from typing import Generator, List, Optional
+from typing import Generator, List, Optional, Tuple
 import numpy as np
 import pyarrow as pa
 import ray
@@ -14,6 +14,7 @@ from deltacat.compute.compactor import (
     RoundCompletionInfo,
 )
 from deltacat.compute.compactor.model.delta_file_envelope import DeltaFileEnvelopeGroups
+from deltacat.compute.compactor.model.hash_bucket_result import HashBucketResult
 from deltacat.compute.compactor.utils import system_columns as sc
 from deltacat.compute.compactor.utils.primary_key_index import (
     group_hash_bucket_indices,
@@ -35,8 +36,6 @@ if importlib.util.find_spec("memray"):
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 _PK_BYTES_DELIMITER = b"L6kl7u5f"
-
-HashBucketResult = np.ndarray
 
 
 def _group_by_pk_hash_bucket(
@@ -87,16 +86,16 @@ def _group_file_records_by_pk_hash_bucket(
     sort_key_names: List[str],
     is_src_delta: np.bool_ = True,
     deltacat_storage=unimplemented_deltacat_storage,
-) -> Optional[DeltaFileEnvelopeGroups]:
+) -> Tuple[Optional[DeltaFileEnvelopeGroups], int]:
     # read input parquet s3 objects into a list of delta file envelopes
-    delta_file_envelopes = _read_delta_file_envelopes(
+    delta_file_envelopes, total_record_count = _read_delta_file_envelopes(
         annotated_delta,
         primary_keys,
         sort_key_names,
         deltacat_storage,
     )
     if delta_file_envelopes is None:
-        return None
+        return None, 0
 
     # group the data by primary key hash value
     hb_to_delta_file_envelopes = np.empty([num_hash_buckets], dtype="object")
@@ -119,7 +118,7 @@ def _group_file_records_by_pk_hash_bucket(
                         is_src_delta,
                     )
                 )
-    return hb_to_delta_file_envelopes
+    return hb_to_delta_file_envelopes, total_record_count
 
 
 def _read_delta_file_envelopes(
@@ -127,7 +126,7 @@ def _read_delta_file_envelopes(
     primary_keys: List[str],
     sort_key_names: List[str],
     deltacat_storage=unimplemented_deltacat_storage,
-) -> Optional[List[DeltaFileEnvelope]]:
+) -> Tuple[Optional[List[DeltaFileEnvelope]], int]:
 
     columns_to_read = list(chain(primary_keys, sort_key_names))
     # TODO (rootliu) compare performance of column read from unpartitioned vs partitioned file
@@ -146,10 +145,12 @@ def _read_delta_file_envelopes(
         f"annotations ({len(annotations)}).",
     )
     if not tables:
-        return None
+        return None, 0
 
     delta_file_envelopes = []
+    total_record_count = 0
     for i, table in enumerate(tables):
+        total_record_count += len(table)
         delta_file = DeltaFileEnvelope.of(
             annotations[i].annotation_stream_position,
             annotations[i].annotation_file_index,
@@ -157,7 +158,7 @@ def _read_delta_file_envelopes(
             table,
         )
         delta_file_envelopes.append(delta_file)
-    return delta_file_envelopes
+    return delta_file_envelopes, total_record_count
 
 
 def _timed_hash_bucket(
@@ -183,7 +184,10 @@ def _timed_hash_bucket(
                 annotated_delta.locator.partition_locator
                 != round_completion_info.compacted_delta_locator.partition_locator
             )
-        delta_file_envelope_groups = _group_file_records_by_pk_hash_bucket(
+        (
+            delta_file_envelope_groups,
+            total_record_count,
+        ) = _group_file_records_by_pk_hash_bucket(
             annotated_delta,
             num_buckets,
             primary_keys,
@@ -196,7 +200,7 @@ def _timed_hash_bucket(
             num_buckets,
             num_groups,
         )
-        return hash_bucket_group_to_obj_id
+        return HashBucketResult(hash_bucket_group_to_obj_id, total_record_count)
 
 
 @ray.remote
@@ -213,7 +217,7 @@ def hash_bucket(
 ) -> HashBucketResult:
 
     logger.info(f"Starting hash bucket task...")
-    hash_bucket_group_to_obj_id, duration = timed_invocation(
+    hash_bucket_result, duration = timed_invocation(
         func=_timed_hash_bucket,
         annotated_delta=annotated_delta,
         round_completion_info=round_completion_info,
@@ -229,4 +233,4 @@ def hash_bucket(
             metrics_name="hash_bucket", value=duration, metrics_config=metrics_config
         )
     logger.info(f"Finished hash bucket task...")
-    return hash_bucket_group_to_obj_id
+    return hash_bucket_result

--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -103,6 +103,7 @@ def _discover_deltas(
         table_version=table_version,
         first_stream_position=start_position_exclusive,
         last_stream_position=end_position_inclusive,
+        ascending_order=True,
         include_manifest=True,
         **kwargs,
     )
@@ -115,7 +116,7 @@ def _discover_deltas(
             f"'{end_position_inclusive}']. Source partition: "
             f"{source_partition_locator}"
         )
-    if start_position_exclusive:
+    if start_position_exclusive == deltas[0].stream_position:
         first_delta = deltas.pop(0)
         logger.info(
             f"Removed exclusive start delta w/ expected stream "
@@ -138,7 +139,7 @@ def limit_input_deltas(
     user_hash_bucket_chunk_size: int,
     input_deltas_stats: Dict[int, DeltaStats],
     deltacat_storage=unimplemented_deltacat_storage,
-) -> Tuple[List[DeltaAnnotated], int, HighWatermark]:
+) -> Tuple[List[DeltaAnnotated], int, HighWatermark, bool]:
     # TODO (pdames): when row counts are available in metadata, use them
     #  instead of bytes - memory consumption depends more on number of
     #  input delta records than bytes.
@@ -161,6 +162,7 @@ def limit_input_deltas(
     delta_bytes = 0
     delta_bytes_pyarrow = 0
     delta_manifest_entries = 0
+    require_multiple_rounds = False
     # tracks the latest stream position for each partition locator
     high_watermark = HighWatermark()
     limited_input_da_list = []
@@ -202,6 +204,7 @@ def limit_input_deltas(
                 f"{len(limited_input_da_list)} by object store mem "
                 f"({delta_bytes_pyarrow} > {worker_obj_store_mem})"
             )
+            require_multiple_rounds = True
             break
         delta_annotated = DeltaAnnotated.of(delta)
         limited_input_da_list.append(delta_annotated)
@@ -281,4 +284,4 @@ def limit_input_deltas(
     logger.info(f"Hash bucket count: {hash_bucket_count}")
     logger.info(f"Input uniform delta count: {len(rebatched_da_list)}")
 
-    return rebatched_da_list, hash_bucket_count, high_watermark
+    return rebatched_da_list, hash_bucket_count, high_watermark, require_multiple_rounds


### PR DESCRIPTION
This change adds logging for record counts and validates `# of hash bucket records - # of deduped records = # of materialized records`.