### PR TITLE
Move s3_client_kwargs default setter to parent scope

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -43,7 +43,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.1.18b10"
+__version__ = "0.1.18b11"
 
 
 __all__ = [

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -124,6 +124,9 @@ def compact_partition(
         logger.info(f"memray profiler not available, disabling all profiling")
         enable_profiler = False
 
+    if s3_client_kwargs is None:
+        s3_client_kwargs = {}
+
     # memray official documentation link:
     # https://bloomberg.github.io/memray/getting_started.html
     with memray.Tracker(
@@ -283,9 +286,6 @@ def _execute_compaction_round(
     # "safe" number of parallel tasks that our autoscaling cluster could handle
     max_parallelism = int(cluster_cpus)
     logger.info(f"Max parallelism: {max_parallelism}")
-
-    if s3_client_kwargs is None:
-        s3_client_kwargs = {}
 
     # read the results from any previously completed compaction round
     round_completion_info = None


### PR DESCRIPTION
Setting default value in parent scope to avoid unpacking None type values.