### PR TITLE
Add pytest benchmarking for Parquet reads

### DIFF
--- a/benchmark-requirements.txt
+++ b/benchmark-requirements.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+-r dev-requirements.txt
+
+getdaft==0.1.10
+pytest-benchmark == 4.0.0

--- a/deltacat/benchmarking/README.md
+++ b/deltacat/benchmarking/README.md
@@ -2,8 +2,8 @@
 
 ## Setup
 
-1. Install DeltaCat's `requirements.txt` and `dev-requirements.txt`
-2. Install the appropriate versions of additional packages that are being benchmarked (e.g. `pip install getdaft`)
+1. Install DeltaCat's `benchmark-requirements.txt`
+2. Ensure the appropriate versions of additional packages that are being benchmarked are installed (e.g. `pip install getdaft==X.X.XX`)
 
 ## Adding Benchmarks
 

--- a/deltacat/benchmarking/README.md
+++ b/deltacat/benchmarking/README.md
@@ -1,0 +1,18 @@
+# Benchmarking
+
+## Setup
+
+1. Install DeltaCat's `requirements.txt` and `dev-requirements.txt`
+2. Install the appropriate versions of additional packages that are being benchmarked (e.g. `pip install getdaft`)
+
+## Running Benchmarks
+
+### Parquet Reads
+
+We recommend running these benchmarks in a production AWS environment with the appropriate setup for high bandwidth access to AWS S3.
+
+```bash
+pytest deltacat/benchmarking/benchmark_parquet_reads.py --benchmark-only --benchmark-group-by=group,param:path
+```
+
+Grab a coffee, it will be a few minutes!

--- a/deltacat/benchmarking/README.md
+++ b/deltacat/benchmarking/README.md
@@ -12,7 +12,7 @@
 We recommend running these benchmarks in a production AWS environment with the appropriate setup for high bandwidth access to AWS S3.
 
 ```bash
-pytest deltacat/benchmarking/benchmark_parquet_reads.py --benchmark-only --benchmark-group-by=group,param:path
+pytest deltacat/benchmarking/benchmark_parquet_reads.py --benchmark-only --benchmark-group-by=group,param:name
 ```
 
 Grab a coffee, it will be a few minutes!

--- a/deltacat/benchmarking/README.md
+++ b/deltacat/benchmarking/README.md
@@ -5,6 +5,13 @@
 1. Install DeltaCat's `requirements.txt` and `dev-requirements.txt`
 2. Install the appropriate versions of additional packages that are being benchmarked (e.g. `pip install getdaft`)
 
+## Adding Benchmarks
+
+### Parquet Reads
+
+Modify the `SINGLE_COLUMN_BENCHMARKS` and `ALL_COLUMN_BENCHMARKS` fixtures in `deltacat/benchmarking/benchmark_parquet_reads.py`
+to add more files and benchmark test cases.
+
 ## Running Benchmarks
 
 ### Parquet Reads

--- a/deltacat/benchmarking/README.md
+++ b/deltacat/benchmarking/README.md
@@ -9,7 +9,7 @@
 
 ### Parquet Reads
 
