### PR TITLE
Add index array size to estimation, fix dedupe and concurrency

### DIFF
--- a/deltacat/compute/compactor_v2/utils/dedupe.py
+++ b/deltacat/compute/compactor_v2/utils/dedupe.py
@@ -16,7 +16,14 @@ def _create_chunked_index_array(array: pa.Array) -> pa.Array:
     chunk_lengths = [
         len(array.chunk(chunk_index)) for chunk_index in range(len(array.chunks))
     ]
-    result = np.array([np.arange(cl) for cl in chunk_lengths], dtype="object")
+
+    # if all chunk lengths are equal, numpy assumes correct shape
+    # which make addition operation append elements instead of adding.
+    result = np.empty((len(chunk_lengths),), dtype="object")
+
+    for index, cl in enumerate(chunk_lengths):
+        result[index] = np.arange(cl, dtype="int32")
+
     chunk_lengths = ([0] + chunk_lengths)[:-1]
     result = pa.chunked_array(result + np.cumsum(chunk_lengths))
     return result

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -232,7 +232,8 @@ def merge_resource_options_provider(
                     else:
                         pk_size_bytes += pk_size
 
-    # total data downloaded + primary key hash column + primary key column + dict size for merge
+    # total data downloaded + primary key hash column + primary key column
+    # + dict size for merge + incremental index array size
     total_memory = (
         data_size
         + pk_size_bytes

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -179,7 +179,9 @@ def merge_resource_options_provider(
     data_size = hash_group_size_bytes.get(hb_group_idx, 0)
     num_rows = hash_group_num_rows.get(hb_group_idx, 0)
 
-    pk_size_bytes = 0
+    # upper bound for pk size of incremental
+    pk_size_bytes = data_size
+    incremental_index_array_size = num_rows * 4
 
     if (
         round_completion_info
@@ -231,7 +233,13 @@ def merge_resource_options_provider(
                         pk_size_bytes += pk_size
 
     # total data downloaded + primary key hash column + primary key column + dict size for merge
-    total_memory = data_size + pk_size_bytes + num_rows * 20 + num_rows * 20
+    total_memory = (
+        data_size
+        + pk_size_bytes
+        + num_rows * 20
+        + num_rows * 20
+        + incremental_index_array_size
+    )
 
     total_memory = total_memory * (1 + TOTAL_MEMORY_BUFFER_PERCENTAGE / 100.0)
 

--- a/deltacat/utils/ray_utils/concurrency.py
+++ b/deltacat/utils/ray_utils/concurrency.py
@@ -1,5 +1,4 @@
 import copy
-import itertools
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 from deltacat.utils.placement import PlacementGroupConfig
 import ray
@@ -49,20 +48,12 @@ def invoke_parallel(
     if max_parallelism is not None and max_parallelism <= 0:
         raise ValueError(f"Max parallelism ({max_parallelism}) must be > 0.")
     pending_ids = []
+    remaining_refs = []
+
     for i, item in enumerate(items):
-        if max_parallelism is not None and len(pending_ids) > max_parallelism:
-            # Some tasks return multiple values while others have only return one.
-            # For multiple return values we flatten the list of pending futures.
-            # TODO (pdames): Support tasks with an unbound number of return values.
-            if isinstance(pending_ids[0], list):
-                ray.wait(
-                    list(itertools.chain(*pending_ids)),
-                    num_returns=int(
-                        len(pending_ids[0]) * (len(pending_ids) - max_parallelism)
-                    ),
-                )
-            else:
-                ray.wait(pending_ids, num_returns=len(pending_ids) - max_parallelism)
+        if max_parallelism is not None and len(remaining_refs) > max_parallelism:
+            _, remaining_refs = ray.wait(remaining_refs, num_returns=1)
+
         opt = {}
         if options_provider:
             opt = options_provider(i, item)
@@ -72,7 +63,10 @@ def invoke_parallel(
             kwargs_dict = kwargs_provider(i, item)
             kwargs.update(kwargs_dict)
             pending_id = ray_task.options(**opt).remote(*args, **kwargs)
+
         pending_ids.append(pending_id)
+        remaining_refs.append(pending_id)
+
     return pending_ids
 
 

--- a/deltacat/utils/ray_utils/concurrency.py
+++ b/deltacat/utils/ray_utils/concurrency.py
@@ -52,7 +52,9 @@ def invoke_parallel(
 
     for i, item in enumerate(items):
         if max_parallelism is not None and len(remaining_refs) > max_parallelism:
-            _, remaining_refs = ray.wait(remaining_refs, num_returns=1)
+            _, remaining_refs = ray.wait(
+                remaining_refs, num_returns=1, fetch_local=False
+            )
 
         opt = {}
         if options_provider:


### PR DESCRIPTION
#150 

- [x] Incremental index array size estimation. 
- [x] numpy + operator was appending elements instead of adding due to correct shape inference when all chunks are of same length. 
- [x] Reduce the ray.wait time complexity from O(N^2) to O(N). 
- [x] Set fetch_local=False so that ray.wait can return without downloading the object to node for performance.  