### PR TITLE
Adding support for reading table into ParquetFile

### DIFF
--- a/deltacat/aws/s3u.py
+++ b/deltacat/aws/s3u.py
@@ -3,6 +3,8 @@ import multiprocessing
 from functools import partial
 from typing import Any, Callable, Dict, Generator, List, Optional, Union
 from uuid import uuid4
+from botocore.config import Config
+from deltacat.aws.constants import BOTO_MAX_RETRIES
 
 import pyarrow as pa
 import ray
@@ -385,14 +387,16 @@ def download_manifest_entry(
     content_encoding: Optional[ContentEncoding] = None,
 ) -> LocalTable:
 
+    conf = Config(retries={"max_attempts": BOTO_MAX_RETRIES, "mode": "adaptive"})
     s3_client_kwargs = (
         {
             "aws_access_key_id": token_holder["accessKeyId"],
             "aws_secret_access_key": token_holder["secretAccessKey"],
             "aws_session_token": token_holder["sessionToken"],
+            "config": conf,
         }
         if token_holder
-        else {}
+        else {"config": conf}
     )
     if not content_type:
         content_type = manifest_entry.meta.content_type

--- a/deltacat/exceptions.py
+++ b/deltacat/exceptions.py
@@ -8,3 +8,7 @@ class NonRetryableError(Exception):
 
 class ConcurrentModificationError(Exception):
     pass
+
+
+class ValidationError(NonRetryableError):
+    pass

--- a/deltacat/storage/model/types.py
+++ b/deltacat/storage/model/types.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import List, Union, Any
 
+from pyarrow.parquet import ParquetFile
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -8,7 +9,7 @@ import pkg_resources
 from ray.data._internal.arrow_block import ArrowRow
 from ray.data.dataset import Dataset
 
-LocalTable = Union[pa.Table, pd.DataFrame, np.ndarray]
+LocalTable = Union[pa.Table, pd.DataFrame, np.ndarray, ParquetFile]
 LocalDataset = List[LocalTable]
 # Starting Ray 2.5.0, Dataset follows a strict mode (https://docs.ray.io/en/latest/data/faq.html#migrating-to-strict-mode),
 # and generic annotation is removed. So add a version checker to determine whether to use the old or new definition.

--- a/deltacat/types/media.py
+++ b/deltacat/types/media.py
@@ -41,6 +41,7 @@ class TableType(str, Enum):
     PYARROW = "pyarrow"
     PANDAS = "pandas"
     NUMPY = "numpy"
+    PYARROW_PARQUET = "pyarrow_parquet"
 
 
 class SchemaType(str, Enum):

--- a/deltacat/types/tables.py
+++ b/deltacat/types/tables.py
@@ -21,6 +21,7 @@ from deltacat.utils import pyarrow as pa_utils
 from deltacat.utils.ray_utils import dataset as ds_utils
 
 TABLE_TYPE_TO_READER_FUNC: Dict[int, Callable] = {
+    TableType.PYARROW_PARQUET.value: pa_utils.s3_file_to_parquet,
     TableType.PYARROW.value: pa_utils.s3_file_to_table,
     TableType.PANDAS.value: pd_utils.s3_file_to_dataframe,
     TableType.NUMPY.value: np_utils.s3_file_to_ndarray,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 boto3 ~= 1.20
 numpy == 1.21.5
 pandas == 1.3.5
-pyarrow == 10.0.1
+pyarrow == 12.0.1
 pydantic == 1.10.4
 pymemcache == 4.0.0
 ray[default] ~= 2.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
         "boto3 ~= 1.20",
         "numpy == 1.21.5",
         "pandas == 1.3.5",
-        "pyarrow == 10.0.1",
+        "pyarrow == 12.0.1",
         "pydantic == 1.10.4",
         "ray[default] ~= 2.0",
         "s3fs == 2022.2.0",


### PR DESCRIPTION
[Motivation] #162

Testing
-----

```python
delta_result = DS.list_deltas(namespace=namespace, 
...                         table_name=table_name, 
...                         partition_values=ordered_partition_values, 
...                         table_version=table_version, 
...                         include_manifest=True,
...                         equivalent_table_types=[])

delta = delta_result.read_page()[0]

table = DS.download_delta_manifest_entry(delta, 0, TableType.PYARROW_PARQUET)
# <pyarrow.parquet.core.ParquetFile object at 0xffffa168c100>
```