### PR TITLE
Persisting previous delta inflation and avg record sizes

### DIFF
--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -47,6 +47,8 @@ class RoundCompletionInfo(dict):
         hash_bucket_count: Optional[int] = None,
         hb_index_to_entry_range: Optional[Dict[int, Tuple[int, int]]] = None,
         compactor_version: Optional[str] = None,
+        input_inflation: Optional[float] = None,
+        input_average_record_size_bytes: Optional[float] = None,
     ) -> RoundCompletionInfo:
 
         rci = RoundCompletionInfo()
@@ -62,6 +64,8 @@ class RoundCompletionInfo(dict):
         rci["hashBucketCount"] = hash_bucket_count
         rci["hbIndexToEntryRange"] = hb_index_to_entry_range
         rci["compactorVersion"] = compactor_version
+        rci["inputInflation"] = input_inflation
+        rci["inputAverageRecordSizeBytes"] = input_average_record_size_bytes
         return rci
 
     @property
@@ -119,3 +123,11 @@ class RoundCompletionInfo(dict):
     @property
     def compactor_version(self) -> Optional[str]:
         return self.get("compactorVersion")
+
+    @property
+    def input_inflation(self) -> Optional[float]:
+        return self.get("inputInflation")
+
+    @property
+    def input_average_record_size_bytes(self) -> Optional[float]:
+        return self.get("inputAverageRecordSizeBytes")

--- a/deltacat/compute/compactor_v2/steps/merge.py
+++ b/deltacat/compute/compactor_v2/steps/merge.py
@@ -404,7 +404,7 @@ def _timed_merge(input: MergeInput) -> MergeResult:
 
                 logger.info(
                     f"[Merge task index {input.merge_task_index}] Merged "
-                    f"record count: {len(table)}, took: {merge_time}s"
+                    f"record count: {len(table)}, size={table.nbytes} took: {merge_time}s"
                 )
 
                 materialized_results.append(_materialize(hb_idx, [table]))

--- a/deltacat/tests/compute/compactor_v2/test_hashlib.py
+++ b/deltacat/tests/compute/compactor_v2/test_hashlib.py
@@ -1,0 +1,12 @@
+import hashlib
+
+
+def test_hashlib_sanity():
+    """
+    This test ensures that there is no change in hashlib behavior
+    across different python version. If there is, a rebase is required.
+    """
+    assert (
+        hashlib.sha1("test".encode("utf-8")).hexdigest()
+        == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
+    )

--- a/deltacat/tests/utils/test_resources.py
+++ b/deltacat/tests/utils/test_resources.py
@@ -48,3 +48,4 @@ class TestClusterUtilizationOverTimeRange(unittest.TestCase):
             )  # total is greater than used
             self.assertIsNotNone(cu.total_memory_gb_seconds)
             self.assertIsNotNone(cu.used_memory_gb_seconds)
+            self.assertIsNotNone(cu.max_cpu)

--- a/deltacat/utils/pyarrow.py
+++ b/deltacat/utils/pyarrow.py
@@ -368,7 +368,16 @@ def s3_partial_parquet_file_to_table(
                 [input_schema.field(col) for col in column_names],
                 metadata=input_schema.metadata,
             )
-        return coerce_pyarrow_table_to_schema(table, input_schema)
+        coerced_table, coerce_latency = timed_invocation(
+            coerce_pyarrow_table_to_schema, table, input_schema
+        )
+
+        logger.debug(
+            f"Coercing the PyArrow table of len {len(coerced_table)} "
+            f"into passed schema took {coerce_latency}s"
+        )
+
+        return coerced_table
 
     return table
 

--- a/deltacat/utils/resources.py
+++ b/deltacat/utils/resources.py
@@ -76,6 +76,7 @@ class ClusterUtilizationOverTimeRange(AbstractContextManager):
         self.used_vcpu_seconds = 0.0
         self.total_memory_gb_seconds = 0.0
         self.used_memory_gb_seconds = 0.0
+        self.max_cpu = 0.0
 
     def __enter__(self) -> Any:
         schedule.every().second.do(self._update_resources)
@@ -111,6 +112,7 @@ class ClusterUtilizationOverTimeRange(AbstractContextManager):
         self.total_vcpu_seconds = self.total_vcpu_seconds + float(
             str(cluster_resources["CPU"])
         )
+        self.max_cpu = max(self.max_cpu, float(str(cluster_resources["CPU"])))
 
         if "memory" not in cluster_resources:
             return


### PR DESCRIPTION
#150 

As part of this commit, we will persist input inflation and input average record sizes in round completion file. This will allow us to use it to infer sizes of upcoming incremental deltas. Though we have sizes of compacted, we don't have sizes for incremental delta. Hence, this approach has been found to provide most accurate figures instead of parquet uncompressed size in the parquet metadata. Moreover, this solution is generic and applies to any content type. 