-We recommend running these benchmarks in a production AWS environment with the appropriate setup for high bandwidth access to AWS S3.
+We recommend running these benchmarks in an AWS environment configured for high bandwidth access to AWS S3. For example, on an EC2 instance with enhanced networking support: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html.
 
 ```bash
 pytest deltacat/benchmarking/benchmark_parquet_reads.py --benchmark-only --benchmark-group-by=group,param:name

--- a/deltacat/benchmarking/benchmark_parquet_reads.py
+++ b/deltacat/benchmarking/benchmark_parquet_reads.py
@@ -2,29 +2,37 @@ from __future__ import annotations
 
 import pytest
 
-# Data to benchmark against:
-# {`benchmark_name`: (`s3_path`, `column_to_read`), ...}
-BENCHMARK_DATA = {
+
+# Benchmarks for retrieving a single column in the Parquet file
+SINGLE_COLUMN_BENCHMARKS = {
     "mvp": ("s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet", ["a"]),
-    "TPCH-lineitems-200MB-1RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", ["L_ORDERKEY"]),
+    # "TPCH-lineitems-200MB-1RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", ["L_ORDERKEY"]),
 }
 
+# Benchmarks for retrieving all columns in the Parquet file
+ALL_COLUMN_BENCHMARKS = {
+    "mvp": ("s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet", None),
+    # "TPCH-lineitems-200MB-1RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", None),
+}
 
 @pytest.mark.benchmark(group="num_rowgroups_single_column")
 @pytest.mark.parametrize(
-    ["path", "columns"],
-    [(path, columns) for _, (path, columns) in BENCHMARK_DATA.items()],
-    ids=[name for name, _ in BENCHMARK_DATA.items()],
+    ["name", "path", "columns"],
+    [(name, path, columns) for name, (path, columns) in SINGLE_COLUMN_BENCHMARKS.items()],
+    ids=[name for name in SINGLE_COLUMN_BENCHMARKS],
 )
-def test_read_parquet_num_rowgroups_single_column(path, columns, read_fn, benchmark):
+def test_read_parquet_num_rowgroups_single_column(name, path, columns, read_fn, benchmark):
     data = benchmark(read_fn, path, columns=columns)
-
+    if columns is not None:
+        assert data.column_names == columns
 
 @pytest.mark.benchmark(group="num_rowgroups_all_columns")
 @pytest.mark.parametrize(
-    "path",
-    [path for _, (path, _) in BENCHMARK_DATA.items()],
-    ids=[name for name, _ in BENCHMARK_DATA.items()],
+    ["name", "path", "columns"],
+    [(name, path, columns) for name, (path, columns) in ALL_COLUMN_BENCHMARKS.items()],
+    ids=[name for name in ALL_COLUMN_BENCHMARKS],
 )
-def test_read_parquet_num_rowgroups_all_columns(path, read_fn, benchmark):
-    data = benchmark(read_fn, path)
+def test_read_parquet_num_rowgroups_all_columns(name, path, columns, read_fn, benchmark):
+    data = benchmark(read_fn, path, columns=columns)
+    if columns is not None:
+        assert data.column_names == columns

--- a/deltacat/benchmarking/benchmark_parquet_reads.py
+++ b/deltacat/benchmarking/benchmark_parquet_reads.py
@@ -6,13 +6,13 @@ import pytest
 # Benchmarks for retrieving a single column in the Parquet file
 SINGLE_COLUMN_BENCHMARKS = {
     "mvp": ("s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet", ["a"]),
-    "TPCH-lineitems-200MB-1RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", ["L_ORDERKEY"]),
+    "TPCH-lineitems-200MB-2RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", ["L_ORDERKEY"]),
 }
 
 # Benchmarks for retrieving all columns in the Parquet file
 ALL_COLUMN_BENCHMARKS = {
     "mvp": ("s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet", None),
-    "TPCH-lineitems-200MB-1RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", None),
+    "TPCH-lineitems-200MB-2RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", None),
 }
 
 @pytest.mark.benchmark(group="num_rowgroups_single_column")

--- a/deltacat/benchmarking/benchmark_parquet_reads.py
+++ b/deltacat/benchmarking/benchmark_parquet_reads.py
@@ -6,25 +6,38 @@ import pytest
 # Benchmarks for retrieving a single column in the Parquet file
 SINGLE_COLUMN_BENCHMARKS = {
     "mvp": ("s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet", ["a"]),
-    "TPCH-lineitems-200MB-2RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", ["L_ORDERKEY"]),
+    "TPCH-lineitems-200MB-2RG": (
+        "s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet",
+        ["L_ORDERKEY"],
+    ),
 }
 
 # Benchmarks for retrieving all columns in the Parquet file
 ALL_COLUMN_BENCHMARKS = {
     "mvp": ("s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet", None),
-    "TPCH-lineitems-200MB-2RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", None),
+    "TPCH-lineitems-200MB-2RG": (
+        "s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet",
+        None,
+    ),
 }
+
 
 @pytest.mark.benchmark(group="num_rowgroups_single_column")
 @pytest.mark.parametrize(
     ["name", "path", "columns"],
-    [(name, path, columns) for name, (path, columns) in SINGLE_COLUMN_BENCHMARKS.items()],
+    [
+        (name, path, columns)
+        for name, (path, columns) in SINGLE_COLUMN_BENCHMARKS.items()
+    ],
     ids=[name for name in SINGLE_COLUMN_BENCHMARKS],
 )
-def test_read_parquet_num_rowgroups_single_column(name, path, columns, read_fn, benchmark):
+def test_read_parquet_num_rowgroups_single_column(
+    name, path, columns, read_fn, benchmark
+):
     data = benchmark(read_fn, path, columns=columns)
     if columns is not None:
         assert data.column_names == columns
+
 
 @pytest.mark.benchmark(group="num_rowgroups_all_columns")
 @pytest.mark.parametrize(
@@ -32,7 +45,9 @@ def test_read_parquet_num_rowgroups_single_column(name, path, columns, read_fn, 
     [(name, path, columns) for name, (path, columns) in ALL_COLUMN_BENCHMARKS.items()],
     ids=[name for name in ALL_COLUMN_BENCHMARKS],
 )
-def test_read_parquet_num_rowgroups_all_columns(name, path, columns, read_fn, benchmark):
+def test_read_parquet_num_rowgroups_all_columns(
+    name, path, columns, read_fn, benchmark
+):
     data = benchmark(read_fn, path, columns=columns)
     if columns is not None:
         assert data.column_names == columns

--- a/deltacat/benchmarking/benchmark_parquet_reads.py
+++ b/deltacat/benchmarking/benchmark_parquet_reads.py
@@ -6,13 +6,13 @@ import pytest
 # Benchmarks for retrieving a single column in the Parquet file
 SINGLE_COLUMN_BENCHMARKS = {
     "mvp": ("s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet", ["a"]),
-    # "TPCH-lineitems-200MB-1RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", ["L_ORDERKEY"]),
+    "TPCH-lineitems-200MB-1RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", ["L_ORDERKEY"]),
 }
 
 # Benchmarks for retrieving all columns in the Parquet file
 ALL_COLUMN_BENCHMARKS = {
     "mvp": ("s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet", None),
-    # "TPCH-lineitems-200MB-1RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", None),
+    "TPCH-lineitems-200MB-1RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", None),
 }
 
 @pytest.mark.benchmark(group="num_rowgroups_single_column")

--- a/deltacat/benchmarking/benchmark_parquet_reads.py
+++ b/deltacat/benchmarking/benchmark_parquet_reads.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+# Data to benchmark against:
+# {`benchmark_name`: (`s3_path`, `column_to_read`), ...}
+BENCHMARK_DATA = {
+    "mvp": ("s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet", ["a"]),
+    "TPCH-lineitems-200MB-1RG": ("s3://daft-public-data/test_fixtures/parquet-dev/daft_200MB_lineitem_chunk.RG-2.parquet", ["L_ORDERKEY"]),
+}
+
+
+@pytest.mark.benchmark(group="num_rowgroups_single_column")
+@pytest.mark.parametrize(
+    ["path", "columns"],
+    [(path, columns) for _, (path, columns) in BENCHMARK_DATA.items()],
+    ids=[name for name, _ in BENCHMARK_DATA.items()],
+)
+def test_read_parquet_num_rowgroups_single_column(path, columns, read_fn, benchmark):
+    data = benchmark(read_fn, path, columns=columns)
+
+
+@pytest.mark.benchmark(group="num_rowgroups_all_columns")
+@pytest.mark.parametrize(
+    "path",
+    [path for _, (path, _) in BENCHMARK_DATA.items()],
+    ids=[name for name, _ in BENCHMARK_DATA.items()],
+)
+def test_read_parquet_num_rowgroups_all_columns(path, read_fn, benchmark):
+    data = benchmark(read_fn, path)

--- a/deltacat/benchmarking/conftest.py
+++ b/deltacat/benchmarking/conftest.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import io
+
+import boto3
+import pyarrow as pa
+import pyarrow.fs as pafs
+import pyarrow.parquet as papq
+import pytest
+
+from deltacat.utils.pyarrow import s3_file_to_table
+from deltacat.types.media import (
+    ContentEncoding,
+    ContentType,
+)
+
+
+def pyarrow_read(path: str, columns: list[str] | None = None) -> pa.Table:
+    assert path.startswith("s3://")
+    fs = pafs.S3FileSystem()
+    path = path.replace("s3://", "")
+    return papq.read_table(path, columns=columns, filesystem=fs)
+
+
+def deltacat_read(path: str, columns: list[str] | None = None) -> pa.Table:
+    assert path.startswith("s3://")
+    return s3_file_to_table(
+        path,
+        content_type=ContentType.PARQUET,
+        content_encoding=ContentEncoding.IDENTITY,
+        column_names=None,  # Parquet files are schemaful
+        include_columns=columns,
+    )
+
+
+def daft_table_read(path: str, columns: list[str] | None = None) -> pa.Table:
+    try:
+        import daft
+    except ImportError:
+        raise ImportError("Daft not installed. Install Daft using pip to run these benchmarks: `pip install getdaft`")
+
+    tbl = daft.table.Table.read_parquet(path, columns=columns)
+    return tbl.to_arrow()
+
+
+@pytest.fixture(
+    params=[
+        daft_table_read,
+        pyarrow_read,
+        deltacat_read,
+    ],
+    ids=[
+        "daft_table",
+        "pyarrow",
+        "deltacat",
+    ],
+)
+def read_fn(request):
+    """Fixture which returns the function to read a PyArrow table from a path"""
+    return request.param

--- a/deltacat/benchmarking/conftest.py
+++ b/deltacat/benchmarking/conftest.py
@@ -16,7 +16,7 @@ from deltacat.types.media import (
 
 
 def pyarrow_read(path: str, columns: list[str] | None = None) -> pa.Table:
-    assert path.startswith("s3://")
+    assert path.startswith("s3://"), f"Expected file path to start with 's3://', but got {path}."
     fs = pafs.S3FileSystem()
     path = path.replace("s3://", "")
     return papq.read_table(path, columns=columns, filesystem=fs)

--- a/deltacat/benchmarking/conftest.py
+++ b/deltacat/benchmarking/conftest.py
@@ -13,7 +13,9 @@ from deltacat.types.media import (
 
 
 def pyarrow_read(path: str, columns: list[str] | None = None) -> pa.Table:
-    assert path.startswith("s3://"), f"Expected file path to start with 's3://', but got {path}."
+    assert path.startswith(
+        "s3://"
+    ), f"Expected file path to start with 's3://', but got {path}."
     fs = pafs.S3FileSystem()
     path = path.replace("s3://", "")
     return papq.read_table(path, columns=columns, filesystem=fs)
@@ -34,7 +36,9 @@ def daft_table_read(path: str, columns: list[str] | None = None) -> pa.Table:
     try:
         import daft
     except ImportError:
-        raise ImportError("Daft not installed. Install Daft using pip to run these benchmarks: `pip install getdaft`")
+        raise ImportError(
+            "Daft not installed. Install Daft using pip to run these benchmarks: `pip install getdaft`"
+        )
 
     tbl = daft.table.Table.read_parquet(path, columns=columns)
     return tbl.to_arrow()

--- a/deltacat/benchmarking/conftest.py
+++ b/deltacat/benchmarking/conftest.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import io
-
-import boto3
 import pyarrow as pa
 import pyarrow.fs as pafs
 import pyarrow.parquet as papq

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,5 @@ isort == 5.10.1
 memray == 1.6.0; platform_system != "Windows" and sys_platform != "darwin" and platform_machine != "arm64" and platform_machine != "aarch64"
 pre-commit == 2.20.0
 pytest == 7.2.0
-pytest-cov == 4.0.0
 pytest-benchmark == 4.0.0
+pytest-cov == 4.0.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,4 @@ isort == 5.10.1
 memray == 1.6.0; platform_system != "Windows" and sys_platform != "darwin" and platform_machine != "arm64" and platform_machine != "aarch64"
 pre-commit == 2.20.0
 pytest == 7.2.0
-pytest-benchmark == 4.0.0
 pytest-cov == 4.0.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ memray == 1.6.0; platform_system != "Windows" and sys_platform != "darwin" and p
 pre-commit == 2.20.0
 pytest == 7.2.0
 pytest-cov == 4.0.0
+pytest-benchmark == 4.0.0


### PR DESCRIPTION
# Summary

This PR adds in `pytest-benchmark` harnesses for benchmarking DeltaCat's Parquet reads across different possible solutions.

The various axes being benchmarked in this PR:

1. `read_fn` is the function used to read the Parquet file (DeltaCat vs PyArrow vs Daft Table)
2. We use publicly-available Parquet files hosted in AWS S3, where different files have different data distributions/profiles
3. We also benchmark single-column-reads vs all-column-reads

## Running Benchmarks

```
pytest deltacat/benchmarking/benchmark_parquet_reads.py --benchmark-only --benchmark-group-by=group,param:name
```

The above will output a benchmarking report, comparing the performance of various functions which perform a Parquet file read into an Arrow table.