### PR TITLE
Upgrade Daft to 0.1.17 for improved performance and resource usage

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.1.19b1"
+__version__ = "0.1.20"
 
 
 __all__ = [

--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.1.19"
+__version__ = "0.1.19b1"
 
 
 __all__ = [

--- a/deltacat/aws/constants.py
+++ b/deltacat/aws/constants.py
@@ -2,6 +2,7 @@ from typing import List
 
 from deltacat.utils.common import env_integer, env_string
 
+DAFT_MAX_S3_CONNECTIONS_PER_FILE = env_integer("DAFT_MAX_S3_CONNECTIONS_PER_FILE", 8)
 BOTO_MAX_RETRIES = env_integer("BOTO_MAX_RETRIES", 15)
 TIMEOUT_ERROR_CODES: List[str] = ["ReadTimeoutError", "ConnectTimeoutError"]
 AWS_REGION = env_string("AWS_REGION", "us-east-1")

--- a/deltacat/tests/utils/test_daft.py
+++ b/deltacat/tests/utils/test_daft.py
@@ -69,11 +69,11 @@ class TestDaftParquetReader(unittest.TestCase):
             include_columns=["a", "b"],
             pa_read_func_kwargs_provider=pa_read_func_kwargs_provider,
         )
-        self.assertEqual(table.schema.names, ["a", "b"])
+        self.assertEqual(table.schema.names, ["a", "b"])  # NOTE: Order matches `include_columns`
         self.assertEqual(table.schema.field("a").type, pa.int8())
         self.assertEqual(table.num_rows, 100)
 
-    def test_read_from_s3_single_column_with_schema_missing_some(self):
+    def test_read_from_s3_single_column_with_schema_subset_cols(self):
         schema = pa.schema([("a", pa.int8())])
         pa_read_func_kwargs_provider = ReadKwargsProviderPyArrowSchemaOverride(
             schema=schema
@@ -82,11 +82,26 @@ class TestDaftParquetReader(unittest.TestCase):
             self.MVP_PATH,
             content_encoding=ContentEncoding.IDENTITY.value,
             content_type=ContentType.PARQUET.value,
-            include_columns=["a", "b"],
             pa_read_func_kwargs_provider=pa_read_func_kwargs_provider,
         )
-        self.assertEqual(table.schema.names, ["a", "b"])
+        self.assertEqual(table.schema.names, ["a"])
         self.assertEqual(table.schema.field("a").type, pa.int8())
+        self.assertEqual(table.num_rows, 100)
+
+    def test_read_from_s3_single_column_with_schema_extra_cols(self):
+        schema = pa.schema([("a", pa.int8()), ("MISSING", pa.string())])
+        pa_read_func_kwargs_provider = ReadKwargsProviderPyArrowSchemaOverride(
+            schema=schema
+        )
+        table = daft_s3_file_to_table(
+            self.MVP_PATH,
+            content_encoding=ContentEncoding.IDENTITY.value,
+            content_type=ContentType.PARQUET.value,
+            pa_read_func_kwargs_provider=pa_read_func_kwargs_provider,
+        )
+        self.assertEqual(table.schema.names, ["a", "MISSING"])  # NOTE: "MISSING" is padded as a null array
+        self.assertEqual(table.schema.field("a").type, pa.int8())
+        self.assertEqual(table.schema.field("MISSING").type, pa.string())
         self.assertEqual(table.num_rows, 100)
 
     def test_read_from_s3_single_column_with_row_groups(self):

--- a/deltacat/tests/utils/test_daft.py
+++ b/deltacat/tests/utils/test_daft.py
@@ -66,10 +66,9 @@ class TestDaftParquetReader(unittest.TestCase):
             self.MVP_PATH,
             content_encoding=ContentEncoding.IDENTITY.value,
             content_type=ContentType.PARQUET.value,
-            include_columns=["a", "b"],
             pa_read_func_kwargs_provider=pa_read_func_kwargs_provider,
         )
-        self.assertEqual(table.schema.names, ["a", "b"])  # NOTE: Order matches `include_columns`
+        self.assertEqual(table.schema.names, ["b", "a"])
         self.assertEqual(table.schema.field("a").type, pa.int8())
         self.assertEqual(table.num_rows, 100)
 

--- a/deltacat/tests/utils/test_daft.py
+++ b/deltacat/tests/utils/test_daft.py
@@ -98,7 +98,9 @@ class TestDaftParquetReader(unittest.TestCase):
             content_type=ContentType.PARQUET.value,
             pa_read_func_kwargs_provider=pa_read_func_kwargs_provider,
         )
