### PR TITLE
Capturing all the performance metrics in an audit

### DIFF
--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -4,6 +4,8 @@ import functools
 import logging
 import ray
 import time
+import json
+from deltacat.aws import s3u as s3_utils
 import deltacat
 from deltacat import logs
 import pyarrow as pa
@@ -43,8 +45,7 @@ from deltacat.utils.metrics import MetricsConfig
 from deltacat.compute.compactor.model.compaction_session_audit_info import (
     CompactionSessionAuditInfo,
 )
-from deltacat.utils.resources import ClusterUtilization
-from deltacat.utils.performance import timed_invocation
+
 
 if importlib.util.find_spec("memray"):
     import memray
@@ -195,10 +196,22 @@ def _execute_compaction_round(
     **kwargs,
 ) -> Tuple[Optional[Partition], Optional[RoundCompletionInfo], Optional[str]]:
 
-    compaction_audit = CompactionSessionAuditInfo()
-    compaction_audit.set_deltacat_version(deltacat.__version__)
+    rcf_source_partition_locator = (
+        rebase_source_partition_locator
+        if rebase_source_partition_locator
+        else source_partition_locator
+    )
 
-    compaction_start = time.time()
+    base_audit_url = rcf_source_partition_locator.path(
+        f"{compaction_artifact_s3_bucket}/compaction-audit"
+    )
+    audit_url = f"{base_audit_url}.json"
+
+    logger.info(f"Compaction will be written to {audit_url}")
+
+    compaction_audit = CompactionSessionAuditInfo(deltacat.__version__, audit_url)
+
+    compaction_start = time.monotonic()
 
     if not primary_keys:
         # TODO (pdames): run simple rebatch to reduce all deltas into 1 delta
@@ -242,7 +255,7 @@ def _execute_compaction_round(
             f"{node_resource_keys}"
         )
 
