### PR TITLE
[skip download cold manifest] Add support for skipping download cold manifest entries during materialize step

### DIFF
--- a/deltacat/compute/compactor/model/delta_file_envelope.py
+++ b/deltacat/compute/compactor/model/delta_file_envelope.py
@@ -5,6 +5,8 @@ import numpy as np
 
 from deltacat.storage import DeltaType, LocalTable
 
+from typing import Optional
+
 DeltaFileEnvelopeGroups = np.ndarray
 
 
@@ -16,6 +18,7 @@ class DeltaFileEnvelope(dict):
         delta_type: DeltaType,
         table: LocalTable,
         is_src_delta: np.bool_ = True,
+        row_count: Optional[int] = None,
     ) -> DeltaFileEnvelope:
         """Static factory builder for a Delta File Envelope
         `
@@ -46,6 +49,7 @@ class DeltaFileEnvelope(dict):
         delta_file_envelope["deltaType"] = delta_type.value
         delta_file_envelope["table"] = table
         delta_file_envelope["is_src_delta"] = is_src_delta
+        delta_file_envelope["row_count"] = row_count
         return delta_file_envelope
 
     @property
@@ -67,3 +71,7 @@ class DeltaFileEnvelope(dict):
     @property
     def is_src_delta(self) -> np.bool_:
         return self["is_src_delta"]
+
+    @property
+    def row_count(self) -> int:
+        return self["row_count"]

--- a/deltacat/compute/compactor/model/delta_file_envelope.py
+++ b/deltacat/compute/compactor/model/delta_file_envelope.py
@@ -18,7 +18,7 @@ class DeltaFileEnvelope(dict):
         delta_type: DeltaType,
         table: LocalTable,
         is_src_delta: np.bool_ = True,
-        row_count: Optional[int] = None,
+        file_record_count: Optional[int] = None,
     ) -> DeltaFileEnvelope:
         """Static factory builder for a Delta File Envelope
         `
@@ -49,7 +49,7 @@ class DeltaFileEnvelope(dict):
         delta_file_envelope["deltaType"] = delta_type.value
         delta_file_envelope["table"] = table
         delta_file_envelope["is_src_delta"] = is_src_delta
-        delta_file_envelope["row_count"] = row_count
+        delta_file_envelope["file_record_count"] = file_record_count
         return delta_file_envelope
 
     @property
@@ -73,5 +73,5 @@ class DeltaFileEnvelope(dict):
         return self["is_src_delta"]
 
     @property
-    def row_count(self) -> int:
-        return self["row_count"]
+    def file_record_count(self) -> int:
+        return self["file_record_count"]

--- a/deltacat/compute/compactor/model/delta_file_locator.py
+++ b/deltacat/compute/compactor/model/delta_file_locator.py
@@ -5,11 +5,16 @@ import numpy as np
 
 from deltacat.storage import Locator
 
+from typing import Optional
+
 
 class DeltaFileLocator(Locator, tuple):
     @staticmethod
     def of(
-        is_src_delta: np.bool_, stream_position: np.int64, file_index: np.int32
+        is_src_delta: np.bool_,
+        stream_position: np.int64,
+        file_index: np.int32,
+        row_count: Optional[np.int64] = None,
     ) -> DeltaFileLocator:
         """
         Create a Delta File Locator tuple that can be used to uniquely identify
@@ -30,13 +35,7 @@ class DeltaFileLocator(Locator, tuple):
             delta_file_locator: The Delta File Locator Tuple as
             (is_source_delta, stream_position, file_index).
         """
-        return DeltaFileLocator(
-            (
-                is_src_delta,
-                stream_position,
-                file_index,
-            )
-        )
+        return DeltaFileLocator((is_src_delta, stream_position, file_index, row_count))
 
     @property
     def is_source_delta(self) -> np.bool_:
@@ -49,6 +48,10 @@ class DeltaFileLocator(Locator, tuple):
     @property
     def file_index(self) -> np.int32:
         return self[2]
+
+    @property
+    def row_count(self) -> np.int64:
+        return self[3]
 
     def canonical_string(self) -> str:
         """

--- a/deltacat/compute/compactor/model/delta_file_locator.py
+++ b/deltacat/compute/compactor/model/delta_file_locator.py
@@ -14,7 +14,7 @@ class DeltaFileLocator(Locator, tuple):
         is_src_delta: np.bool_,
         stream_position: np.int64,
         file_index: np.int32,
-        row_count: Optional[np.int64] = None,
+        file_record_count: Optional[np.int64] = None,
     ) -> DeltaFileLocator:
         """
         Create a Delta File Locator tuple that can be used to uniquely identify
@@ -35,7 +35,9 @@ class DeltaFileLocator(Locator, tuple):
             delta_file_locator: The Delta File Locator Tuple as
             (is_source_delta, stream_position, file_index).
         """
-        return DeltaFileLocator((is_src_delta, stream_position, file_index, row_count))
+        return DeltaFileLocator(
+            (is_src_delta, stream_position, file_index, file_record_count)
+        )
 
     @property
     def is_source_delta(self) -> np.bool_:
@@ -50,7 +52,7 @@ class DeltaFileLocator(Locator, tuple):
         return self[2]
 
     @property
-    def row_count(self) -> np.int64:
+    def file_record_count(self) -> np.int64:
         return self[3]
 
     def canonical_string(self) -> str:

--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -189,13 +189,13 @@ def _timed_dedupe(
             file_idx_col = sc.file_index_column_np(table)
             row_idx_col = sc.record_index_column_np(table)
             is_source_col = sc.is_source_column_np(table)
-            row_count_col = sc.row_count_column_np(table)
+            file_record_count_col = sc.file_record_count_column_np(table)
             for row_idx in range(len(table)):
                 src_dfl = DeltaFileLocator.of(
                     is_source_col[row_idx],
                     stream_position_col[row_idx],
                     file_idx_col[row_idx],
-                    row_count_col[row_idx],
+                    file_record_count_col[row_idx],
                 )
                 # TODO(pdames): merge contiguous record number ranges
                 src_file_id_to_row_indices[src_dfl].append(row_idx_col[row_idx])

--- a/deltacat/compute/compactor/steps/dedupe.py
+++ b/deltacat/compute/compactor/steps/dedupe.py
@@ -189,11 +189,13 @@ def _timed_dedupe(
             file_idx_col = sc.file_index_column_np(table)
             row_idx_col = sc.record_index_column_np(table)
             is_source_col = sc.is_source_column_np(table)
+            row_count_col = sc.row_count_column_np(table)
             for row_idx in range(len(table)):
                 src_dfl = DeltaFileLocator.of(
                     is_source_col[row_idx],
                     stream_position_col[row_idx],
                     file_idx_col[row_idx],
+                    row_count_col[row_idx],
                 )
                 # TODO(pdames): merge contiguous record number ranges
                 src_file_id_to_row_indices[src_dfl].append(row_idx_col[row_idx])

--- a/deltacat/compute/compactor/steps/hash_bucket.py
+++ b/deltacat/compute/compactor/steps/hash_bucket.py
@@ -116,11 +116,12 @@ def _group_file_records_by_pk_hash_bucket(
                     hb_to_delta_file_envelopes[hb] = []
                 hb_to_delta_file_envelopes[hb].append(
                     DeltaFileEnvelope.of(
-                        dfe.stream_position,
-                        dfe.file_index,
-                        dfe.delta_type,
-                        table,
-                        is_src_delta,
+                        stream_position=dfe.stream_position,
+                        file_index=dfe.file_index,
+                        delta_type=dfe.delta_type,
+                        table=table,
+                        is_src_delta=is_src_delta,
+                        row_count=dfe.row_count,
                     )
                 )
     return hb_to_delta_file_envelopes, total_record_count
@@ -159,10 +160,11 @@ def _read_delta_file_envelopes(
     for i, table in enumerate(tables):
         total_record_count += len(table)
         delta_file = DeltaFileEnvelope.of(
-            annotations[i].annotation_stream_position,
-            annotations[i].annotation_file_index,
-            annotations[i].annotation_delta_type,
-            table,
+            stream_position=annotations[i].annotation_stream_position,
+            file_index=annotations[i].annotation_file_index,
+            delta_type=annotations[i].annotation_delta_type,
+            table=table,
+            row_count=len(table),
         )
         delta_file_envelopes.append(delta_file)
     return delta_file_envelopes, total_record_count

--- a/deltacat/compute/compactor/steps/hash_bucket.py
+++ b/deltacat/compute/compactor/steps/hash_bucket.py
@@ -121,7 +121,7 @@ def _group_file_records_by_pk_hash_bucket(
                         delta_type=dfe.delta_type,
                         table=table,
                         is_src_delta=is_src_delta,
-                        row_count=dfe.row_count,
+                        file_record_count=dfe.file_record_count,
                     )
                 )
     return hb_to_delta_file_envelopes, total_record_count
@@ -164,7 +164,7 @@ def _read_delta_file_envelopes(
             file_index=annotations[i].annotation_file_index,
             delta_type=annotations[i].annotation_delta_type,
             table=table,
-            row_count=len(table),
+            file_record_count=len(table),
         )
         delta_file_envelopes.append(delta_file)
     return delta_file_envelopes, total_record_count

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -196,14 +196,13 @@ def materialize(
             is_src_partition_file_np = src_dfl.is_source_delta
             src_stream_position_np = src_dfl.stream_position
             src_file_idx_np = src_dfl.file_index
-            src_file_row_count = src_dfl.row_count.item()
+            src_file_record_count = src_dfl.file_record_count.item()
             count_of_src_dfl += 1
             src_file_partition_locator = (
                 source_partition_locator
                 if is_src_partition_file_np
                 else round_completion_info.compacted_delta_locator.partition_locator
             )
-
             delta_locator = DeltaLocator.of(
                 src_file_partition_locator,
                 src_stream_position_np.item(),
@@ -227,19 +226,19 @@ def materialize(
                     )
             record_numbers = chain.from_iterable(record_numbers_tpl)
             record_numbers_length = 0
-            mask_pylist = list(repeat(False, src_file_row_count))
+            mask_pylist = list(repeat(False, src_file_record_count))
             for record_number in record_numbers:
                 record_numbers_length += 1
                 mask_pylist[record_number] = True
             if (
-                record_numbers_length == src_file_row_count
+                record_numbers_length == src_file_record_count
                 and src_file_partition_locator
                 == round_completion_info.compacted_delta_locator.partition_locator
             ):
                 logger.debug(
                     f"Untouched manifest file found, "
                     f"record numbers length: {record_numbers_length} "
-                    f"same as downloaded table length: {src_file_row_count}"
+                    f"same as downloaded table length: {src_file_record_count}"
                 )
                 untouched_src_manifest_entry = manifest.entries[src_file_idx_np.item()]
                 manifest_entry_list_reference.append(untouched_src_manifest_entry)
@@ -247,7 +246,7 @@ def materialize(
                     1,
                     manifest.meta.source_content_length,
                     manifest.meta.content_length,
-                    src_file_row_count,
+                    src_file_record_count,
                 )
                 referenced_pyarrow_write_results.append(referenced_pyarrow_write_result)
             else:

--- a/deltacat/compute/compactor/steps/materialize.py
+++ b/deltacat/compute/compactor/steps/materialize.py
@@ -99,7 +99,6 @@ def materialize(
         delta = _stage_delta_implementation(
             data=manifest,
             partition=partition,
-            delta_type=delta_type,
             stage_delta_from_existing_manifest=True,
         )
         return delta
@@ -197,6 +196,7 @@ def materialize(
             is_src_partition_file_np = src_dfl.is_source_delta
             src_stream_position_np = src_dfl.stream_position
             src_file_idx_np = src_dfl.file_index
+            src_file_row_count = src_dfl.row_count.item()
             count_of_src_dfl += 1
             src_file_partition_locator = (
                 source_partition_locator
@@ -225,43 +225,43 @@ def materialize(
                     read_kwargs_provider = ReadKwargsProviderPyArrowSchemaOverride(
                         schema=schema
                     )
-            pa_table, download_delta_manifest_entry_time = timed_invocation(
-                deltacat_storage.download_delta_manifest_entry,
-                Delta.of(delta_locator, None, None, None, manifest),
-                src_file_idx_np.item(),
-                file_reader_kwargs_provider=read_kwargs_provider,
-            )
-            logger.debug(
-                f"Time taken for materialize task"
-                f" to download delta locator {delta_locator} with entry ID {src_file_idx_np.item()}"
-                f" is: {download_delta_manifest_entry_time}s"
-            )
             record_numbers = chain.from_iterable(record_numbers_tpl)
             record_numbers_length = 0
-            mask_pylist = list(repeat(False, len(pa_table)))
+            mask_pylist = list(repeat(False, src_file_row_count))
             for record_number in record_numbers:
                 record_numbers_length += 1
                 mask_pylist[record_number] = True
             if (
-                record_numbers_length == len(pa_table)
+                record_numbers_length == src_file_row_count
                 and src_file_partition_locator
                 == round_completion_info.compacted_delta_locator.partition_locator
             ):
                 logger.debug(
                     f"Untouched manifest file found, "
                     f"record numbers length: {record_numbers_length} "
-                    f"same as downloaded table length: {len(pa_table)}"
+                    f"same as downloaded table length: {src_file_row_count}"
                 )
                 untouched_src_manifest_entry = manifest.entries[src_file_idx_np.item()]
                 manifest_entry_list_reference.append(untouched_src_manifest_entry)
                 referenced_pyarrow_write_result = PyArrowWriteResult.of(
                     1,
-                    TABLE_CLASS_TO_SIZE_FUNC[type(pa_table)](pa_table),
+                    manifest.meta.source_content_length,
                     manifest.meta.content_length,
-                    len(pa_table),
+                    src_file_row_count,
                 )
                 referenced_pyarrow_write_results.append(referenced_pyarrow_write_result)
             else:
+                pa_table, download_delta_manifest_entry_time = timed_invocation(
+                    deltacat_storage.download_delta_manifest_entry,
+                    Delta.of(delta_locator, None, None, None, manifest),
+                    src_file_idx_np.item(),
+                    file_reader_kwargs_provider=read_kwargs_provider,
+                )
+                logger.debug(
+                    f"Time taken for materialize task"
+                    f" to download delta locator {delta_locator} with entry ID {src_file_idx_np.item()}"
+                    f" is: {download_delta_manifest_entry_time}s"
+                )
                 mask = pa.array(mask_pylist)
                 pa_table = pa_table.filter(mask)
                 record_batch_tables.append(pa_table)

--- a/deltacat/compute/compactor/utils/system_columns.py
+++ b/deltacat/compute/compactor/utils/system_columns.py
@@ -64,11 +64,11 @@ _IS_SOURCE_COLUMN_FIELD = pa.field(
     _IS_SOURCE_COLUMN_TYPE,
 )
 
-_ROW_COUNT_COLUMN_NAME = _get_sys_col_name("row_count")
-_ROW_COUNT_COLUMN_TYPE = pa.int64()
-_ROW_COUNT_COLUMN_FIELD = pa.field(
-    _ROW_COUNT_COLUMN_NAME,
-    _ROW_COUNT_COLUMN_TYPE,
+_FILE_RECORD_COUNT_COLUMN_NAME = _get_sys_col_name("file_record_count")
+_FILE_RECORD_COUNT_COLUMN_TYPE = pa.int64()
+_FILE_RECORD_COUNT_COLUMN_FIELD = pa.field(
+    _FILE_RECORD_COUNT_COLUMN_NAME,
+    _FILE_RECORD_COUNT_COLUMN_TYPE,
 )
 
 
@@ -150,14 +150,14 @@ def get_is_source_column_array(obj) -> Union[pa.Array, pa.ChunkedArray]:
     )
 
 
-def row_count_column_np(table: pa.Table) -> np.ndarray:
-    return table[_ROW_COUNT_COLUMN_NAME].to_numpy()
+def file_record_count_column_np(table: pa.Table) -> np.ndarray:
+    return table[_FILE_RECORD_COUNT_COLUMN_NAME].to_numpy()
 
 
-def get_row_count_column_array(obj) -> Union[pa.Array, pa.ChunkedArray]:
+def get_file_record_count_column_array(obj) -> Union[pa.Array, pa.ChunkedArray]:
     return pa.array(
         obj,
-        _ROW_COUNT_COLUMN_TYPE,
+        _FILE_RECORD_COUNT_COLUMN_TYPE,
     )
 
 
@@ -199,8 +199,10 @@ def project_delta_file_metadata_on_table(
     table = append_is_source_col(table, is_source_iterator)
 
     # append row count column
-    row_count_iterator = repeat(delta_file_envelope.row_count, len(table))
-    table = append_row_count_col(table, row_count_iterator)
+    file_record_count_iterator = repeat(
+        delta_file_envelope.file_record_count, len(table)
+    )
+    table = append_file_record_count_col(table, file_record_count_iterator)
     return table
 
 
@@ -274,9 +276,10 @@ def append_is_source_col(table: pa.Table, booleans) -> pa.Table:
     return table
 
 
-def append_row_count_col(table: pa.Table, row_count):
+def append_file_record_count_col(table: pa.Table, file_record_count):
     table = table.append_column(
-        _ROW_COUNT_COLUMN_FIELD, get_row_count_column_array(row_count)
+        _FILE_RECORD_COUNT_COLUMN_FIELD,
+        get_file_record_count_column_array(file_record_count),
     )
     return table
 


### PR DESCRIPTION
This PR adds support for skipping download cold manifest entries during materialize step.
To achieve this, we add row count of downloaded manifest entries from hash bucket step and carry over to materialize step. Before actually downloading manifest entries in materialize, we check if the row count equals to dedupped row count first. When row count matches, we simply copy the manifest entry by reference.