### PR TITLE
Adding compactor version in audit info and rci

### DIFF
--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -241,8 +241,9 @@ def _execute_compaction_round(
 
     logger.info(f"Compaction audit will be written to {audit_url}")
 
-    compaction_audit = CompactionSessionAuditInfo(deltacat.__version__, audit_url)
-    compaction_audit.set_compactor_version(CompactorVersion.V1.value)
+    compaction_audit = CompactionSessionAuditInfo(
+        deltacat.__version__, audit_url
+    ).set_compactor_version(CompactorVersion.V1.value)
 
     compaction_start = time.monotonic()
 

--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -50,6 +50,7 @@ from deltacat.utils.metrics import MetricsConfig
 from deltacat.compute.compactor.model.compaction_session_audit_info import (
     CompactionSessionAuditInfo,
 )
+from deltacat.compute.compactor.model.compactor_version import CompactorVersion
 from deltacat.compute.compactor.utils.sort_key import validate_sort_keys
 from deltacat.utils.resources import get_current_node_peak_memory_usage_in_bytes
 
@@ -241,6 +242,7 @@ def _execute_compaction_round(
     logger.info(f"Compaction audit will be written to {audit_url}")
 
     compaction_audit = CompactionSessionAuditInfo(deltacat.__version__, audit_url)
+    compaction_audit.set_compactor_version(CompactorVersion.V1.value)
 
     compaction_start = time.monotonic()
 
@@ -698,6 +700,9 @@ def _execute_compaction_round(
         last_rebase_source_partition_locator,
         compaction_audit.untouched_file_ratio,
         audit_url,
+        hash_bucket_count,
+        None,
+        CompactorVersion.V1.value,
     )
 
     logger.info(

--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -442,6 +442,13 @@ class CompactionSessionAuditInfo(dict):
         """
         return self.get("pyarrowVersion")
 
+    @property
+    def compactor_version(self) -> str:
+        """
+        The version of the compactor used to compact.
+        """
+        return self.get("compactorVersion")
+
     # Setters follow
 
     def set_audit_url(self, audit_url: str) -> CompactionSessionAuditInfo:
@@ -768,6 +775,10 @@ class CompactionSessionAuditInfo(dict):
 
     def set_pyarrow_version(self, value: str) -> CompactionSessionAuditInfo:
         self["pyarrowVersion"] = value
+        return self
+
+    def set_compactor_version(self, value: str) -> CompactionSessionAuditInfo:
+        self["compactorVersion"] = value
         return self
 
     # High level methods to save stats

--- a/deltacat/compute/compactor/model/compactor_version.py
+++ b/deltacat/compute/compactor/model/compactor_version.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
 
-class CompactorVersion(Enum):
+class CompactorVersion(str, Enum):
     V1 = "V1"
     V2 = "V2"

--- a/deltacat/compute/compactor/model/compactor_version.py
+++ b/deltacat/compute/compactor/model/compactor_version.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class CompactorVersion(Enum):
+    V1 = "V1"
+    V2 = "V2"

--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -46,6 +46,7 @@ class RoundCompletionInfo(dict):
         compaction_audit_url: Optional[str] = None,
         hash_bucket_count: Optional[int] = None,
         hb_index_to_entry_range: Optional[Dict[int, Tuple[int, int]]] = None,
+        compactor_version: Optional[str] = None,
     ) -> RoundCompletionInfo:
 
         rci = RoundCompletionInfo()
@@ -60,6 +61,7 @@ class RoundCompletionInfo(dict):
         rci["compactionAuditUrl"] = compaction_audit_url
         rci["hashBucketCount"] = hash_bucket_count
         rci["hbIndexToEntryRange"] = hb_index_to_entry_range
+        rci["compactorVersion"] = compactor_version
         return rci
 
     @property
@@ -113,3 +115,7 @@ class RoundCompletionInfo(dict):
         The start index is inclusive and end index is exclusive by default.
         """
         return self["hbIndexToEntryRange"]
+
+    @property
+    def compactor_version(self) -> Optional[str]:
+        return self.get("compactorVersion")

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -112,10 +112,11 @@ def _execute_compaction(
     )
     audit_url = f"{base_audit_url}.json"
     logger.info(f"Compaction audit will be written to {audit_url}")
-    compaction_audit = CompactionSessionAuditInfo(deltacat.__version__, audit_url)
-
-    compaction_audit.set_hash_bucket_count(params.hash_bucket_count)
-    compaction_audit.set_compactor_version(CompactorVersion.V2.value)
+    compaction_audit = (
+        CompactionSessionAuditInfo(deltacat.__version__, audit_url)
+        .set_hash_bucket_count(params.hash_bucket_count)
+        .set_compactor_version(CompactorVersion.V2.value)
+    )
 
     compaction_start = time.monotonic()
 

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -48,6 +48,7 @@ from deltacat.compute.compactor_v2.utils.task_options import (
     merge_resource_options_provider,
 )
 from deltacat.utils.resources import ClusterUtilizationOverTimeRange
+from deltacat.compute.compactor.model.compactor_version import CompactorVersion
 
 if importlib.util.find_spec("memray"):
     import memray
@@ -114,6 +115,7 @@ def _execute_compaction(
     compaction_audit = CompactionSessionAuditInfo(deltacat.__version__, audit_url)
 
     compaction_audit.set_hash_bucket_count(params.hash_bucket_count)
+    compaction_audit.set_compactor_version(CompactorVersion.V2.value)
 
     compaction_start = time.monotonic()
 
@@ -501,6 +503,7 @@ def _execute_compaction(
         compaction_audit_url=audit_url,
         hash_bucket_count=params.hash_bucket_count,
         hb_index_to_entry_range=hb_id_to_entry_indices_range,
+        compactor_version=CompactorVersion.V2.value,
     )
 
     logger.info(


### PR DESCRIPTION
#150 

This commit adds the compactor version in round completion file and audit to allow looking up what version was used and also allows driver to programmatically lookup version to decide whether to run rebase or incremental compaction. E.g., if version changes, a rebase has to be run. 