### PR TITLE
0.2.0 file name has already been used, hence bumping up the version

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 __all__ = [


### PR DESCRIPTION
#150 

This commit only has a version bump. We bump up the version because the previous version 0.2.0 was already used.