### PR TITLE
remove dependency on rebase_source_partition

### DIFF
--- a/deltacat/compute/compactor/repartition_session.py
+++ b/deltacat/compute/compactor/repartition_session.py
@@ -166,7 +166,9 @@ def repartition(
         bit_width_of_sort_keys,
         None,
     )
-    return rcf.write_repartition_completion_file(
-        repartition_completion_file_s3_url,
+    return rcf.write_round_completion_file(
+        None,
+        None,
         repartition_completion_info,
+        repartition_completion_file_s3_url,
     )

--- a/deltacat/compute/compactor/utils/round_completion_file.py
+++ b/deltacat/compute/compactor/utils/round_completion_file.py
@@ -5,6 +5,7 @@ from deltacat import logs
 from deltacat.compute.compactor import RoundCompletionInfo
 from deltacat.storage import PartitionLocator
 from deltacat.aws import s3u as s3_utils
+from typing import Optional
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
@@ -36,40 +37,19 @@ def read_round_completion_file(
 
 
 def write_round_completion_file(
-    bucket: str,
-    source_partition_locator: PartitionLocator,
+    bucket: Optional[str],
+    source_partition_locator: Optional[PartitionLocator],
     round_completion_info: RoundCompletionInfo,
+    completion_file_s3_url: str = None,
 ) -> str:
 
     logger.info(f"writing round completion file contents: {round_completion_info}")
-    round_completion_file_s3_url = get_round_completion_file_s3_url(
-        bucket,
-        source_partition_locator,
-    )
-    logger.info(f"writing round completion file to: {round_completion_file_s3_url}")
-    s3_utils.upload(
-        round_completion_file_s3_url, str(json.dumps(round_completion_info))
-    )
-    logger.info(f"round completion file written to: {round_completion_file_s3_url}")
-    return round_completion_file_s3_url
-
-
-# write rcf given s3 url
-def write_repartition_completion_file(
-    repartition_completion_file_s3_url: str,
-    round_completion_info: RoundCompletionInfo,
-) -> str:
-
-    logger.info(
-        f"writing repartition completion file contents: {round_completion_info}"
-    )
-    logger.info(
-        f"writing repartition completion file to: {repartition_completion_file_s3_url}"
-    )
-    s3_utils.upload(
-        repartition_completion_file_s3_url, str(json.dumps(round_completion_info))
-    )
-    logger.info(
-        f"repartition completion file written to: {repartition_completion_file_s3_url}"
-    )
-    return repartition_completion_file_s3_url
+    if completion_file_s3_url is None:
+        completion_file_s3_url = get_round_completion_file_s3_url(
+            bucket,
+            source_partition_locator,
+        )
+    logger.info(f"writing round completion file to: {completion_file_s3_url}")
+    s3_utils.upload(completion_file_s3_url, str(json.dumps(round_completion_info)))
+    logger.info(f"round completion file written to: {completion_file_s3_url}")
+    return completion_file_s3_url

--- a/deltacat/compute/compactor/utils/round_completion_file.py
+++ b/deltacat/compute/compactor/utils/round_completion_file.py
@@ -4,6 +4,7 @@ import logging
 from deltacat import logs
 from deltacat.compute.compactor import RoundCompletionInfo
 from deltacat.storage import PartitionLocator
+from deltacat.aws import s3u as s3_utils
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
@@ -19,8 +20,6 @@ def get_round_completion_file_s3_url(
 def read_round_completion_file(
     bucket: str, source_partition_locator: PartitionLocator
 ) -> RoundCompletionInfo:
-
-    from deltacat.aws import s3u as s3_utils
 
     round_completion_file_url = get_round_completion_file_s3_url(
         bucket,
@@ -42,8 +41,6 @@ def write_round_completion_file(
     round_completion_info: RoundCompletionInfo,
 ) -> str:
 
-    from deltacat.aws import s3u as s3_utils
-
     logger.info(f"writing round completion file contents: {round_completion_info}")
     round_completion_file_s3_url = get_round_completion_file_s3_url(
         bucket,
@@ -55,3 +52,24 @@ def write_round_completion_file(
     )
     logger.info(f"round completion file written to: {round_completion_file_s3_url}")
     return round_completion_file_s3_url
+
+
+# write rcf given s3 url
+def write_repartition_completion_file(
+    repartition_completion_file_s3_url: str,
+    round_completion_info: RoundCompletionInfo,
+) -> str:
+
+    logger.info(
+        f"writing repartition completion file contents: {round_completion_info}"
+    )
+    logger.info(
+        f"writing repartition completion file to: {repartition_completion_file_s3_url}"
+    )
+    s3_utils.upload(
+        repartition_completion_file_s3_url, str(json.dumps(round_completion_info))
+    )
+    logger.info(
+        f"repartition completion file written to: {repartition_completion_file_s3_url}"
+    )
+    return repartition_completion_file_s3_url


### PR DESCRIPTION
Repartition only needs to know the source and destination. This pr removes the dependency on rebase_source_partition and simplifies the delta discovery by directly scanning the compacted table, either ray or spark.
```
If repartition_during_rebase:
  use spark variant
else:
  use ray variant
```
Related issue: https://github.com/ray-project/deltacat/issues/133