### PR TITLE
Install dev-dependencies before running tests

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,42 +1,42 @@
 name: Publish Python distributions to PyPI
 on:
-  release:
-    types: [published, created, edited] # triggered whenever a new GitHub release is published
+    release:
+        types: [published, created, edited] # triggered whenever a new GitHub release is published
 jobs:
-  build-n-publish:
-    name: Build and publish Python distributions to PyPI
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@main
-      with:
-          fetch-depth: 0
-    - name: Set up Python 3.7 (minimum supported python version for deltaCAT)
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.7"
-    - name: Install pypa/build
-      run: >-
-        python -m
-        pip install
-        build
-        --user
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Run unit tests
-      run: >-
-        python -m pytest
-    - name: Echo release tag
-      run: echo ${{ github.ref_name }}
-    - name: Build a binary wheel and a source tarball
-      run: >-
-        python setup.py sdist bdist_wheel
-    - name: Publish distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        verbose: true
+    build-n-publish:
+        name: Build and publish Python distributions to PyPI
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@main
+              with:
+                  fetch-depth: 0
+            - name: Set up Python 3.7 (minimum supported python version for deltaCAT)
+              uses: actions/setup-python@v3
+              with:
+                  python-version: "3.7"
+            - name: Install pypa/build
+              run: >-
+                  python -m
+                  pip install
+                  build
+                  --user
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install pytest
+                  if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+            - name: Run unit tests
+              run: >-
+                  python -m pytest
+            - name: Echo release tag
+              run: echo ${{ github.ref_name }}
+            - name: Build a binary wheel and a source tarball
+              run: >-
+                  python setup.py sdist bdist_wheel
+            - name: Publish distribution to PyPI
+              if: startsWith(github.ref, 'refs/tags')
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                  password: ${{ secrets.PYPI_API_TOKEN }}
+                  verbose: true


### PR DESCRIPTION
#186 

This commit fixes the issue when using `moto` to run unit tests as it is only defined in `dev-requirements.txt`. 