### PR TITLE
Capture memory gb seconds and bug fixes

### DIFF
--- a/deltacat/aws/clients.py
+++ b/deltacat/aws/clients.py
@@ -109,7 +109,7 @@ def block_until_instance_metadata_service_returns_success(
     url=INSTANCE_METADATA_SERVICE_IPV4_URI,
     retry_strategy=RetryIfRetryableHTTPStatusCode,
     wait_strategy=wait_fixed(2),  # wait 2 seconds before retrying,
-    stop_strategy=stop_after_delay(60 * 10),  # stop trying after 10 minutes
+    stop_strategy=stop_after_delay(60 * 30),  # stop trying after 30 minutes
 ) -> Optional[Response]:
     """Blocks until the instance metadata service returns a successful response.
 

--- a/deltacat/compute/compactor/model/compact_partition_params.py
+++ b/deltacat/compute/compactor/model/compact_partition_params.py
@@ -90,6 +90,7 @@ class CompactPartitionParams(dict):
             "hash_group_count", result.hash_bucket_count
         )
         result.drop_duplicates = params.get("drop_duplicates", DROP_DUPLICATES)
+        result.ray_custom_resources = params.get("ray_custom_resources")
 
         if not importlib.util.find_spec("memray"):
             result.enable_profiler = False
@@ -287,6 +288,14 @@ class CompactPartitionParams(dict):
     @property
     def hash_group_count(self) -> int:
         return self["hash_group_count"]
+
+    @property
+    def ray_custom_resources(self) -> Dict:
+        return self["ray_custom_resources"]
+
+    @ray_custom_resources.setter
+    def ray_custom_resources(self, res) -> None:
+        self["ray_custom_resources"] = res
 
     @hash_group_count.setter
     def hash_group_count(self, count: int) -> None:

--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -421,6 +421,21 @@ class CompactionSessionAuditInfo(dict):
         return self.get("usedCPUSeconds")
 
     @property
+    def used_memory_gb_seconds(self) -> float:
+        """
+        The used memory in the cluster weighted over time. This
+        determines opportunities for better memory estimation.
+        """
+        return self.get("usedMemoryGBSeconds")
+
+    @property
+    def total_memory_gb_seconds(self) -> float:
+        """
+        Total memory in the cluster weighted over time in GB.
+        """
+        return self.get("totalMemoryGBSeconds")
+
+    @property
     def pyarrow_version(self) -> str:
         """
         The version of PyArrow used.
@@ -741,6 +756,14 @@ class CompactionSessionAuditInfo(dict):
 
     def set_used_cpu_seconds(self, value: float) -> CompactionSessionAuditInfo:
         self["usedCPUSeconds"] = value
+        return self
+
+    def set_used_memory_gb_seconds(self, value: float) -> CompactionSessionAuditInfo:
+        self["usedMemoryGBSeconds"] = value
+        return self
+
+    def set_total_memory_gb_seconds(self, value: float) -> CompactionSessionAuditInfo:
+        self["totalMemoryGBSeconds"] = value
         return self
 
     def set_pyarrow_version(self, value: str) -> CompactionSessionAuditInfo:

--- a/deltacat/compute/compactor/model/delta_annotated.py
+++ b/deltacat/compute/compactor/model/delta_annotated.py
@@ -287,7 +287,8 @@ class DeltaAnnotated(Delta):
                         result.append(new_da)
                 else:
                     logger.info(
-                        f"Split was not performed on correct delta with locator: {delta_annotated.locator}"
+                        f"Split was not performed on delta with locator: {delta_annotated.locator} "
+                        "as partial parquet params was not found."
                     )
                     return [delta_annotated]
 

--- a/deltacat/compute/compactor/model/delta_annotated.py
+++ b/deltacat/compute/compactor/model/delta_annotated.py
@@ -286,7 +286,13 @@ class DeltaAnnotated(Delta):
 
                         result.append(new_da)
                 else:
+                    logger.info(
+                        f"Split was not performed on correct delta with locator: {delta_annotated.locator}"
+                    )
                     return [delta_annotated]
