### PR TITLE
keep null row and remove dw_int64 column

### DIFF
--- a/deltacat/compute/compactor/steps/repartition.py
+++ b/deltacat/compute/compactor/steps/repartition.py
@@ -126,9 +126,12 @@ def repartition_range(
     partition_deltas: List[Delta] = []
     for partition_tables in partitioned_tables_list:
         if len(partition_tables) > 0:
+            col_name_int64_id = partition_tables[0].schema.get_field_index(
+                col_name_int64
+            )
             partition_table: pa.Table = pa.concat_tables(
                 partition_tables
-            ).remove_column(0)
+            ).remove_column(col_name_int64_id)
             assert col_name_int64 not in partition_table.schema.names
             if len(partition_table) > 0:
                 partition_table_length += len(partition_table)

--- a/deltacat/compute/compactor/steps/repartition.py
+++ b/deltacat/compute/compactor/steps/repartition.py
@@ -129,6 +129,7 @@ def repartition_range(
             partition_table: pa.Table = pa.concat_tables(
                 partition_tables
             ).remove_column(0)
+            assert col_name_int64 not in partition_table.schema.names
             if len(partition_table) > 0:
                 partition_table_length += len(partition_table)
                 partition_delta: Delta = deltacat_storage.stage_delta(
@@ -142,6 +143,7 @@ def repartition_range(
     assert (
         partition_table_length == total_record_count
     ), f"Repartitioned table should have the same number of records {partition_table_length} as the original table {total_record_count}"
+
     return RepartitionResult(
         range_deltas=partition_deltas,
     )

--- a/deltacat/compute/compactor/steps/repartition.py
+++ b/deltacat/compute/compactor/steps/repartition.py
@@ -126,12 +126,9 @@ def repartition_range(
     partition_deltas: List[Delta] = []
     for partition_tables in partitioned_tables_list:
         if len(partition_tables) > 0:
-            col_name_int64_id = partition_tables[0].schema.get_field_index(
+            partition_table: pa.Table = pa.concat_tables(partition_tables).drop(
                 col_name_int64
             )
-            partition_table: pa.Table = pa.concat_tables(
-                partition_tables
-            ).remove_column(col_name_int64_id)
             assert col_name_int64 not in partition_table.schema.names
             if len(partition_table) > 0:
                 partition_table_length += len(partition_table)

--- a/deltacat/compute/compactor/steps/repartition.py
+++ b/deltacat/compute/compactor/steps/repartition.py
@@ -126,8 +126,9 @@ def repartition_range(
     partition_deltas: List[Delta] = []
     for partition_tables in partitioned_tables_list:
         if len(partition_tables) > 0:
+            print(f"column to be dropped: {col_name_int64}")
             partition_table: pa.Table = pa.concat_tables(partition_tables).drop(
-                col_name_int64
+                [col_name_int64]
             )
             assert col_name_int64 not in partition_table.schema.names
             if len(partition_table) > 0:

--- a/deltacat/tests/test_repartition.py
+++ b/deltacat/tests/test_repartition.py
@@ -188,6 +188,36 @@ class TestRepartitionRange(unittest.TestCase):
         )
         self.assertEqual(len(result.range_deltas), 2)
 
+    def test_null_rows_are_not_dropped(self):
+        # Add null value to the first table
+        tables_with_null = [
+            pa.table(
+                {
+                    "last_updated": [
+                        None,
+                        1678665487112746,
+                        1678665487112747,
+                        1678665487112748,
+                    ]
+                }
+            ),
+            self.tables[1],
+        ]
+
+        result = repartition_range(
+            tables_with_null,
+            self.destination_partition,
+            self.repartition_args,
+            self.max_records_per_output_file,
+            self.repartitioned_file_content_type,
+            self.deltacat_storage,
+        )
+
+        # Assuming range_deltas is a list of DataFrames,
+        # check that the first DataFrame has the null value in the 'last_updated' column
+        # This may need to be adjusted depending on the actual structure of range_deltas
+        self.assertEqual(len(result.range_deltas), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixed Issue 1: a new dw_last_update_int64 column is added for filtering, but need to be dropped 
Fixed issue 2: dw_last_update could have null value, avoid dropping it during filtering
