### PR TITLE
Use `coerce_pyarrow_table_to_schema` in pyarrow download

### DIFF
--- a/deltacat/tests/utils/test_pyarrow.py
+++ b/deltacat/tests/utils/test_pyarrow.py
@@ -85,7 +85,9 @@ class TestS3PartialParquetFileToTable(TestCase):
         self.assertEqual(result_schema.field(2).type, "int64")
         self.assertEqual(result_schema.field(2).name, "MISSING")
 
-    def test_s3_partial_parquet_file_to_table_when_schema_passed_with_include_columns(self):
+    def test_s3_partial_parquet_file_to_table_when_schema_passed_with_include_columns(
+        self,
+    ):
 
         pq_file = ParquetFile(PARQUET_FILE_PATH)
         partial_parquet_params = PartialParquetParameters.of(

--- a/deltacat/utils/schema.py
+++ b/deltacat/utils/schema.py
@@ -8,7 +8,8 @@ def coerce_pyarrow_table_to_schema(
 
     1. For each field in `pa_table`, cast it to the field in `input_schema` if one with a matching name
         is available
-    2. Reorder the fields in the casted table to the supplied schema
+    2. Reorder the fields in the casted table to the supplied schema, dropping any fields in `pa_table`
+        that do not exist in the supplied schema
     3. If any fields in the supplied schema are not present, add a null array of the correct type
 
     Args:


### PR DESCRIPTION
This PR shares `coerce_pyarrow_table_to_schema` across `pyarrow.py` and `daft.py` utility files

This utility will apply a provided schema (`input_schema`) to a table that is read from a file. This application has the following properties, as documented in the function docstring:

```
    1. For each field in `pa_table`, cast it to the field in `input_schema` if one with a matching name
        is available
    2. Reorder the fields in the casted table to the supplied schema, dropping any fields in `pa_table`
        that do not exist in the supplied schema
    3. If any fields in the supplied schema are not present, add a null array of the correct type
```

Note that this is a departure from the current behavior in `pyarrow.py`, which leverages the `_get_compatible_target_schema` function (removed in this PR) and only performs `Step (1)` of the above steps.

Concretely this means that the current behavior will produce tables that have a different fields than the provided schema. This PR ensures that the tables produced will have exactly the same schema as the provided schema.