-    compaction_audit.set_cluster_cpu(cluster_cpus)
+    compaction_audit.set_cluster_cpu_max(cluster_cpus)
     # create a remote options provider to round-robin tasks across all nodes or allocated bundles
     logger.info(f"Setting round robin scheduling with node id:{node_resource_keys}")
     round_robin_opt_provider = functools.partial(
@@ -281,7 +294,7 @@ def _execute_compaction_round(
         round_completion_info.high_watermark if round_completion_info else None
     )
 
-    delta_discovery_start = time.time()
+    delta_discovery_start = time.monotonic()
     (
         input_deltas,
         previous_last_stream_position_compacted_on_destination_table,
@@ -296,10 +309,12 @@ def _execute_compaction_round(
         **list_deltas_kwargs,
     )
 
-    delta_discovery_end = time.time()
+    delta_discovery_end = time.monotonic()
     compaction_audit.set_delta_discovery_time_in_seconds(
         delta_discovery_end - delta_discovery_start
     )
+
+    s3_utils.upload(compaction_audit.audit_url, str(json.dumps(compaction_audit)))
 
     if not input_deltas:
         logger.info("No input deltas found to compact.")
@@ -356,7 +371,7 @@ def _execute_compaction_round(
             "Multiple rounds are not supported. Please increase the cluster size and run again."
         )
 
-    hb_start = time.time()
+    hb_start = time.monotonic()
 
     hb_tasks_pending = invoke_parallel(
         items=uniform_deltas,
@@ -373,26 +388,24 @@ def _execute_compaction_round(
         read_kwargs_provider=read_kwargs_provider,
         deltacat_storage=deltacat_storage,
     )
+
+    hb_invoke_end = time.monotonic()
+
     logger.info(f"Getting {len(hb_tasks_pending)} hash bucket results...")
     hb_results: List[HashBucketResult] = ray.get(hb_tasks_pending)
     logger.info(f"Got {len(hb_results)} hash bucket results.")
+    hb_end = time.monotonic()
+    hb_results_retrieved_at = time.time()
 
-    hb_end = time.time()
-    compaction_audit.set_hash_bucket_time_in_seconds(hb_end - hb_start)
-
-    cluster_utilization_after_hb, cluster_util_after_hb_latency = timed_invocation(
-        ClusterUtilization.get_current_cluster_utilization
+    telemetry_time_hb = compaction_audit.save_step_stats(
+        CompactionSessionAuditInfo.HASH_BUCKET_STEP_NAME,
+        hb_results,
+        hb_results_retrieved_at,
+        hb_invoke_end - hb_start,
+        hb_end - hb_start,
     )
 
-    compaction_audit.set_total_cluster_object_store_memory_bytes(
-        cluster_utilization_after_hb.total_object_store_memory_bytes
-    )
-    compaction_audit.set_total_cluster_memory_bytes(
-        cluster_utilization_after_hb.total_memory_bytes
-    )
-    compaction_audit.set_object_store_memory_used_bytes_by_hash_bucketing(
-        cluster_utilization_after_hb.used_object_store_memory_bytes
-    )
+    s3_utils.upload(compaction_audit.audit_url, str(json.dumps(compaction_audit)))
 
     all_hash_group_idx_to_obj_id = defaultdict(list)
     for hb_result in hb_results:
@@ -407,18 +420,8 @@ def _execute_compaction_round(
     logger.info(
         f"Got {total_hb_record_count} hash bucket records from hash bucketing step..."
     )
-    peak_memory_during_hb = max(
-        [hb_result.peak_memory_usage_bytes for hb_result in hb_results]
-    )
-
-    telemetry_time_hb = sum(
-        [hb_result.telemetry_time_in_seconds for hb_result in hb_results]
-    )
 
     compaction_audit.set_input_records(total_hb_record_count.item())
-    compaction_audit.set_peak_memory_used_bytes_by_hash_bucketing(
-        peak_memory_during_hb.item()
-    )
 
     # TODO (pdames): when resources are freed during the last round of hash
     #  bucketing, start running dedupe tasks that read existing dedupe
@@ -443,7 +446,7 @@ def _execute_compaction_round(
     num_materialize_buckets = max_parallelism
     logger.info(f"Materialize Bucket Count: {num_materialize_buckets}")
 
-    dedupe_start = time.time()
+    dedupe_start = time.monotonic()
 
     dd_tasks_pending = invoke_parallel(
         items=all_hash_group_idx_to_obj_id.values(),
@@ -459,30 +462,27 @@ def _execute_compaction_round(
         enable_profiler=enable_profiler,
         metrics_config=metrics_config,
     )
+
+    dedupe_invoke_end = time.monotonic()
     logger.info(f"Getting {len(dd_tasks_pending)} dedupe results...")
     dd_results: List[DedupeResult] = ray.get(dd_tasks_pending)
     logger.info(f"Got {len(dd_results)} dedupe results.")
 
-    dedupe_end = time.time()
-    compaction_audit.set_dedupe_time_in_seconds(dedupe_end - dedupe_start)
-
-    cluster_utilization_after_dd, cluster_util_after_dd_latency = timed_invocation(
-        ClusterUtilization.get_current_cluster_utilization
-    )
-
-    compaction_audit.set_object_store_memory_used_bytes_by_dedupe(
-        cluster_utilization_after_dd.used_object_store_memory_bytes
-        - cluster_utilization_after_hb.used_object_store_memory_bytes
-    )
+    dedupe_results_retrieved_at = time.time()
+    dedupe_end = time.monotonic()
 
     total_dd_record_count = sum([ddr.deduped_record_count for ddr in dd_results])
     logger.info(f"Deduped {total_dd_record_count} records...")
 
-    peak_memory_usage_dd = max([ddr.peak_memory_usage_bytes for ddr in dd_results])
-    telemetry_time_dd = sum([ddr.telemetry_time_in_seconds for ddr in dd_results])
+    telemetry_time_dd = compaction_audit.save_step_stats(
+        CompactionSessionAuditInfo.DEDUPE_STEP_NAME,
+        dd_results,
+        dedupe_results_retrieved_at,
+        dedupe_invoke_end - dedupe_start,
+        dedupe_end - dedupe_start,
+    )
 
     compaction_audit.set_records_deduped(total_dd_record_count.item())
-    compaction_audit.set_peak_memory_used_bytes_by_dedupe(peak_memory_usage_dd.item())
 
     all_mat_buckets_to_obj_id = defaultdict(list)
     for dd_result in dd_results:
@@ -511,7 +511,9 @@ def _execute_compaction_round(
     # parallel step 3:
     # materialize records to keep by index
 
-    materialize_start = time.time()
+    s3_utils.upload(compaction_audit.audit_url, str(json.dumps(compaction_audit)))
+
+    materialize_start = time.monotonic()
 
     mat_tasks_pending = invoke_parallel(
         items=all_mat_buckets_to_obj_id.items(),
@@ -534,73 +536,27 @@ def _execute_compaction_round(
         s3_table_writer_kwargs=s3_table_writer_kwargs,
         deltacat_storage=deltacat_storage,
     )
+
+    materialize_invoke_end = time.monotonic()
+
     logger.info(f"Getting {len(mat_tasks_pending)} materialize result(s)...")
     mat_results: List[MaterializeResult] = ray.get(mat_tasks_pending)
-    total_count_of_src_dfl_not_touched = sum(
-        m.count_of_src_dfl_not_touched for m in mat_results
-    )
-    total_length_src_dfl = sum(m.count_of_src_dfl for m in mat_results)
-    logger.info(
-        f"Got total of {total_count_of_src_dfl_not_touched} manifest files not touched."
-    )
-    logger.info(
-        f"Got total of {total_length_src_dfl} manifest files during compaction."
-    )
-    manifest_entry_copied_by_reference_ratio = (
-        (round(total_count_of_src_dfl_not_touched / total_length_src_dfl, 4) * 100)
-        if total_length_src_dfl != 0
-        else None
-    )
-    logger.info(
-        f"{manifest_entry_copied_by_reference_ratio} percent of manifest files are copied by reference during materialize."
-    )
 
     logger.info(f"Got {len(mat_results)} materialize result(s).")
 
-    materialize_end = time.time()
+    materialize_end = time.monotonic()
+    materialize_results_retrieved_at = time.time()
 
-    cluster_utilization_after_mat, cluster_util_after_mat_latency = timed_invocation(
-        ClusterUtilization.get_current_cluster_utilization
-    )
-
-    compaction_audit.set_materialize_time_in_seconds(
-        materialize_end - materialize_start
+    telemetry_time_materialize = compaction_audit.save_step_stats(
+        CompactionSessionAuditInfo.MATERIALIZE_STEP_NAME,
+        mat_results,
+        materialize_results_retrieved_at,
+        materialize_invoke_end - materialize_start,
+        materialize_end - materialize_start,
     )
 
     mat_results = sorted(mat_results, key=lambda m: m.task_index)
     deltas = [m.delta for m in mat_results]
-
-    telemetry_time_materialize = sum(
-        [mat_result.telemetry_time_in_seconds for mat_result in mat_results]
-    )
-    peak_memory_usage_materialize = max(
-        [mat_result.peak_memory_usage_bytes for mat_result in mat_results]
-    )
-
-    compaction_audit.set_peak_memory_used_bytes_by_materialize(
-        peak_memory_usage_materialize.item()
-    )
-    compaction_audit.set_total_object_store_memory_used_bytes(
-        cluster_utilization_after_mat.used_object_store_memory_bytes
-    )
-    compaction_audit.set_peak_memory_used_bytes(
-        max(
-            [
-                compaction_audit.peak_memory_used_bytes_by_hash_bucketing,
-                compaction_audit.peak_memory_used_bytes_by_dedupe,
-                compaction_audit.peak_memory_used_bytes_by_materialize,
-            ]
-        )
-    )
-
-    compaction_audit.set_telemetry_time_in_seconds(
-        cluster_util_after_hb_latency
-        + cluster_util_after_dd_latency
-        + telemetry_time_dd
-        + telemetry_time_hb
-        + telemetry_time_materialize
-        + cluster_util_after_mat_latency
-    )
 
     # Note: An appropriate last stream position must be set
     # to avoid correctness issue.
@@ -628,7 +584,7 @@ def _execute_compaction_round(
     )
     logger.info(f"Committed compacted delta: {compacted_delta}")
 
-    compaction_end = time.time()
+    compaction_end = time.monotonic()
     compaction_audit.set_compaction_time_in_seconds(compaction_end - compaction_start)
 
     new_compacted_delta_locator = DeltaLocator.of(
@@ -646,9 +602,11 @@ def _execute_compaction_round(
         [m.pyarrow_write_result for m in mat_results]
     )
 
-    compaction_audit.set_output_file_count(pyarrow_write_result.files)
-    compaction_audit.set_output_size_bytes(pyarrow_write_result.file_bytes)
-    compaction_audit.set_output_size_pyarrow_bytes(pyarrow_write_result.pyarrow_bytes)
+    compaction_audit.save_round_completion_stats(
+        mat_results, telemetry_time_hb + telemetry_time_dd + telemetry_time_materialize
+    )
+
+    s3_utils.upload(compaction_audit.audit_url, str(json.dumps(compaction_audit)))
 
     new_round_completion_info = RoundCompletionInfo.of(
         last_stream_position_compacted,
@@ -656,14 +614,10 @@ def _execute_compaction_round(
         pyarrow_write_result,
         bit_width_of_sort_keys,
         last_rebase_source_partition_locator,
-        manifest_entry_copied_by_reference_ratio,
-        compaction_audit,
+        compaction_audit.untouched_file_ratio,
+        audit_url,
     )
-    rcf_source_partition_locator = (
-        rebase_source_partition_locator
-        if rebase_source_partition_locator
-        else source_partition_locator
-    )
+
     logger.info(
         f"partition-{source_partition_locator.partition_values},"
         f"compacted at: {last_stream_position_compacted},"

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -207,7 +207,7 @@ def _execute_compaction_round(
     )
     audit_url = f"{base_audit_url}.json"
 
-    logger.info(f"Compaction will be written to {audit_url}")
+    logger.info(f"Compaction audit will be written to {audit_url}")
 
     compaction_audit = CompactionSessionAuditInfo(deltacat.__version__, audit_url)
 
@@ -348,6 +348,8 @@ def _execute_compaction_round(
         )
     )
 
+    compaction_audit.set_uniform_deltas_created(len(uniform_deltas))
+
     assert hash_bucket_count is not None and hash_bucket_count > 0, (
         f"Expected hash bucket count to be a positive integer, but found "
         f"`{hash_bucket_count}`"
@@ -468,6 +470,9 @@ def _execute_compaction_round(
     dd_results: List[DedupeResult] = ray.get(dd_tasks_pending)
     logger.info(f"Got {len(dd_results)} dedupe results.")
 
+    # we use time.time() here because time.monotonic() has no reference point
+    # whereas time.time() measures epoch seconds. Hence, it will be reasonable
+    # to compare time.time()s captured in different nodes.
     dedupe_results_retrieved_at = time.time()
     dedupe_end = time.monotonic()
 

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -45,6 +45,7 @@ from deltacat.utils.metrics import MetricsConfig
 from deltacat.compute.compactor.model.compaction_session_audit_info import (
     CompactionSessionAuditInfo,
 )
+from deltacat.utils.resources import get_current_node_peak_memory_usage_in_bytes
 
 
 if importlib.util.find_spec("memray"):
@@ -203,7 +204,7 @@ def _execute_compaction_round(
     )
 
     base_audit_url = rcf_source_partition_locator.path(
-        f"{compaction_artifact_s3_bucket}/compaction-audit"
+        f"s3://{compaction_artifact_s3_bucket}/compaction-audit"
     )
     audit_url = f"{base_audit_url}.json"
 
@@ -605,6 +606,11 @@ def _execute_compaction_round(
 
     pyarrow_write_result = PyArrowWriteResult.union(
         [m.pyarrow_write_result for m in mat_results]
+    )
+
+    session_peak_memory = get_current_node_peak_memory_usage_in_bytes()
+    compaction_audit.set_peak_memory_used_bytes_by_compaction_session_process(
+        session_peak_memory
     )
 
     compaction_audit.save_round_completion_stats(

--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -1,0 +1,417 @@
+# Allow classes to use self-referencing Type hints in Python 3.7.
+from __future__ import annotations
+
+
+class CompactionSessionAuditInfo(dict):
+    @property
+    def deltacat_version(self) -> str:
+        """
+        The deltacat version used to run compaction job.
+        """
+        return self.get("deltacatVersion")
+
+    @property
+    def input_records(self) -> int:
+        """
+        The total number of records from input deltas that needs to be compacted
+        (before deduplication).
+        """
+        return self.get("inputRecords")
+
+    @property
+    def input_file_count(self) -> int:
+        """
+        The total number of input files that needs to be compacted.
+        """
+        return self.get("inputFileCount")
+
+    @property
+    def records_deduped(self) -> int:
+        """
+        The total number of records that were deduplicated. For example,
+        if there are 100 records with a particular primary key, 99 records
+        will be deduplicated.
+        """
+        return self.get("recordsDeduped")
+
+    @property
+    def input_size_bytes(self) -> float:
+        """
+        The on-disk size in bytes of the input.
+        """
+        return self.get("inputSizeBytes")
+
+    @property
+    def hash_bucket_count(self) -> int:
+        """
+        Total number of hash buckets used during compaction.
+        """
+        return self.get("hashBucketCount")
+
+    @property
+    def cluster_cpu(self) -> float:
+        """
+        Total cluster cpu allocated for the compaction job.
+        """
+        return self.get("clusterCpu")
+
+    @property
+    def compaction_time_in_seconds(self) -> float:
+        """
+        The total time taken by the compaction session to complete.
+        """
+        return self.get("compactionTimeInSeconds")
+
+    @property
+    def total_object_store_memory_used_bytes(self) -> float:
+        """
+        The total object store memory used by the compaction session across all
+        nodes in the entire cluster.
+        """
+        return self.get("totalObjectStoreMemoryUsedBytes")
+
+    @property
+    def peak_memory_used_bytes(self) -> float:
+        """
+        The peak memory used by a single process in the compaction job. Note that
+        Ray creates a single process to run each hash bucketing, dedupe and
+        materialize task and the process is reused. Hence, you may see
+        monotonically increasing values. Peak memory is important because,
+        the cluster must be scaled to handle  the peak memory per node even
+        though average memory usage is low.
+        """
+        return self.get("peakMemoryUsedBytes")
+
+    @property
+    def peak_memory_used_bytes_by_hash_bucketing(self) -> float:
+        """
+        The peak memory used by a single hash bucketing process. For example,
+        if peak usage of hash bucketing process is 40GB, it is not safe to run
+        more than 3 hash bucketing tasks on a node with 120GB to avoid crashing
+        due to memory overflow.
+        """
+        return self.get("peakMemoryUsedBytesByHashBucketing")
+
+    @property
+    def peak_memory_used_bytes_by_dedupe(self) -> float:
+        """
+        The peak memory used by a single dedupe python process. Note that
+        results may be max of dedupe and hash bucketing as processes are
+        reused by Ray to run dedupe and hash bucketing.
+        """
+        return self.get("peakMemoryUsedBytesByDedupe")
+
+    @property
+    def peak_memory_used_bytes_by_materialize(self) -> float:
+        """
+        The peak memory used by a single materialize python process. Note
+        that results may be max of materialize, dedupe and hash bucketing as
+        processes are reused by Ray to run all compaction steps.
+        """
+        return self.get("peakMemoryUsedBytesByMaterialize")
+
+    @property
+    def object_store_memory_used_bytes_by_hash_bucketing(self) -> float:
+        """
+        The total object store memory used by hash bucketing step across
+        cluster, before dedupe is run.
+        """
+        return self.get("objectStoreMemoryUsedBytesByHashBucketing")
+
+    @property
+    def object_store_memory_used_bytes_by_dedupe(self) -> float:
+        """
+        The total object store memory used after dedupe step subtracted by the
+        object store memory using during hash bucketing.
+        """
+        return self.get("objectStoreMemoryUsedBytesByDedupe")
+
+    @property
+    def materialize_buckets(self) -> int:
+        """
+        The total number of materialize buckets created.
+        """
+        return self.get("materializeBuckets")
+
+    @property
+    def hash_bucket_time_in_seconds(self) -> float:
+        """
+        The time taken by hash bucketing step. This includes all hash bucket tasks.
+        """
+        return self.get("hashBucketTimeInSeconds")
+
+    @property
+    def dedupe_time_in_seconds(self) -> float:
+        """
+        The time taken by dedupe step. This include all dedupe tasks.
+        """
+        return self.get("dedupeTimeInSeconds")
+
+    @property
+    def materialize_time_in_seconds(self) -> float:
+        """
+        The time taken by materialize step. This includes all materialize tasks.
+        """
+        return self.get("materializeTimeInSeconds")
+
+    @property
+    def delta_discovery_time_in_seconds(self) -> float:
+        """
+        The time taken by delta discovery step which is mostly run before hash bucketing is started.
+        """
+        return self.get("deltaDiscoveryTimeInSeconds")
+
+    @property
+    def output_file_count(self) -> int:
+        """
+        The total number of files in the compacted output (includes untouched files).
+        """
+        return self.get("outputFileCount")
+
+    @property
+    def output_size_bytes(self) -> float:
+        """
+        The on-disk size of the compacted output including any untouched files.
+        """
+        return self.get("outputSizeBytes")
+
+    @property
+    def output_size_pyarrow_bytes(self) -> float:
+        """
+        The pyarrow in-memory size of compacted output including any untouched files.
+        """
+        return self.get("outputSizePyarrowBytes")
+
+    @property
+    def total_cluster_memory_bytes(self) -> float:
+        """
+        The total memory allocated to the cluster.
+        """
+        return self.get("totalClusterMemoryBytes")
+
+    @property
+    def total_cluster_object_store_memory_bytes(self) -> float:
+        """
+        The total object store memory allocated to the cluster.
+        """
+        return self.get("totalClusterObjectStoreMemoryBytes")
+
+    @property
+    def untouched_file_count(self) -> int:
+        """
+        The total number of files that were untouched by materialize step.
+        TODO: set this value after implementation of manifest skipping.
+        """
+        return self.get("untouchedFileCount")
+
+    @property
+    def untouched_file_ratio(self) -> float:
+        """
+        The ratio between total number of files untouched and total number of files in the compacted output.
+        TODO: set this value after implementation of manifest skipping.
+        """
+        return self.get("untouchedFileRatio")
+
+    @property
+    def untouched_record_count(self) -> int:
+        """
+        The total number of records untouched during materialization.
+        TODO: set this value after implementation of manifest skipping.
+        """
+        return self.get("untouchedRecordCount")
+
+    @property
+    def untouched_size_bytes(self) -> float:
+        """
+        The on-disk size of the data untouched during materialization.
+        TODO: set this value after implementation of manifest skipping.
+        """
+        return self.get("untouchedSizeBytes")
+
+    @property
+    def telemetry_time_in_seconds(self) -> float:
+        """
+        The total time taken by all the telemetry activity across the nodes in the cluster. This includes
+        collecting cluster resources information, emitting metrics, etc.
+        """
+        return self.get("telemetryTimeInSeconds")
+
+    # Setters follow
+
+    def set_deltacat_version(self, version: str) -> CompactionSessionAuditInfo:
+        self["deltacatVersion"] = version
+        return self
+
+    def set_input_records(self, input_records: int) -> CompactionSessionAuditInfo:
+        self["inputRecords"] = input_records
+        return self
+
+    def set_input_file_count(self, input_file_count: int) -> CompactionSessionAuditInfo:
+        self["inputFileCount"] = input_file_count
+        return self
+
+    def set_records_deduped(self, records_deduped: int) -> CompactionSessionAuditInfo:
+        self["recordsDeduped"] = records_deduped
+        return self
+
+    def set_input_size_bytes(
+        self, input_size_bytes: float
+    ) -> CompactionSessionAuditInfo:
+        self["inputSizeBytes"] = input_size_bytes
+        return self
+
+    def set_hash_bucket_count(
+        self, hash_bucket_count: int
+    ) -> CompactionSessionAuditInfo:
+        self["hashBucketCount"] = hash_bucket_count
+        return self
+
+    def set_cluster_cpu(self, cluster_cpu: float) -> CompactionSessionAuditInfo:
+        self["clusterCpu"] = cluster_cpu
+        return self
+
+    def set_compaction_time_in_seconds(
+        self, compaction_time_in_seconds: float
+    ) -> CompactionSessionAuditInfo:
+        self["compactionTimeInSeconds"] = compaction_time_in_seconds
+        return self
+
+    def set_total_object_store_memory_used_bytes(
+        self, total_object_store_memory_used_bytes: float
+    ) -> CompactionSessionAuditInfo:
+        self["totalObjectStoreMemoryUsedBytes"] = total_object_store_memory_used_bytes
+        return self
+
+    def set_peak_memory_used_bytes(
+        self, peak_memory_used_bytes: float
+    ) -> CompactionSessionAuditInfo:
+        self["peakMemoryUsedBytes"] = peak_memory_used_bytes
+        return self
+
+    def set_peak_memory_used_bytes_by_hash_bucketing(
+        self, peak_memory_used_bytes_by_hash_bucketing: float
+    ) -> CompactionSessionAuditInfo:
+        self[
+            "peakMemoryUsedBytesByHashBucketing"
+        ] = peak_memory_used_bytes_by_hash_bucketing
+        return self
+
+    def set_peak_memory_used_bytes_by_dedupe(
+        self, peak_memory_used_bytes_by_dedupe: float
+    ) -> CompactionSessionAuditInfo:
+        self["peakMemoryUsedBytesByDedupe"] = peak_memory_used_bytes_by_dedupe
+        return self
+
+    def set_peak_memory_used_bytes_by_materialize(
+        self, peak_memory_used_bytes_by_materialize: float
+    ) -> CompactionSessionAuditInfo:
+        self["peakMemoryUsedBytesByMaterialize"] = peak_memory_used_bytes_by_materialize
+        return self
+
+    def set_object_store_memory_used_bytes_by_hash_bucketing(
+        self, object_store_memory_used_bytes_by_hb: float
+    ) -> CompactionSessionAuditInfo:
+        self[
+            "objectStoreMemoryUsedBytesByHashBucketing"
+        ] = object_store_memory_used_bytes_by_hb
+        return self
+
+    def set_object_store_memory_used_bytes_by_dedupe(
+        self, object_store_memory_used_bytes_by_dedupe: float
+    ) -> CompactionSessionAuditInfo:
+        self[
+            "objectStoreMemoryUsedBytesByDedupe"
+        ] = object_store_memory_used_bytes_by_dedupe
+        return self
+
+    def set_materialize_buckets(
+        self, materialize_buckets: int
+    ) -> CompactionSessionAuditInfo:
+        self["materializeBuckets"] = materialize_buckets
+        return self
+
+    def set_hash_bucket_time_in_seconds(
+        self, hash_bucket_time_in_seconds: float
+    ) -> CompactionSessionAuditInfo:
+        self["hashBucketTimeInSeconds"] = hash_bucket_time_in_seconds
+        return self
+
+    def set_dedupe_time_in_seconds(
+        self, dedupe_time_in_seconds: float
+    ) -> CompactionSessionAuditInfo:
+        self["dedupeTimeInSeconds"] = dedupe_time_in_seconds
+        return self
+
+    def set_materialize_time_in_seconds(
+        self, materialize_time_in_seconds: float
+    ) -> CompactionSessionAuditInfo:
+        self["materializeTimeInSeconds"] = materialize_time_in_seconds
+        return self
+
+    def set_delta_discovery_time_in_seconds(
+        self, delta_discovery_time_in_seconds: float
+    ) -> CompactionSessionAuditInfo:
+        self["deltaDiscoveryTimeInSeconds"] = delta_discovery_time_in_seconds
+        return self
+
+    def set_output_file_count(
+        self, output_file_count: float
+    ) -> CompactionSessionAuditInfo:
+        self["outputFileCount"] = output_file_count
+        return self
+
+    def set_output_size_bytes(
+        self, output_size_bytes: float
+    ) -> CompactionSessionAuditInfo:
+        self["outputSizeBytes"] = output_size_bytes
+        return output_size_bytes
+
+    def set_output_size_pyarrow_bytes(
+        self, output_size_pyarrow_bytes: float
+    ) -> CompactionSessionAuditInfo:
+        self["outputSizePyarrowBytes"] = output_size_pyarrow_bytes
+        return output_size_pyarrow_bytes
+
+    def set_total_cluster_memory_bytes(
+        self, total_cluster_memory_bytes: float
+    ) -> CompactionSessionAuditInfo:
+        self["totalClusterMemoryBytes"] = total_cluster_memory_bytes
+        return self
+
+    def set_total_cluster_object_store_memory_bytes(
+        self, total_cluster_object_store_memory_bytes: float
+    ) -> CompactionSessionAuditInfo:
+        self[
+            "totalClusterObjectStoreMemoryBytes"
+        ] = total_cluster_object_store_memory_bytes
+        return self
+
+    def set_untouched_file_count(
+        self, untouched_file_count: int
+    ) -> CompactionSessionAuditInfo:
+        self["untouchedFileCount"] = untouched_file_count
+        return self
+
+    def set_untouched_file_ratio(
+        self, untouched_file_ratio: float
+    ) -> CompactionSessionAuditInfo:
+        self["untouchedFileRatio"] = untouched_file_ratio
+        return self
+
+    def set_untouched_record_count(
+        self, untouched_record_count: int
+    ) -> CompactionSessionAuditInfo:
+        self["untouchedRecordCount"] = untouched_record_count
+        return self
+
+    def set_untouched_size_bytes(
+        self, untouched_size_bytes: float
+    ) -> CompactionSessionAuditInfo:
+        self["untouchedSizeBytes"] = untouched_size_bytes
+        return self
+
+    def set_telemetry_time_in_seconds(
+        self, telemetry_time_in_seconds: float
+    ) -> CompactionSessionAuditInfo:
+        self["telemetryTimeInSeconds"] = telemetry_time_in_seconds
+        return self

--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -133,7 +133,7 @@ class CompactionSessionAuditInfo(dict):
         that results may be max of materialize, dedupe and hash bucketing as
         processes are reused by Ray to run all compaction steps.
         """
-        return self.get("materializeTaskpeakMemoryUsedBytes")
+        return self.get("materializeTaskPeakMemoryUsedBytes")
 
     @property
     def hash_bucket_post_object_store_memory_used_bytes(self) -> float:

--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -50,6 +50,13 @@ class CompactionSessionAuditInfo(dict):
         return self.get("inputFileCount")
 
     @property
+    def uniform_deltas_created(self) -> int:
+        """
+        The total number of unitform deltas fed into the hash bucket step.
+        """
+        return self.get("uniformDeltasCreated")
+
+    @property
     def records_deduped(self) -> int:
         """
         The total number of records that were deduplicated. For example,
@@ -327,6 +334,12 @@ class CompactionSessionAuditInfo(dict):
         self["inputFileCount"] = input_file_count
         return self
 
+    def set_uniform_deltas_created(
+        self, uniform_deltas_created: int
+    ) -> CompactionSessionAuditInfo:
+        self["uniformDeltasCreated"] = uniform_deltas_created
+        return self
+
     def set_records_deduped(self, records_deduped: int) -> CompactionSessionAuditInfo:
         self["recordsDeduped"] = records_deduped
         return self
@@ -554,12 +567,12 @@ class CompactionSessionAuditInfo(dict):
         Saves the stats by calling individual setters and returns the cluster telemetry time.
         """
 
-        last_hb_task_completed_at = max(
-            hb_result.task_completed_at for hb_result in task_results
+        last_task_completed_at = max(
+            result.task_completed_at for result in task_results
         )
 
         self[f"{step_name}ResultWaitTimeInSeconds"] = (
-            task_results_retrieved_at - last_hb_task_completed_at.item()
+            task_results_retrieved_at - last_task_completed_at.item()
         )
         self[f"{step_name}TimeInSeconds"] = task_time_in_seconds
         self[f"{step_name}InvokeTimeInSeconds"] = invoke_time_in_seconds
@@ -584,11 +597,11 @@ class CompactionSessionAuditInfo(dict):
         ] = cluster_utilization_after_task.used_object_store_memory_bytes
 
         peak_task_memory = max(
-            hb_result.peak_memory_usage_bytes for hb_result in task_results
+            result.peak_memory_usage_bytes for result in task_results
         )
 
         telemetry_time = sum(
-            hb_result.telemetry_time_in_seconds for hb_result in task_results
+            result.telemetry_time_in_seconds for result in task_results
         )
 
         self[f"{step_name}TaskPeakMemoryUsedBytes"] = peak_task_memory.item()

--- a/deltacat/compute/compactor/model/dedupe_result.py
+++ b/deltacat/compute/compactor/model/dedupe_result.py
@@ -8,3 +8,4 @@ class DedupeResult(NamedTuple):
     deduped_record_count: np.int64
     peak_memory_usage_bytes: np.double
     telemetry_time_in_seconds: np.double
+    task_completed_at: np.double

--- a/deltacat/compute/compactor/model/dedupe_result.py
+++ b/deltacat/compute/compactor/model/dedupe_result.py
@@ -6,3 +6,5 @@ import numpy as np
 class DedupeResult(NamedTuple):
     mat_bucket_idx_to_obj_id: Dict[int, Tuple]
     deduped_record_count: np.int64
+    peak_memory_usage_bytes: np.double
+    telemetry_time_in_seconds: np.double

--- a/deltacat/compute/compactor/model/hash_bucket_result.py
+++ b/deltacat/compute/compactor/model/hash_bucket_result.py
@@ -8,3 +8,4 @@ class HashBucketResult(NamedTuple):
     hb_record_count: np.int64
     peak_memory_usage_bytes: np.double
     telemetry_time_in_seconds: np.double
+    task_completed_at: np.double

--- a/deltacat/compute/compactor/model/hash_bucket_result.py
+++ b/deltacat/compute/compactor/model/hash_bucket_result.py
@@ -6,3 +6,5 @@ import numpy as np
 class HashBucketResult(NamedTuple):
     hash_bucket_group_to_obj_id: np.ndarray
     hb_record_count: np.int64
+    peak_memory_usage_bytes: np.double
+    telemetry_time_in_seconds: np.double

--- a/deltacat/compute/compactor/model/materialize_result.py
+++ b/deltacat/compute/compactor/model/materialize_result.py
@@ -14,7 +14,7 @@ class MaterializeResult(dict):
         delta: Delta,
         task_index: int,
         pyarrow_write_result: PyArrowWriteResult,
-        referenced_pyarrow_write_result: Optional[PyArrowWriteResult],
+        referenced_pyarrow_write_result: Optional[PyArrowWriteResult] = None,
         peak_memory_usage_bytes: Optional[np.double] = None,
         telemetry_time_in_seconds: Optional[np.double] = None,
         task_completed_at: Optional[np.double] = None,

--- a/deltacat/compute/compactor/model/materialize_result.py
+++ b/deltacat/compute/compactor/model/materialize_result.py
@@ -1,7 +1,7 @@
 # Allow classes to use self-referencing Type hints in Python 3.7.
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Optional
+from typing import Any, Dict, Optional
 import numpy as np
 
 from deltacat.compute.compactor.model.pyarrow_write_result import PyArrowWriteResult
@@ -12,23 +12,21 @@ class MaterializeResult(dict):
     @staticmethod
     def of(
         delta: Delta,
-
         task_index: int,
-
         pyarrow_write_result: PyArrowWriteResult,
-        count_of_src_dfl_not_touched: Optional[int] = 0,
-        count_of_src_dfl: Optional[int] = 0, ,
-        peak_memory_usage_bytes: np.double = None,
-        telemetry_time_in_seconds: np.double = None,
+        referenced_pyarrow_write_result: Optional[PyArrowWriteResult],
+        peak_memory_usage_bytes: Optional[np.double] = None,
+        telemetry_time_in_seconds: Optional[np.double] = None,
+        task_completed_at: Optional[np.double] = None,
     ) -> MaterializeResult:
         materialize_result = MaterializeResult()
         materialize_result["delta"] = delta
         materialize_result["taskIndex"] = task_index
         materialize_result["paWriteResult"] = pyarrow_write_result
-        materialize_result["countOfSrcFileNotTouched"] = count_of_src_dfl_not_touched
-        materialize_result["countOfSrcFile"] = count_of_src_dfl
+        materialize_result["referencedPaWriteResult"] = referenced_pyarrow_write_result
         materialize_result["peakMemoryUsageBytes"] = peak_memory_usage_bytes
         materialize_result["telemetryTimeInSeconds"] = telemetry_time_in_seconds
+        materialize_result["taskCompletedAt"] = task_completed_at
         return materialize_result
 
     @property
@@ -62,5 +60,13 @@ class MaterializeResult(dict):
         return self["countOfSrcFileNotTouched"]
 
     @property
-    def count_of_src_dfl(self) -> int:
-        return self["countOfSrcFile"]
+    def referenced_pyarrow_write_result(self) -> PyArrowWriteResult:
+        val: Dict[str, Any] = self.get("referencedPaWriteResult")
+        if val is not None and not isinstance(val, PyArrowWriteResult):
+            self["referencedPaWriteResult"] = val = PyArrowWriteResult(val)
+
+        return val
+
+    @property
+    def task_completed_at(self) -> Optional[np.double]:
+        return self["taskCompletedAt"]

--- a/deltacat/compute/compactor/model/materialize_result.py
+++ b/deltacat/compute/compactor/model/materialize_result.py
@@ -1,7 +1,8 @@
 # Allow classes to use self-referencing Type hints in Python 3.7.
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Optional
+import numpy as np
 
 from deltacat.compute.compactor.model.pyarrow_write_result import PyArrowWriteResult
 from deltacat.storage import Delta
@@ -11,10 +12,14 @@ class MaterializeResult(dict):
     @staticmethod
     def of(
         delta: Delta,
+
         task_index: int,
+
         pyarrow_write_result: PyArrowWriteResult,
         count_of_src_dfl_not_touched: Optional[int] = 0,
-        count_of_src_dfl: Optional[int] = 0,
+        count_of_src_dfl: Optional[int] = 0, ,
+        peak_memory_usage_bytes: np.double = None,
+        telemetry_time_in_seconds: np.double = None,
     ) -> MaterializeResult:
         materialize_result = MaterializeResult()
         materialize_result["delta"] = delta
@@ -22,6 +27,8 @@ class MaterializeResult(dict):
         materialize_result["paWriteResult"] = pyarrow_write_result
         materialize_result["countOfSrcFileNotTouched"] = count_of_src_dfl_not_touched
         materialize_result["countOfSrcFile"] = count_of_src_dfl
+        materialize_result["peakMemoryUsageBytes"] = peak_memory_usage_bytes
+        materialize_result["telemetryTimeInSeconds"] = telemetry_time_in_seconds
         return materialize_result
 
     @property
@@ -34,6 +41,14 @@ class MaterializeResult(dict):
     @property
     def task_index(self) -> int:
         return self["taskIndex"]
+
+    @property
+    def peak_memory_usage_bytes(self) -> Optional[np.double]:
+        return self["peakMemoryUsageBytes"]
+
+    @property
+    def telemetry_time_in_seconds(self) -> Optional[np.double]:
+        return self["telemetryTimeInSeconds"]
 
     @property
     def pyarrow_write_result(self) -> PyArrowWriteResult:

--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 from deltacat.storage import DeltaLocator, PartitionLocator
 from deltacat.compute.compactor.model.pyarrow_write_result import PyArrowWriteResult
+from deltacat.compute.compactor.model.compaction_session_audit_info import (
+    CompactionSessionAuditInfo,
+)
 from typing import Any, Dict, Optional
 
 
@@ -39,6 +42,7 @@ class RoundCompletionInfo(dict):
         sort_keys_bit_width: int,
         rebase_source_partition_locator: Optional[PartitionLocator],
         manifest_entry_copied_by_reference_ratio: Optional[float] = None,
+        compaction_audit: Optional[CompactionSessionAuditInfo] = None,
     ) -> RoundCompletionInfo:
 
         rci = RoundCompletionInfo()
@@ -50,6 +54,7 @@ class RoundCompletionInfo(dict):
         rci[
             "manifestEntryCopiedByReferenceRatio"
         ] = manifest_entry_copied_by_reference_ratio
+        rci["compactionAudit"] = compaction_audit
         return rci
 
     @property
@@ -80,6 +85,10 @@ class RoundCompletionInfo(dict):
     @property
     def sort_keys_bit_width(self) -> int:
         return self["sortKeysBitWidth"]
+
+    @property
+    def compaction_audit(self) -> Optional[CompactionSessionAuditInfo]:
+        return self.get("compactionAudit")
 
     @property
     def rebase_source_partition_locator(self) -> Optional[PartitionLocator]:

--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -42,7 +42,7 @@ class RoundCompletionInfo(dict):
         sort_keys_bit_width: int,
         rebase_source_partition_locator: Optional[PartitionLocator],
         manifest_entry_copied_by_reference_ratio: Optional[float] = None,
-        compaction_audit: Optional[CompactionSessionAuditInfo] = None,
+        compaction_audit_url: Optional[str] = None,
     ) -> RoundCompletionInfo:
 
         rci = RoundCompletionInfo()
@@ -54,7 +54,7 @@ class RoundCompletionInfo(dict):
         rci[
             "manifestEntryCopiedByReferenceRatio"
         ] = manifest_entry_copied_by_reference_ratio
-        rci["compactionAudit"] = compaction_audit
+        rci["compactionAuditUrl"] = compaction_audit_url
         return rci
 
     @property

--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import time
 from collections import defaultdict
 from contextlib import nullcontext
 from typing import Any, Dict, List, Tuple
@@ -238,6 +239,7 @@ def _timed_dedupe(
             np.int64(total_deduped_records),
             np.double(peak_memory_usage_bytes),
             np.double(0.0),
+            np.double(time.time()),
         )
 
 
@@ -276,4 +278,5 @@ def dedupe(
         dedupe_result[1],
         dedupe_result[2],
         np.double(emit_metrics_time),
+        dedupe_result[4],
     )

--- a/deltacat/compute/compactor/steps/hash_bucket.py
+++ b/deltacat/compute/compactor/steps/hash_bucket.py
@@ -30,6 +30,7 @@ from deltacat.utils.ray_utils.runtime import (
 from deltacat.utils.common import ReadKwargsProvider
 from deltacat.utils.performance import timed_invocation
 from deltacat.utils.metrics import emit_timer_metrics, MetricsConfig
+from deltacat.utils.resources import get_current_node_peak_memory_usage_in_bytes
 
 if importlib.util.find_spec("memray"):
     import memray
@@ -207,8 +208,13 @@ def _timed_hash_bucket(
             num_buckets,
             num_groups,
         )
+
+        peak_memory_usage_bytes = get_current_node_peak_memory_usage_in_bytes()
         return HashBucketResult(
-            hash_bucket_group_to_obj_id, np.int64(total_record_count)
+            hash_bucket_group_to_obj_id,
+            np.int64(total_record_count),
+            np.double(peak_memory_usage_bytes),
+            np.double(0.0),
         )
 
 
@@ -239,9 +245,21 @@ def hash_bucket(
         read_kwargs_provider=read_kwargs_provider,
         deltacat_storage=deltacat_storage,
     )
+
+    emit_metrics_time = 0.0
     if metrics_config:
-        emit_timer_metrics(
-            metrics_name="hash_bucket", value=duration, metrics_config=metrics_config
+        emit_result, latency = timed_invocation(
+            func=emit_timer_metrics,
+            metrics_name="hash_bucket",
+            value=duration,
+            metrics_config=metrics_config,
         )
+        emit_metrics_time = latency
+
     logger.info(f"Finished hash bucket task...")
-    return hash_bucket_result
+    return HashBucketResult(
+        hash_bucket_result[0],
+        hash_bucket_result[1],
+        hash_bucket_result[2],
+        np.double(emit_metrics_time),
+    )

--- a/deltacat/compute/compactor/steps/hash_bucket.py
+++ b/deltacat/compute/compactor/steps/hash_bucket.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import time
 from contextlib import nullcontext
 from itertools import chain
 from typing import Generator, List, Optional, Tuple
@@ -215,6 +216,7 @@ def _timed_hash_bucket(
             np.int64(total_record_count),
             np.double(peak_memory_usage_bytes),
             np.double(0.0),
+            np.double(time.time()),
         )
 
 
@@ -262,4 +264,5 @@ def hash_bucket(
         hash_bucket_result[1],
         hash_bucket_result[2],
         np.double(emit_metrics_time),
+        hash_bucket_result[4],
     )

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -310,7 +310,7 @@ def materialize(
         ), "The total number of files written by materialize must match manifest entries"
 
         logger.debug(
-            f"{len(write_result.files)} files written"
+            f"{write_result.files} files written"
             f" with records: {write_result.records}"
         )
 

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -301,13 +301,12 @@ def materialize(
             logger.info(
                 f"Got delta with {len(referenced_manifest_delta.manifest.entries)} referenced manifest entries"
             )
-            assert (
-                referenced_write_result.files
-                == referenced_manifest_delta.manifest.entries
+            assert referenced_write_result.files == len(
+                referenced_manifest_delta.manifest.entries
             ), "The files referenced must match with the entries in the delta"
 
-        assert (
-            write_result.files == merged_delta.manifest.entries
+        assert write_result.files == len(
+            merged_delta.manifest.entries
         ), "The total number of files written by materialize must match manifest entries"
 
         logger.debug(

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -276,7 +276,7 @@ def materialize(
 
         referenced_manifest_delta = (
             _stage_delta_from_manifest_entry_reference_list(
-                manifest_entry_list_reference
+                manifest_entry_list_reference, partition
             )
             if manifest_entry_list_reference
             else None

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -281,10 +281,6 @@ def materialize(
             if manifest_entry_list_reference
             else None
         )
-        if referenced_manifest_delta:
-            logger.info(
-                f"Got delta with {len(referenced_manifest_delta.manifest.entries)} referenced manifest entries"
-            )
 
         merged_materialized_delta = [mr.delta for mr in materialized_results]
         merged_materialized_delta.append(referenced_manifest_delta)
@@ -301,9 +297,14 @@ def materialize(
             referenced_pyarrow_write_results
         )
 
-        assert (
-            referenced_write_result.files == referenced_manifest_delta.manifest.entries
-        ), "The files referenced must match with the entries in the delta"
+        if referenced_manifest_delta:
+            logger.info(
+                f"Got delta with {len(referenced_manifest_delta.manifest.entries)} referenced manifest entries"
+            )
+            assert (
+                referenced_write_result.files
+                == referenced_manifest_delta.manifest.entries
+            ), "The files referenced must match with the entries in the delta"
 
         assert (
             write_result.files == merged_delta.manifest.entries

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -255,7 +255,7 @@ def materialize(
                 untouched_src_manifest_entry = manifest.entries[src_file_idx_np.item()]
                 manifest_entry_list_reference.append(untouched_src_manifest_entry)
                 referenced_pyarrow_write_result = PyArrowWriteResult.of(
-                    len(untouched_src_manifest_entry.entries),
+                    1,
                     TABLE_CLASS_TO_SIZE_FUNC[type(pa_table)](pa_table),
                     manifest.meta.content_length,
                     len(pa_table),

--- a/deltacat/compute/compactor/utils/round_completion_file.py
+++ b/deltacat/compute/compactor/utils/round_completion_file.py
@@ -42,6 +42,8 @@ def write_round_completion_file(
     round_completion_info: RoundCompletionInfo,
     completion_file_s3_url: str = None,
 ) -> str:
+    if bucket is None and completion_file_s3_url is None:
+        raise AssertionError("Either bucket or completion_file_s3_url must be passed")
 
     logger.info(f"writing round completion file contents: {round_completion_info}")
     if completion_file_s3_url is None:

--- a/deltacat/storage/model/delta.py
+++ b/deltacat/storage/model/delta.py
@@ -256,7 +256,8 @@ class Delta(dict):
 class DeltaLocator(Locator, dict):
     @staticmethod
     def of(
-        partition_locator: Optional[PartitionLocator], stream_position: Optional[int]
+        partition_locator: Optional[PartitionLocator] = None,
+        stream_position: Optional[int] = None,
     ) -> DeltaLocator:
         """
         Creates a partition delta locator. Stream Position, if provided, should

--- a/deltacat/tests/compactor/utils/test_io.py
+++ b/deltacat/tests/compactor/utils/test_io.py
@@ -1,18 +1,19 @@
 import unittest
 from unittest import mock
-from deltacat.compute.compactor.model.compaction_session_audit_info import (
-    CompactionSessionAuditInfo,
-)
 from deltacat.tests.test_utils.constants import TEST_DELTA
 
 
 class TestFitInputDeltas(unittest.TestCase):
-    COMPACTION_AUDIT = CompactionSessionAuditInfo("1.0", "test")
-
     @classmethod
     def setUpClass(cls):
         cls.module_patcher = mock.patch.dict("sys.modules", {"ray": mock.MagicMock()})
         cls.module_patcher.start()
+
+        from deltacat.compute.compactor.model.compaction_session_audit_info import (
+            CompactionSessionAuditInfo,
+        )
+
+        cls.COMPACTION_AUDIT = CompactionSessionAuditInfo("1.0", "test")
 
         super().setUpClass()
 

--- a/deltacat/tests/compactor/utils/test_io.py
+++ b/deltacat/tests/compactor/utils/test_io.py
@@ -7,7 +7,7 @@ from deltacat.tests.test_utils.constants import TEST_DELTA
 
 
 class TestFitInputDeltas(unittest.TestCase):
-    COMPACTION_AUDIT = CompactionSessionAuditInfo()
+    COMPACTION_AUDIT = CompactionSessionAuditInfo("1.0", "test")
 
     @classmethod
     def setUpClass(cls):

--- a/deltacat/tests/utils/test_resources.py
+++ b/deltacat/tests/utils/test_resources.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import mock
+import sys
 
 
 class TestGetCurrentClusterUtilization(unittest.TestCase):
@@ -19,6 +20,10 @@ class TestGetCurrentClusterUtilization(unittest.TestCase):
 
         cls.module_patcher = mock.patch.dict("sys.modules", {"ray": cls.ray_mock})
         cls.module_patcher.start()
+
+        # delete reference to reload from mocked ray
+        if "deltacat.utils.resources" in sys.modules:
+            del sys.modules["deltacat.utils.resources"]
 
         super().setUpClass()
 

--- a/deltacat/utils/ray_utils/concurrency.py
+++ b/deltacat/utils/ray_utils/concurrency.py
@@ -7,7 +7,6 @@ from ray._private.ray_constants import MIN_RESOURCE_GRANULARITY
 from ray.types import ObjectRef
 
 from deltacat.utils.ray_utils.runtime import current_node_resource_key
-from deltacat.utils.resources import log_current_cluster_utilization
 
 
 def invoke_parallel(
@@ -47,7 +46,6 @@ def invoke_parallel(
     Returns:
         List of Ray object references returned from the submitted tasks.
     """
-    log_current_cluster_utilization(log_identifier=ray_task.__name__)
     if max_parallelism is not None and max_parallelism <= 0:
         raise ValueError(f"Max parallelism ({max_parallelism}) must be > 0.")
     pending_ids = []

--- a/deltacat/utils/resources.py
+++ b/deltacat/utils/resources.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import ray
+import sys
 from typing import Dict, Any
 from dataclasses import dataclass
 from deltacat import logs
@@ -68,3 +69,16 @@ def get_current_node_peak_memory_usage_in_bytes():
         return usage
     else:
         return psutil.Process().memory_info().peak_wset
+
+
+def get_size_of_object_in_bytes(obj: object) -> float:
+    size = sys.getsizeof(obj)
+    if isinstance(obj, dict):
+        return (
+            size
+            + sum(map(get_size_of_object_in_bytes, obj.keys()))
+            + sum(map(get_size_of_object_in_bytes, obj.values()))
+        )
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        return size + sum(map(get_size_of_object_in_bytes, obj))
+    return size


### PR DESCRIPTION
[Description] It is important to capture audit automatically and analyze the datapoints from significant number of runs to recognize a pattern and come up with a formula to predict resource consumption. This would improve reliability and efficiency.

[Motivation] #141 

Example Audit Info:

```
"compactionAudit": {
    "deltacatVersion": "0.1.18b1",
    "clusterCpu": 3658,
    "deltaDiscoveryTimeInSeconds": 2.710052251815796,
    "inputFileCount": 31750,
    "inputSizeBytes": 5234658392405,
    "totalClusterMemoryBytes": 42087227851116,
    "hashBucketCount": 385,
    "hashBucketTimeInSeconds": 111.62457704544067,
    "totalClusterObjectStoreMemoryBytes": 23050000000000,
    "objectStoreMemoryUsedBytesByHashBucketing": 1719833215762,
    "inputRecords": 61183765994,
    "peakMemoryUsedBytesByHashBucketing": 1595277312,
    "dedupeTimeInSeconds": 351.89735102653503,
    "objectStoreMemoryUsedBytesByDedupe": 492114348197,
    "recordsDeduped": 0,
    "peakMemoryUsedBytesByDedupe": 40259301376,
    "materializeBuckets": 3658,
    "materializeTimeInSeconds": 297.6463842391968,
    "peakMemoryUsedBytesByMaterialize": 40259301376,
    "peakMemoryUsedBytes": 40259301376,
    "telemetryTimeInSeconds": 0.029021817000057126,
    "compactionTimeInSeconds": 768.3967623710632,
    "outputFileCount": 16766,
    "outputSizeBytes": 5003900801250,
    "outputSizePyarrowBytes": 16070617399347
  }
```