### PR TITLE
Daft Parquet Reader - convert large strings to regular pyarrow strings

### DIFF
--- a/deltacat/tests/utils/test_daft.py
+++ b/deltacat/tests/utils/test_daft.py
@@ -20,6 +20,7 @@ class TestDaftParquetReader(unittest.TestCase):
         )
         self.assertEqual(table.schema.names, ["a", "b"])
         self.assertEqual(table.num_rows, 100)
+        self._util_check_strings_in_schema(table.schema)
 
     def test_read_from_s3_single_column_via_include_columns(self):
         table = daft_s3_file_to_table(
@@ -30,6 +31,7 @@ class TestDaftParquetReader(unittest.TestCase):
         )
         self.assertEqual(table.schema.names, ["b"])
         self.assertEqual(table.num_rows, 100)
+        self._util_check_strings_in_schema(table.schema)
 
     def test_read_from_s3_single_column_via_column_names(self):
         table = daft_s3_file_to_table(
@@ -40,6 +42,7 @@ class TestDaftParquetReader(unittest.TestCase):
         )
         self.assertEqual(table.schema.names, ["b"])
         self.assertEqual(table.num_rows, 100)
+        self._util_check_strings_in_schema(table.schema)
 
     def test_read_from_s3_single_column_with_schema(self):
         schema = pa.schema([("a", pa.int64()), ("b", pa.string())])
@@ -55,6 +58,7 @@ class TestDaftParquetReader(unittest.TestCase):
         )
         self.assertEqual(table.schema.names, ["b"])
         self.assertEqual(table.num_rows, 100)
+        self._util_check_strings_in_schema(table.schema)
 
     def test_read_from_s3_single_column_with_row_groups(self):
 
@@ -70,6 +74,11 @@ class TestDaftParquetReader(unittest.TestCase):
         )
         self.assertEqual(table.schema.names, ["b"])
         self.assertEqual(table.num_rows, 10)
+        self._util_check_strings_in_schema(table.schema)
+
+    def _util_check_strings_in_schema(self, schema: pa.Schema):
+        for field in schema:
+            self.assertFalse(pa.types.is_large_string(field.type))
 
 
 if __name__ == "__main__":

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -82,6 +82,6 @@ def daft_s3_file_to_table(
         if include_columns is not None:
             schema = pa.schema([schema.field(col) for col in include_columns])
         daft_schema = Schema.from_pyarrow_schema(schema)
-        return table.cast_to_schema(daft_schema).to_arrow()
+        return table.cast_to_schema(daft_schema).to_arrow(convert_large_arrays=True)
     else:
-        return table.to_arrow()
+        return table.to_arrow(convert_large_arrays=True)


### PR DESCRIPTION
* Converts large strings to regular strings when exporting a daft table to pyarrow