+
+        if result:
+            return result
 
         logger.info(
             f"Split was not performed on the delta with locator: {delta_annotated.locator}"

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -217,6 +217,7 @@ def _execute_compaction(
         previous_inflation=params.previous_inflation,
         average_record_size_bytes=params.average_record_size_bytes,
         primary_keys=params.primary_keys,
+        ray_custom_resources=params.ray_custom_resources,
     )
 
     hb_start = time.monotonic()
@@ -337,6 +338,7 @@ def _execute_compaction(
         primary_keys=params.primary_keys,
         deltacat_storage=params.deltacat_storage,
         deltacat_storage_kwargs=params.deltacat_storage_kwargs,
+        ray_custom_resources=params.ray_custom_resources,
     )
 
     def merge_input_provider(index, item):
@@ -479,6 +481,10 @@ def _execute_compaction(
     if cluster_util:
         compaction_audit.set_total_cpu_seconds(cluster_util.total_vcpu_seconds)
         compaction_audit.set_used_cpu_seconds(cluster_util.used_vcpu_seconds)
+        compaction_audit.set_used_memory_gb_seconds(cluster_util.used_memory_gb_seconds)
+        compaction_audit.set_total_memory_gb_seconds(
+            cluster_util.total_memory_gb_seconds
+        )
 
     s3_utils.upload(
         compaction_audit.audit_url,

--- a/deltacat/compute/compactor_v2/constants.py
+++ b/deltacat/compute/compactor_v2/constants.py
@@ -23,10 +23,10 @@ AVERAGE_RECORD_SIZE_BYTES = 1000
 # r5.8xlarge EC2 instances.
 TASK_MAX_PARALLELISM = 5367
 
-# The percentage of memory that needs to be estimated
+# The percentage of memory that needs to be allocated
 # as buffer. This value will ensure the job doesn't run out
 # of memory by considering buffer for uncertainities.
-TOTAL_MEMORY_BUFFER_PERCENTAGE = 20
+TOTAL_MEMORY_BUFFER_PERCENTAGE = 30
 
 # The total size of records that will be hash bucketed at once
 # Since, sorting is nlogn, we ensure that is not performed
@@ -35,3 +35,8 @@ MAX_SIZE_OF_RECORD_BATCH_IN_GIB = 2 * 1024 * 1024 * 1024
 
 # Whether to drop duplicates during merge.
 DROP_DUPLICATES = True
+
+# PARQUET to PYARROW inflation multiplier
+# This is the observed upper bound inflation for parquet
+# size in metadata to pyarrow table size.
+PARQUET_TO_PYARROW_INFLATION = 4

--- a/deltacat/compute/compactor_v2/steps/hash_bucket.py
+++ b/deltacat/compute/compactor_v2/steps/hash_bucket.py
@@ -109,7 +109,10 @@ def _group_file_records_by_pk_hash_bucket(
     if delta_file_envelopes is None:
         return None, 0, 0
 
-    logger.info(f"Read all delta file envelopes: {len(delta_file_envelopes)}")
+    logger.info(
+        f"Read all delta file envelopes: {len(delta_file_envelopes)} "
+        f"and total_size_bytes={total_size_bytes} and records={total_record_count}"
+    )
 
     # group the data by primary key hash value
     hb_to_delta_file_envelopes = np.empty([num_hash_buckets], dtype="object")

--- a/deltacat/compute/compactor_v2/utils/content_type_params.py
+++ b/deltacat/compute/compactor_v2/utils/content_type_params.py
@@ -46,7 +46,7 @@ def append_content_type_params(
         pq_files = deltacat_storage.download_delta(
             delta,
             table_type=TableType.PYARROW_PARQUET,
-            storage_type=StorageType.DISTRIBUTED,
+            storage_type=StorageType.LOCAL,
             **deltacat_storage_kwargs,
         )
 

--- a/deltacat/io/memcached_object_store.py
+++ b/deltacat/io/memcached_object_store.py
@@ -29,6 +29,7 @@ class MemcachedObjectStore(IObjectStore):
         self.port = port
         self.storage_node_ips = storage_node_ips
         self.hasher = None
+        logger.info(f"The storage node IPs: {self.storage_node_ips}")
         super().__init__()
 
     def initialize_hasher(self):
@@ -129,9 +130,13 @@ class MemcachedObjectStore(IObjectStore):
         base_client = Client((ip_address, self.port))
         client = RetryingClient(
             base_client,
-            attempts=3,
-            retry_delay=0.01,
-            retry_for=[MemcacheUnexpectedCloseError, ConnectionResetError],
+            attempts=15,
+            retry_delay=1,
+            retry_for=[
+                MemcacheUnexpectedCloseError,
+                ConnectionResetError,
+                BrokenPipeError,
+            ],
         )
 
         self.client_cache[ip_address] = client

--- a/deltacat/tests/utils/test_resources.py
+++ b/deltacat/tests/utils/test_resources.py
@@ -46,3 +46,5 @@ class TestClusterUtilizationOverTimeRange(unittest.TestCase):
             self.assertTrue(
                 cu.total_vcpu_seconds >= cu.used_vcpu_seconds
             )  # total is greater than used
+            self.assertIsNotNone(cu.total_memory_gb_seconds)
+            self.assertIsNotNone(cu.used_memory_gb_seconds)


### PR DESCRIPTION
- [x] fix delta split
- [x] added inflation to the parquet size
- [x] added more logging
- [x] change storage_type to LOCAL as ParquetFile cannot be pickled
- [x] increase the delay for blocking instance metadata service
- [x] capture total and used memory gb seconds to understand memory efficiency
- [x] add ray_custom_resources compaction param to allow scheduling to particular node types