### PR TITLE
update daft to 0.1.16 that uses openssl and correct arrow schema parsing with int96 options

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.1.18b18"
+__version__ = "0.1.18b19"
 
 
 __all__ = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # setup.py install_requires
 # any changes here should also be reflected in setup.py "install_requires"
 boto3 ~= 1.20
-getdaft==0.1.15
+getdaft==0.1.16
 numpy == 1.21.5
 pandas == 1.3.5
 pyarrow == 12.0.1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         "typing-extensions == 4.4.0",
         "pymemcache == 4.0.0",
         "redis == 4.6.0",
-        "getdaft == 0.1.15",
+        "getdaft == 0.1.16",
         "schedule == 1.2.0",
     ],
     setup_requires=["wheel"],


### PR DESCRIPTION
* Updates the daft version to 0.1.16 which switches daft over to use OpenSSL over Rustls
* Also includes correct behavior when parsing a parquet schema with int96 options which the `ARROW_SCHEMA` field is also set