### PR TITLE
Version Bump to 0.1.19 (non-prerelease)

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.1.18b19"
+__version__ = "0.1.19"
 
 
 __all__ = [


### PR DESCRIPTION
## Motivation
- Can't use compatible minor versions (`deltacat ~= 0.1`) for pre-releases (like 0.1.18b19)