### PR TITLE
Polling EC2 Instance Metadata endpoint until HTTP 200 OK

### DIFF
--- a/deltacat/aws/clients.py
+++ b/deltacat/aws/clients.py
@@ -97,6 +97,3 @@ def client_cache(name: str, region: Optional[str], **kwargs) -> BaseClient:
     # we don't use the @lru_cache decorator because Ray can't pickle it
     cached_function = lru_cache()(_client)
     return cached_function(name, region, **kwargs)
-
-
-# print(block_until_instance_metadata_service_returns_success())

--- a/deltacat/aws/clients.py
+++ b/deltacat/aws/clients.py
@@ -1,6 +1,5 @@
 import logging
 from functools import lru_cache
-import requests
 from requests import Session
 from typing import Optional
 from http import HTTPStatus
@@ -18,7 +17,7 @@ from deltacat.aws.constants import BOTO_MAX_RETRIES
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 BOTO3_PROFILE_NAME_KWARG_KEY = "boto3_profile_name"
-INSTANCE_METADATA_SERVICE_IPV4_URI = "http://169.254.169.254/latest/meta-data/" # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+INSTANCE_METADATA_SERVICE_IPV4_URI = "http://169.254.169.254/latest/meta-data/"  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
 
 
 def block_until_instance_metadata_service_returns_success(
@@ -26,7 +25,7 @@ def block_until_instance_metadata_service_returns_success(
     backoff_factor=1,
 ) -> Optional[Response]:
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-    with Session as session:
+    with Session() as session:
         retries = Retry(
             total=total_number_of_retries,
             backoff_factor=backoff_factor,  # A backoff factor to apply between attempts after the second try: {backoff factor} * (2 ** ({number of previous retries}))
@@ -43,7 +42,6 @@ def block_until_instance_metadata_service_returns_success(
         adapter = HTTPAdapter(max_retries=retries)
         session.mount("http", adapter)
         response = session.get(INSTANCE_METADATA_SERVICE_IPV4_URI)
-        print(f"response={response.text}")
         logger.info(
             f"Instance profile credentials are now accessible. Instance Metadata Service (IMDS) returned success with status code {response.status_code}"
         )

--- a/deltacat/aws/clients.py
+++ b/deltacat/aws/clients.py
@@ -1,12 +1,15 @@
 import logging
 from functools import lru_cache
+import requests
 from typing import Optional
+from http import HTTPStatus
 
 import boto3
 from boto3.exceptions import ResourceNotExistsError
 from boto3.resources.base import ServiceResource
 from botocore.client import BaseClient
 from botocore.config import Config
+from requests.adapters import HTTPAdapter, Retry, Response
 
 from deltacat import logs
 from deltacat.aws.constants import BOTO_MAX_RETRIES
@@ -14,9 +17,45 @@ from deltacat.aws.constants import BOTO_MAX_RETRIES
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 BOTO3_PROFILE_NAME_KWARG_KEY = "boto3_profile_name"
+INSTANCE_METADATA_SERVICE_URI_BASE = "169.254.169.254/latest/meta-data"
+INSTANCE_PROFILE_ROLE_CREDENTIALS_PATH = (
+    "/identity-credentials/ec2/security-credentials/ec2-instance"
+)
+
+
+def block_until_instance_metadata_service_returns_success(
+    total_number_of_retries=10,
+    backoff_factor=1,
+) -> Optional[Response]:
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+    with requests.Session as session:
+        retries = Retry(
+            total=total_number_of_retries,
+            backoff_factor=backoff_factor,  # A backoff factor to apply between attempts after the second try: {backoff factor} * (2 ** ({number of previous retries}))
+            # For example, if the backoff_factor is 1, then Retry.sleep() will sleep for [1s, 2s, 4s, 8s, …] between retries.
+            status_forcelist=[
+                HTTPStatus.TOO_MANY_REQUESTS,
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                HTTPStatus.BAD_GATEWAY,
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                HTTPStatus.GATEWAY_TIMEOUT,
+            ],
+            raise_on_status=True,  # Whether, if the number of retries are exhausted, to raise a MaxRetryError, or to return a response with a response code in the 3xx range.
+        )
+        adapter = HTTPAdapter(max_retries=retries)
+        session.mount("http", adapter)
+        response = session.get(
+            f"http://{INSTANCE_METADATA_SERVICE_URI_BASE}{INSTANCE_PROFILE_ROLE_CREDENTIALS_PATH}"
+        )
+        print(f"response={response.text}")
+        logger.info(
+            f"Instance profile credentials are now accessible. Instance Metadata Service (IMDS) returned success with status code {response.status_code}"
+        )
+        return response
 
 
 def _get_session_from_kwargs(input_kwargs):
+    block_until_instance_metadata_service_returns_success()
     if input_kwargs.get(BOTO3_PROFILE_NAME_KWARG_KEY) is not None:
         boto3_session = boto3.Session(
             profile_name=input_kwargs.get(BOTO3_PROFILE_NAME_KWARG_KEY)
@@ -67,3 +106,6 @@ def client_cache(name: str, region: Optional[str], **kwargs) -> BaseClient:
     # we don't use the @lru_cache decorator because Ray can't pickle it
     cached_function = lru_cache()(_client)
     return cached_function(name, region, **kwargs)
+
+
+# print(block_until_instance_metadata_service_returns_success())

--- a/deltacat/aws/clients.py
+++ b/deltacat/aws/clients.py
@@ -23,7 +23,6 @@ INSTANCE_METADATA_SERVICE_IPV4_URI = "http://169.254.169.254/latest/meta-data/" 
 def block_until_instance_metadata_service_returns_success(
     total_number_of_retries=10,
     backoff_factor=0.5,
-    backoff_max=600,
 ) -> Optional[Response]:
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
     with Session() as session:

--- a/deltacat/aws/clients.py
+++ b/deltacat/aws/clients.py
@@ -104,7 +104,7 @@ def retry_url(
 def block_until_instance_metadata_service_returns_success(
     retry_strategy=retry_if_retryable_http_status_code,
     wait_strategy=wait_fixed(2),  # wait 2 seconds before retrying,
-    stop_strategy=stop_after_delay(5),  # stop trying after 10 minutes
+    stop_strategy=stop_after_delay(60 * 10),  # stop trying after 10 minutes
     url=INSTANCE_METADATA_SERVICE_IPV4_URI,
 ) -> Optional[Response]:
     """Blocks until the instance metadata service returns a successful response.

--- a/deltacat/aws/clients.py
+++ b/deltacat/aws/clients.py
@@ -37,14 +37,11 @@ def block_until_instance_metadata_service_returns_success(
                 HTTPStatus.SERVICE_UNAVAILABLE,
                 HTTPStatus.GATEWAY_TIMEOUT,
             ],
-            raise_on_status=True,  # Whether, if the number of retries are exhausted, to raise a MaxRetryError, or to return a response with a response code in the 3xx range.
+            raise_on_status=True,  # Whether to raise an MaxRetryError exception if retries are exhausted or to return a response with a response code in the 3xx range.
         )
         adapter = HTTPAdapter(max_retries=retries)
         session.mount("http", adapter)
         response = session.get(INSTANCE_METADATA_SERVICE_IPV4_URI)
-        logger.info(
-            f"Instance profile credentials are now accessible. Instance Metadata Service (IMDS) returned success with status code {response.status_code}"
-        )
         return response
 
 

--- a/deltacat/tests/aws/test_clients.py
+++ b/deltacat/tests/aws/test_clients.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock, patch, call
+import unittest
+import json
+from http import HTTPStatus
+
+HAPPY_RESPONSE = {
+    "AccessKeyId": "ASIA123456789",
+    "Code": "Success",
+    "Expiration": "2023-08-02T13:50:33Z",
+    "LastUpdated": "2023-08-02T07:23:35Z",
+    "SecretAccessKey": "bar",
+    "Token": "foo",
+    "Type": "AWS-HMAC",
+}
+
+
+class MockResponse:
+    """
+    A mock object denoting the response of requests method.
+    """
+
+    def __init__(self, status_code: int, text: str, reason: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+        self.reason = reason
+
+
+class TestBlockUntilInstanceMetadataServiceReturnsSuccess(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        pass
+
+    @patch("deltacat.aws.clients.Session")
+    def test_sanity(self, session_mock):
+        from deltacat.aws.clients import (
+            block_until_instance_metadata_service_returns_success,
+            INSTANCE_METADATA_SERVICE_IPV4_URI,
+        )
+
+        mocked_session = MagicMock()
+        mocked_session.__enter__.return_value.get.return_value = MockResponse(
+            200, "foo"
+        )
+        session_mock.return_value = mocked_session
+        self.assertEqual(
+            block_until_instance_metadata_service_returns_success().status_code, 200
+        )
+        expect_call_to_INSTANCE_METADATA_SERVICE_IPV4_URI = [
+            call.__enter__().get(INSTANCE_METADATA_SERVICE_IPV4_URI)
+        ]
+        session_mock.return_value.assert_has_calls(
+            expect_call_to_INSTANCE_METADATA_SERVICE_IPV4_URI,
+            any_order=True,
+        )
+
+    @patch("deltacat.aws.clients.Session")
+    def test_retrying_on_statuses_in_status_force_list(self, session_mock):
+        from deltacat.aws.clients import (
+            block_until_instance_metadata_service_returns_success,
+            INSTANCE_METADATA_SERVICE_IPV4_URI,
+        )
+
+        mocked_session = MagicMock()
+        mocked_session.__enter__.return_value.get.side_effect = [
+            MockResponse(HTTPStatus.OK, json.dumps(HAPPY_RESPONSE)),
+            MockResponse(HTTPStatus.TOO_MANY_REQUESTS, "foo"),
+            MockResponse(HTTPStatus.INTERNAL_SERVER_ERROR, "foo"),
+        ]
+        session_mock.return_value = mocked_session
+        self.assertEqual(
+            block_until_instance_metadata_service_returns_success().status_code, 200
+        )
+        expect_call_to_INSTANCE_METADATA_SERVICE_IPV4_URI = [
+            call.__enter__().get(INSTANCE_METADATA_SERVICE_IPV4_URI)
+        ]
+        session_mock.return_value.assert_has_calls(
+            expect_call_to_INSTANCE_METADATA_SERVICE_IPV4_URI,
+            any_order=True,
+        )

--- a/deltacat/tests/aws/test_clients.py
+++ b/deltacat/tests/aws/test_clients.py
@@ -75,7 +75,7 @@ class TestBlockUntilInstanceMetadataServiceReturnsSuccess(unittest.TestCase):
             block_until_instance_metadata_service_returns_success().status_code, 200
         )
         expect_call_to_INSTANCE_METADATA_SERVICE_IPV4_URI = [
-            call.__enter__().get(INSTANCE_METADATA_SERVICE_IPV4_URI)
+            call.__enter__().get("http://169.254.169.254/latest/meta-data/")
         ]
         session_mock.return_value.assert_has_calls(
             expect_call_to_INSTANCE_METADATA_SERVICE_IPV4_URI,

--- a/deltacat/tests/aws/test_clients.py
+++ b/deltacat/tests/aws/test_clients.py
@@ -75,7 +75,7 @@ class TestBlockUntilInstanceMetadataServiceReturnsSuccess(unittest.TestCase):
             block_until_instance_metadata_service_returns_success().status_code, 200
         )
         expect_call_to_INSTANCE_METADATA_SERVICE_IPV4_URI = [
-            call.__enter__().get("http://169.254.169.254/latest/meta-data/")
+            call.__enter__().get(INSTANCE_METADATA_SERVICE_IPV4_URI)
         ]
         session_mock.return_value.assert_has_calls(
             expect_call_to_INSTANCE_METADATA_SERVICE_IPV4_URI,

--- a/deltacat/tests/aws/test_clients.py
+++ b/deltacat/tests/aws/test_clients.py
@@ -41,7 +41,6 @@ class TestBlockUntilInstanceMetadataServiceReturnsSuccess(unittest.TestCase):
     def test_sanity(self, requests_mock):
         from deltacat.aws.clients import (
             block_until_instance_metadata_service_returns_success,
-            INSTANCE_METADATA_SERVICE_IPV4_URI,
         )
 
         requests_mock.get.return_value = MockResponse(200, "foo")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ memray == 1.6.0; platform_system != "Windows" and sys_platform != "darwin" and p
 pre-commit == 2.20.0
 pytest == 7.2.0
 pytest-cov == 4.0.0
+requests-mock == 1.11.0


### PR DESCRIPTION
This change adds a function that calls the instance metadata service endpoint with retry logic. The function - `block_until_instance_metadata_service_returns_success` - blocks until the endpoint is available or the maximum number of retries is exceeded. The function is used in _get_session_from_kwargs to block boto3 session creation until the instance profile IAM role is available.