### PR TITLE
Trigger a "Publish Python distributions to PyPI" GH Actions workflow on additional event types

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,7 +1,7 @@
 name: Publish Python distributions to PyPI
 on:
   release:
-    types: [published] # triggered whenever a new GitHub release is published
+    types: [published, created, edited] # triggered whenever a new GitHub release is published
 jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI


### PR DESCRIPTION
Editing and creating a release should now trigger the Publish Python distributions to PyPI workflow. Previously, a new release *and* tag had to be created to trigger the workflow