-        self.assertEqual(table.schema.names, ["a", "MISSING"])  # NOTE: "MISSING" is padded as a null array
+        self.assertEqual(
+            table.schema.names, ["a", "MISSING"]
+        )  # NOTE: "MISSING" is padded as a null array
         self.assertEqual(table.schema.field("a").type, pa.int8())
         self.assertEqual(table.schema.field("MISSING").type, pa.string())
         self.assertEqual(table.num_rows, 100)

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -79,12 +79,11 @@ def daft_s3_file_to_table(
 
     if kwargs.get("schema") is not None:
         input_schema = kwargs["schema"]
-        input_schema_names = set(input_schema.names)
-
         if include_columns is not None:
             input_schema = pa.schema([input_schema.field(col) for col in include_columns])
         elif column_names is not None:
             input_schema = pa.schema([input_schema.field(col) for col in column_names])
+        input_schema_names = set(input_schema.names)
 
         # Perform casting of types to provided schema's types
         cast_to_schema = [

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -10,7 +10,7 @@ from deltacat import logs
 from deltacat.utils.common import ReadKwargsProvider
 
 from deltacat.types.media import ContentType, ContentEncoding
-from deltacat.aws.constants import BOTO_MAX_RETRIES
+from deltacat.aws.constants import BOTO_MAX_RETRIES, DAFT_MAX_S3_CONNECTIONS_PER_FILE
 from deltacat.utils.performance import timed_invocation
 
 from deltacat.types.partial_download import (
@@ -88,6 +88,7 @@ def daft_s3_file_to_table(
             session_token=s3_client_kwargs.get("aws_session_token"),
             retry_mode="adaptive",
             num_tries=BOTO_MAX_RETRIES,
+            max_connections=DAFT_MAX_S3_CONNECTIONS_PER_FILE,
         )
     )
 

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -106,8 +106,7 @@ def daft_s3_file_to_table(
                 columns.append(
                     pa.nulls(len(casted_table), type=input_schema.field(name).type)
                 )
-        return pa.Table.from_arrays(
-            columns, names=input_schema.names, metadata=pa_table.schema.metadata
-        )
+        schema = input_schema.with_metadata(pa_table.schema.metadata)
+        return pa.table(columns, schema=schema)
     else:
         return pa_table

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -102,12 +102,7 @@ def daft_s3_file_to_table(
             if name in pa_table_column_names:
                 columns.append(casted_table[name])
             else:
-                if name not in input_schema_names:
-                    raise ValueError(
-                        f"Provided column name {name} expected to be found in provided schema: {input_schema}"
-                    )
-                dtype = input_schema.field(name).type
-                columns.append(pa.nulls(len(casted_table), type=dtype))
+                columns.append(pa.nulls(len(casted_table), type=input_schema.field(name).type))
         return pa.Table.from_arrays(
             columns, names=input_schema.names, metadata=pa_table.schema.metadata
         )

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -22,9 +22,7 @@ from deltacat.types.partial_download import (
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
-def _apply_schema(
-    table_schema: pa.Schema, input_schema: pa.Schema
-) -> pa.Schema:
+def _apply_schema(table_schema: pa.Schema, input_schema: pa.Schema) -> pa.Schema:
     """Applies fields from the specified `input_schema` on the (inferred) `table_schema`
 
     Args:

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -1,8 +1,7 @@
 import logging
 from typing import Optional, List
 
-from daft.table import Table, read_parquet_into_pyarrow
-from daft.logical.schema import Schema
+from daft.table import read_parquet_into_pyarrow
 from daft import TimeUnit
 from daft.io import IOConfig, S3Config
 import pyarrow as pa

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -81,10 +81,14 @@ def daft_s3_file_to_table(
         input_schema = kwargs["schema"]
         if include_columns is not None:
             input_schema = pa.schema(
-                [input_schema.field(col) for col in include_columns]
+                [input_schema.field(col) for col in include_columns],
+                metadata=input_schema.metadata,
             )
         elif column_names is not None:
-            input_schema = pa.schema([input_schema.field(col) for col in column_names])
+            input_schema = pa.schema(
+                [input_schema.field(col) for col in column_names],
+                metadata=input_schema.metadata,
+            )
         input_schema_names = set(input_schema.names)
 
         # Perform casting of types to provided schema's types
@@ -106,7 +110,6 @@ def daft_s3_file_to_table(
                 columns.append(
                     pa.nulls(len(casted_table), type=input_schema.field(name).type)
                 )
-        schema = input_schema.with_metadata(pa_table.schema.metadata)
-        return pa.table(columns, schema=schema)
+        return pa.table(columns, schema=input_schema)
     else:
         return pa_table

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -21,7 +21,9 @@ from deltacat.types.partial_download import (
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
-def _apply_schema(table_schema: pa.Schema, input_schema: pa.Schema) -> pa.Schema:
+def _get_compatible_target_schema(
+    table_schema: pa.Schema, input_schema: pa.Schema
+) -> pa.Schema:
     """Applies fields from the specified `input_schema` on the (inferred) `table_schema`
 
     Args:
@@ -108,7 +110,7 @@ def daft_s3_file_to_table(
         input_schema = kwargs["schema"]
 
         table_schema = pa_table.schema
-        target_schema = _apply_schema(table_schema, input_schema)
+        target_schema = _get_compatible_target_schema(table_schema, input_schema)
         return pa_table.cast(target_schema)
     else:
         return pa_table

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -80,7 +80,9 @@ def daft_s3_file_to_table(
     if kwargs.get("schema") is not None:
         input_schema = kwargs["schema"]
         if include_columns is not None:
-            input_schema = pa.schema([input_schema.field(col) for col in include_columns])
+            input_schema = pa.schema(
+                [input_schema.field(col) for col in include_columns]
+            )
         elif column_names is not None:
             input_schema = pa.schema([input_schema.field(col) for col in column_names])
         input_schema_names = set(input_schema.names)
@@ -101,7 +103,9 @@ def daft_s3_file_to_table(
             if name in pa_table_column_names:
                 columns.append(casted_table[name])
             else:
-                columns.append(pa.nulls(len(casted_table), type=input_schema.field(name).type))
+                columns.append(
+                    pa.nulls(len(casted_table), type=input_schema.field(name).type)
+                )
         return pa.Table.from_arrays(
             columns, names=input_schema.names, metadata=pa_table.schema.metadata
         )

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -104,9 +104,13 @@ def daft_s3_file_to_table(
                 columns.append(casted_table[name])
             else:
                 if name not in input_schema_names:
-                    raise ValueError(f"Provided column name {name} expected to be found in provided schema: {input_schema}")
+                    raise ValueError(
+                        f"Provided column name {name} expected to be found in provided schema: {input_schema}"
+                    )
                 dtype = input_schema.field(name).type
                 columns.append(pa.nulls(len(casted_table), type=dtype))
-        return pa.Table.from_arrays(columns, names=expected_names, metadata=pa_table.schema.metadata)
+        return pa.Table.from_arrays(
+            columns, names=expected_names, metadata=pa_table.schema.metadata
+        )
     else:
         return pa_table

--- a/deltacat/utils/pyarrow.py
+++ b/deltacat/utils/pyarrow.py
@@ -32,7 +32,7 @@ from deltacat.types.partial_download import (
 )
 from deltacat.utils.common import ContentTypeKwargsProvider, ReadKwargsProvider
 from deltacat.utils.performance import timed_invocation
-from deltacat.utils.daft import daft_s3_file_to_table
+from deltacat.utils.daft import daft_s3_file_to_table, _get_compatible_target_schema
 from deltacat.utils.arguments import (
     sanitize_kwargs_to_callable,
     sanitize_kwargs_by_supported_kwargs,
@@ -312,25 +312,6 @@ def _add_column_kwargs(
                     f"Ignoring request to include columns {include_columns} "
                     f"for non-tabular content type {content_type}"
                 )
-
-
-def _get_compatible_target_schema(
-    table_schema: pa.Schema, input_schema: pa.Schema
-) -> pa.Schema:
-    target_schema_fields = []
-
-    for field in table_schema:
-        index = input_schema.get_field_index(field.name)
-
-        if index != -1:
-            target_field = input_schema.field(index)
-            target_schema_fields.append(target_field)
-        else:
-            target_schema_fields.append(field)
-
-    target_schema = pa.schema(target_schema_fields, metadata=table_schema.metadata)
-
-    return target_schema
 
 
 def s3_partial_parquet_file_to_table(

--- a/deltacat/utils/pyarrow.py
+++ b/deltacat/utils/pyarrow.py
@@ -32,7 +32,7 @@ from deltacat.types.partial_download import (
 )
 from deltacat.utils.common import ContentTypeKwargsProvider, ReadKwargsProvider
 from deltacat.utils.performance import timed_invocation
-from deltacat.utils.daft import daft_s3_file_to_table, _get_compatible_target_schema
+from deltacat.utils.daft import daft_s3_file_to_table
 from deltacat.utils.arguments import (
     sanitize_kwargs_to_callable,
     sanitize_kwargs_by_supported_kwargs,
@@ -312,6 +312,25 @@ def _add_column_kwargs(
                     f"Ignoring request to include columns {include_columns} "
                     f"for non-tabular content type {content_type}"
                 )
+
+
+def _get_compatible_target_schema(
+    table_schema: pa.Schema, input_schema: pa.Schema
+) -> pa.Schema:
+    target_schema_fields = []
+
+    for field in table_schema:
+        index = input_schema.get_field_index(field.name)
+
+        if index != -1:
+            target_field = input_schema.field(index)
+            target_schema_fields.append(target_field)
+        else:
+            target_schema_fields.append(field)
+
+    target_schema = pa.schema(target_schema_fields, metadata=table_schema.metadata)
+
+    return target_schema
 
 
 def s3_partial_parquet_file_to_table(

--- a/deltacat/utils/schema.py
+++ b/deltacat/utils/schema.py
@@ -1,0 +1,42 @@
+import pyarrow as pa
+
+
+def coerce_pyarrow_table_to_schema(
+    pa_table: pa.Table, input_schema: pa.Schema
+) -> pa.Table:
+    """Coerces a PyArrow table to the supplied schema
+
+    1. For each field in `pa_table`, cast it to the field in `input_schema` if one with a matching name
+        is available
+    2. Reorder the fields in the casted table to the supplied schema
+    3. If any fields in the supplied schema are not present, add a null array of the correct type
+
+    Args:
+        pa_table (pa.Table): Table to coerce
+        input_schema (pa.Schema): Schema to coerce to
+
+    Returns:
+        pa.Table: Table with schema == `input_schema`
+    """
+    input_schema_names = set(input_schema.names)
+
+    # Perform casting of types to provided schema's types
+    cast_to_schema = [
+        input_schema.field(inferred_field.name)
+        if inferred_field.name in input_schema_names
+        else inferred_field
+        for inferred_field in pa_table.schema
+    ]
+    casted_table = pa_table.cast(pa.schema(cast_to_schema))
+
+    # Reorder and pad columns with a null column where necessary
+    pa_table_column_names = set(casted_table.column_names)
+    columns = []
+    for name in input_schema.names:
+        if name in pa_table_column_names:
+            columns.append(casted_table[name])
+        else:
+            columns.append(
+                pa.nulls(len(casted_table), type=input_schema.field(name).type)
+            )
+    return pa.table(columns, schema=input_schema)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # setup.py install_requires
 # any changes here should also be reflected in setup.py "install_requires"
 boto3 ~= 1.20
-getdaft==0.1.16
+getdaft==0.1.17
 numpy == 1.21.5
 pandas == 1.3.5
 pyarrow == 12.0.1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         "typing-extensions == 4.4.0",
         "pymemcache == 4.0.0",
         "redis == 4.6.0",
-        "getdaft == 0.1.16",
+        "getdaft == 0.1.17",
         "schedule == 1.2.0",
     ],
     setup_requires=["wheel"],


### PR DESCRIPTION
* Lowers peak memory utilization by 50%
* Introduces eager memory cleanup in jemalloc memory allocator, reducing resting memory utilization
* Speeds up "all-column" reads by 48%
* Adds max connection limit of 8 per file
* Produce an Arrow chunked table directly to work around any schema-related issues when interoperating with PyArrow

These changes come with an API change, where Daft now provides a `read_parquet_into_pyarrow` function which returns a chunked PyArrow table directly. This PR introduces changes to use this new API as well.

Daft PRs that added these improvements:
* Adds API to read directly into a PyArrow table: https://github.com/Eventual-Inc/Daft/pull/1366
* Optimize parquet page reading with streams: https://github.com/Eventual-Inc/Daft/pull/1365
* Add Configurable thread io size: https://github.com/Eventual-Inc/Daft/pull/1363
* Add flag to limit connections to S3: https://github.com/Eventual-Inc/Daft/pull/1360
* Enable jemalloc background thread cleaning: https://github.com/Eventual-Inc/Daft/pull/1361