### PR TITLE
Update hash bucket and dedupe result dataclasses to tuple type

### DIFF
--- a/deltacat/compute/compactor/model/dedupe_result.py
+++ b/deltacat/compute/compactor/model/dedupe_result.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass
-from typing import Dict, Tuple
+from typing import Dict, Tuple, NamedTuple
+
+import numpy as np
 
 
-@dataclass
-class DedupeResult:
+class DedupeResult(NamedTuple):
     mat_bucket_idx_to_obj_id: Dict[int, Tuple]
-    deduped_record_count: int
+    deduped_record_count: np.int64

--- a/deltacat/compute/compactor/model/hash_bucket_result.py
+++ b/deltacat/compute/compactor/model/hash_bucket_result.py
@@ -1,9 +1,8 @@
-from dataclasses import dataclass
+from typing import NamedTuple
 
 import numpy as np
 
 
-@dataclass
-class HashBucketResult:
+class HashBucketResult(NamedTuple):
     hash_bucket_group_to_obj_id: np.ndarray
-    hb_record_count: int
+    hb_record_count: np.int64

--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -231,7 +231,9 @@ def _timed_dedupe(
             f"{len(mat_bucket_to_dd_idx_obj_id)}"
         )
 
-        return DedupeResult(mat_bucket_to_dd_idx_obj_id, total_deduped_records)
+        return DedupeResult(
+            mat_bucket_to_dd_idx_obj_id, np.int64(total_deduped_records)
+        )
 
 
 @ray.remote

--- a/deltacat/compute/compactor/steps/hash_bucket.py
+++ b/deltacat/compute/compactor/steps/hash_bucket.py
@@ -207,7 +207,9 @@ def _timed_hash_bucket(
             num_buckets,
             num_groups,
         )
-        return HashBucketResult(hash_bucket_group_to_obj_id, total_record_count)
+        return HashBucketResult(
+            hash_bucket_group_to_obj_id, np.int64(total_record_count)
+        )
 
 
 @ray.remote


### PR DESCRIPTION
Update the hash bucket and dedupe result from dataclasses to tuple to mitigate some performance issues found during compaction on certain tables.