### PR TITLE
Derive optional metric configurations from metrics_config

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.1.20"
+__version__ = "0.2.0"
 
 
 __all__ = [

--- a/deltacat/utils/metrics.py
+++ b/deltacat/utils/metrics.py
@@ -4,7 +4,7 @@ import logging
 
 from deltacat import logs
 from enum import Enum
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Callable
 from deltacat.aws.clients import resource_cache
 from datetime import datetime
 
@@ -73,8 +73,8 @@ def _emit_metrics(
     assert isinstance(
         metrics_target, MetricsTarget
     ), f"{metrics_target} is not a valid supported metrics target type! "
-    if metrics_target == MetricsTarget.CLOUDWATCH:
-        _emit_cloudwatch_metrics(
+    if metrics_target in METRICS_TARGET_TO_EMITTER_DICT:
+        METRICS_TARGET_TO_EMITTER_DICT.get(metrics_target)(
             metrics_name=metrics_name,
             metrics_type=metrics_type,
             metrics_config=metrics_config,
@@ -115,6 +115,11 @@ def _emit_cloudwatch_metrics(
             f"Failed to publish Cloudwatch metrics with name: {metrics_name}, "
             f"type: {metrics_type}, with exception: {e}, response: {response}"
         )
+
+
+METRICS_TARGET_TO_EMITTER_DICT: Dict[str, Callable] = {
+    MetricsTarget.CLOUDWATCH: _emit_cloudwatch_metrics,
+}
 
 
 def emit_timer_metrics(metrics_name, value, metrics_config, **kwargs):

--- a/deltacat/utils/metrics.py
+++ b/deltacat/utils/metrics.py
@@ -1,15 +1,13 @@
 from dataclasses import dataclass
 
-import ray
 import logging
 
 from deltacat import logs
 from enum import Enum
-from typing import Dict, Any, List, Callable
+from typing import Dict, Any, List
 from deltacat.aws.clients import resource_cache
 from datetime import datetime
 
-from ray._private.services import get_node_ip_address
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
@@ -22,20 +20,21 @@ class MetricsTarget(str, Enum):
 
 @dataclass
 class MetricsConfig:
-    def __init__(self, region: str, job_run_id: str, metrics_target: MetricsTarget):
+    def __init__(
+        self,
+        region: str,
+        metrics_target: MetricsTarget,
+        metrics_namespace: str = DEFAULT_DELTACAT_METRICS_NAMESPACE,
+        metrics_dimensions: List[Dict[str, str]] = [],
+    ):
         self.region = region
-        self.job_run_id = job_run_id
         self.metrics_target = metrics_target
+        self.metrics_namespace = metrics_namespace
+        self.metrics_dimensions = metrics_dimensions
 
 
 class MetricsType(str, Enum):
     TIMER = "timer"
-
-
-class MetricsDimensionType(str, Enum):
-    NODE_IP = "node_ip"
-    RAY_TASK_ID = "task_id"
-    RAY_WORKER_ID = "worker_id"
 
 
 def _build_metrics_name(metrics_type: Enum, metrics_name: str) -> str:
@@ -43,50 +42,19 @@ def _build_metrics_name(metrics_type: Enum, metrics_name: str) -> str:
     return metrics_name_with_type
 
 
-def _get_current_node_ip() -> str:
-    current_node_ip = get_node_ip_address()
-    return {"Name": f"node_ip", "Value": f"{current_node_ip}"}
-
-
-def _get_current_task_id() -> Dict[str, Any]:
-    return {
-        "Name": f"ray_task_id",
-        "Value": f"{ray.get_runtime_context().get_task_id()}",
-    }
-
-
-def _get_current_worker_id() -> Dict[str, Any]:
-    return {
-        "Name": f"ray_worker_id",
-        "Value": f"{ray.get_runtime_context().worker.core_worker.get_worker_id()}",
-    }
-
-
-METRICS_DIMENSION_TYPE_TO_VALUE_DICT: Dict[str, Callable] = {
-    MetricsDimensionType.NODE_IP.value: _get_current_node_ip,
-    MetricsDimensionType.RAY_TASK_ID.value: _get_current_task_id,
-    MetricsDimensionType.RAY_WORKER_ID.value: _get_current_worker_id,
-}
-
-
 def _build_cloudwatch_metrics(
     metrics_name: str,
     metrics_type: Enum,
     value: str,
-    dimension_types: List[Enum],
+    metrics_dimensions: List[Dict[str, str]],
     timestamp: datetime,
     **kwargs,
 ) -> Dict[str, Any]:
     metrics_name_with_type = _build_metrics_name(metrics_type, metrics_name)
-    dimensions = []
-    for dimension_type in dimension_types:
-        dimensions.append(
-            METRICS_DIMENSION_TYPE_TO_VALUE_DICT.get(dimension_type.value)()
-        )
     return [
         {
             "MetricName": f"{metrics_name_with_type}",
-            "Dimensions": dimensions,
+            "Dimensions": metrics_dimensions,
             "Timestamp": timestamp,
             "Value": value,
             **kwargs,
@@ -99,7 +67,6 @@ def _emit_metrics(
     metrics_type: Enum,
     metrics_config: MetricsConfig,
     value: str,
-    dimension_types: List[Enum],
     **kwargs,
 ) -> None:
     metrics_target = metrics_config.metrics_target
@@ -112,7 +79,6 @@ def _emit_metrics(
             metrics_type=metrics_type,
             metrics_config=metrics_config,
             value=value,
-            dimension_types=dimension_types,
             **kwargs,
         )
     else:
@@ -124,20 +90,24 @@ def _emit_cloudwatch_metrics(
     metrics_type: Enum,
     metrics_config: MetricsConfig,
     value: str,
-    dimension_types: List[Enum],
     **kwargs,
 ) -> None:
     ct = datetime.now()
     current_instance_region = metrics_config.region
     cloudwatch_resource = resource_cache("cloudwatch", current_instance_region)
     cloudwatch_client = cloudwatch_resource.meta.client
+
+    metrics_namespace = metrics_config.metrics_namespace
+    metrics_dimensions = metrics_config.metrics_dimensions
+
     metrics_data = _build_cloudwatch_metrics(
-        metrics_name, metrics_type, value, dimension_types, ct, **kwargs
+        metrics_name, metrics_type, value, metrics_dimensions, ct, **kwargs
     )
-    job_run_id = metrics_config.job_run_id
+
+    response = None
     try:
         response = cloudwatch_client.put_metric_data(
-            Namespace=f"{DEFAULT_DELTACAT_METRICS_NAMESPACE}_{job_run_id}",
+            Namespace=metrics_namespace,
             MetricData=metrics_data,
         )
     except Exception as e:
@@ -148,16 +118,10 @@ def _emit_cloudwatch_metrics(
 
 
 def emit_timer_metrics(metrics_name, value, metrics_config, **kwargs):
-    metrics_dimension_type = [
-        MetricsDimensionType.NODE_IP,
-        MetricsDimensionType.RAY_TASK_ID,
-        MetricsDimensionType.RAY_WORKER_ID,
-    ]
     _emit_metrics(
         metrics_name=metrics_name,
         metrics_type=MetricsType.TIMER,
         metrics_config=metrics_config,
         value=value,
-        dimension_types=metrics_dimension_type,
         **kwargs,
     )


### PR DESCRIPTION
The current implementation explicitly sets metric dimensions and namespace. These configurations are not necessarily desired by everybody, and thus should be derived from the passed-in metrics_config object instead. 

This change will "break" existing metrics, thus necessitating a minor package version bump.

Testing
 - Changes were deployed locally and tested to ensure that both passing in and omitting namespace and dimensions worked properly