### PR TITLE
Setting connect timeout and timeout parameters

### DIFF
--- a/deltacat/compute/compactor_v2/constants.py
+++ b/deltacat/compute/compactor_v2/constants.py
@@ -19,7 +19,7 @@ MIN_FILES_IN_BATCH = float("inf")
 AVERAGE_RECORD_SIZE_BYTES = 1000
 
 # Maximum parallelism for the tasks at each BSP step.
-# Default is the number of vCPUs in about 168
+# Default is the number of vCPUs in about 128
 # r5.8xlarge EC2 instances.
 TASK_MAX_PARALLELISM = 4096
 

--- a/deltacat/compute/compactor_v2/constants.py
+++ b/deltacat/compute/compactor_v2/constants.py
@@ -21,7 +21,7 @@ AVERAGE_RECORD_SIZE_BYTES = 1000
 # Maximum parallelism for the tasks at each BSP step.
 # Default is the number of vCPUs in about 168
 # r5.8xlarge EC2 instances.
-TASK_MAX_PARALLELISM = 5367
+TASK_MAX_PARALLELISM = 4096
 
 # The percentage of memory that needs to be allocated
 # as buffer. This value will ensure the job doesn't run out

--- a/deltacat/io/memcached_object_store.py
+++ b/deltacat/io/memcached_object_store.py
@@ -24,7 +24,11 @@ class MemcachedObjectStore(IObjectStore):
     FETCH_TIMEOUT = 30 * 60
 
     def __init__(
-        self, storage_node_ips: Optional[List[str]] = None, port: Optional[int] = 11212
+        self,
+        storage_node_ips: Optional[List[str]] = None,
+        port: Optional[int] = 11212,
+        connect_timeout: float = CONNECT_TIMEOUT,
+        timeout: float = FETCH_TIMEOUT,
     ) -> None:
         self.client_cache = {}
         self.current_ip = None
@@ -32,6 +36,8 @@ class MemcachedObjectStore(IObjectStore):
         self.port = port
         self.storage_node_ips = storage_node_ips
         self.hasher = None
+        self.connect_timeout = connect_timeout
+        self.timeout = timeout
         logger.info(f"The storage node IPs: {self.storage_node_ips}")
         super().__init__()
 
@@ -132,8 +138,8 @@ class MemcachedObjectStore(IObjectStore):
 
         base_client = Client(
             (ip_address, self.port),
-            connect_timeout=self.CONNECT_TIMEOUT,
-            timeout=self.FETCH_TIMEOUT,
+            connect_timeout=self.connect_timeout,
+            timeout=self.timeout,
             no_delay=True,
         )
 


### PR DESCRIPTION
#150 

It is a best practice to set the connect timeout and timeout parameters for socket. Otherwise the connection can hang making the recovery very difficult leading to job wasting resources. This commit aims to set these parameters based on our requirement, and retry on `TimeoutError` to recover from transient connection timeouts.