### PR TITLE
Allow s3_client_kwargs to be passed into repartition

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -43,7 +43,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.1.18b9"
+__version__ = "0.1.18b10"
 
 
 __all__ = [

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -115,7 +115,7 @@ def compact_partition(
     read_kwargs_provider: Optional[ReadKwargsProvider] = None,
     s3_table_writer_kwargs: Optional[Dict[str, Any]] = None,
     object_store: Optional[IObjectStore] = RayPlasmaObjectStore(),
-    s3_client_kwargs: Optional[Dict[str, Any]] = {},
+    s3_client_kwargs: Optional[Dict[str, Any]] = None,
     deltacat_storage=unimplemented_deltacat_storage,
     **kwargs,
 ) -> Optional[str]:
@@ -283,6 +283,9 @@ def _execute_compaction_round(
     # "safe" number of parallel tasks that our autoscaling cluster could handle
     max_parallelism = int(cluster_cpus)
     logger.info(f"Max parallelism: {max_parallelism}")
+
+    if s3_client_kwargs is None:
+        s3_client_kwargs = {}
 
     # read the results from any previously completed compaction round
     round_completion_info = None

--- a/deltacat/compute/compactor/repartition_session.py
+++ b/deltacat/compute/compactor/repartition_session.py
@@ -53,6 +53,7 @@ def repartition(
     pg_config: Optional[PlacementGroupConfig] = None,
     list_deltas_kwargs: Optional[Dict[str, Any]] = None,
     read_kwargs_provider: Optional[ReadKwargsProvider] = None,
+    s3_client_kwargs: Optional[Dict[str, Any]] = None,
     deltacat_storage=unimplemented_deltacat_storage,
     **kwargs,
 ) -> Optional[str]:
@@ -166,9 +167,13 @@ def repartition(
         bit_width_of_sort_keys,
         None,
     )
+    if s3_client_kwargs is None:
+        s3_client_kwargs = {}
+
     return rcf.write_round_completion_file(
         None,
         None,
         repartition_completion_info,
         repartition_completion_file_s3_url,
+        **s3_client_kwargs,
     )


### PR DESCRIPTION
Allows S3 keyword arguments to be passed into repartition session for use cases such as AWS credential overrides.