### PR TITLE
Add functionality for emitting metrics through CloudWatch EMF

### DIFF
--- a/deltacat/utils/metrics.py
+++ b/deltacat/utils/metrics.py
@@ -2,20 +2,27 @@ from dataclasses import dataclass
 
 import logging
 
+from aws_embedded_metrics import metric_scope
+from aws_embedded_metrics.config import get_config
+from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
 from deltacat import logs
 from enum import Enum
 from typing import Dict, Any, List, Callable
 from deltacat.aws.clients import resource_cache
 from datetime import datetime
 
+from ray._private.services import get_node_ip_address
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 DEFAULT_DELTACAT_METRICS_NAMESPACE = "ray-deltacat-metrics"
+DEFAULT_DELTACAT_LOG_GROUP_NAME = "ray-deltacat-metrics-EMF-logs"
+DEFAULT_DELTACAT_LOG_STREAM_CALLABLE = get_node_ip_address
 
 
 class MetricsTarget(str, Enum):
     CLOUDWATCH = "cloudwatch"
+    CLOUDWATCH_EMF = "cloudwatch_emf"
 
 
 @dataclass
@@ -26,11 +33,13 @@ class MetricsConfig:
         metrics_target: MetricsTarget,
         metrics_namespace: str = DEFAULT_DELTACAT_METRICS_NAMESPACE,
         metrics_dimensions: List[Dict[str, str]] = [],
+        metrics_kwargs: Dict[str, Any] = {},
     ):
         self.region = region
         self.metrics_target = metrics_target
         self.metrics_namespace = metrics_namespace
         self.metrics_dimensions = metrics_dimensions
+        self.metrics_kwargs = metrics_kwargs
 
 
 class MetricsType(str, Enum):
@@ -48,7 +57,7 @@ def _build_cloudwatch_metrics(
     value: str,
     metrics_dimensions: List[Dict[str, str]],
     timestamp: datetime,
-    **kwargs,
+    **metrics_kwargs,
 ) -> Dict[str, Any]:
     metrics_name_with_type = _build_metrics_name(metrics_type, metrics_name)
     return [
@@ -57,7 +66,7 @@ def _build_cloudwatch_metrics(
             "Dimensions": metrics_dimensions,
             "Timestamp": timestamp,
             "Value": value,
-            **kwargs,
+            **metrics_kwargs,
         }
     ]
 
@@ -67,7 +76,6 @@ def _emit_metrics(
     metrics_type: Enum,
     metrics_config: MetricsConfig,
     value: str,
-    **kwargs,
 ) -> None:
     metrics_target = metrics_config.metrics_target
     assert isinstance(
@@ -79,7 +87,6 @@ def _emit_metrics(
             metrics_type=metrics_type,
             metrics_config=metrics_config,
             value=value,
-            **kwargs,
         )
     else:
         logger.warning(f"{metrics_target} is not a supported metrics target type.")
@@ -90,7 +97,6 @@ def _emit_cloudwatch_metrics(
     metrics_type: Enum,
     metrics_config: MetricsConfig,
     value: str,
-    **kwargs,
 ) -> None:
     ct = datetime.now()
     current_instance_region = metrics_config.region
@@ -101,7 +107,12 @@ def _emit_cloudwatch_metrics(
     metrics_dimensions = metrics_config.metrics_dimensions
 
     metrics_data = _build_cloudwatch_metrics(
-        metrics_name, metrics_type, value, metrics_dimensions, ct, **kwargs
+        metrics_name,
+        metrics_type,
+        value,
+        metrics_dimensions,
+        ct,
+        **metrics_config.metrics_kwargs,
     )
 
     response = None
@@ -117,8 +128,50 @@ def _emit_cloudwatch_metrics(
         )
 
 
+@metric_scope
+def _emit_cloudwatch_emf_metrics(
+    metrics: MetricsLogger,
+    metrics_name: str,
+    metrics_type: Enum,
+    metrics_config: MetricsConfig,
+    value: str,
+) -> None:
+    dimensions = dict(
+        [(dim["Name"], dim["Value"]) for dim in metrics_config.metrics_dimensions]
+    )
+    metrics_name_with_type = _build_metrics_name(metrics_type, metrics_name)
+    try:
+        # TODO: Check if use_default should be set to false
+        metrics.set_dimensions(dimensions)
+        metrics.set_namespace(metrics_config.metrics_namespace)
+
+        metrics_kwargs = metrics_config.metrics_kwargs
+
+        Config = get_config()
+        Config.log_group_name = (
+            metrics_kwargs["log_group_name"]
+            if "log_group_name" in metrics_kwargs
+            else DEFAULT_DELTACAT_LOG_GROUP_NAME
+        )
+
+        # use a callable to differentiate many possible log streams
+        Config.log_stream_name = (
+            metrics_kwargs["log_stream_name"]()
+            if "log_stream_name" in metrics_kwargs
+            else DEFAULT_DELTACAT_LOG_STREAM_CALLABLE
+        )
+
+        metrics.put_metric(metrics_name_with_type, value)
+    except Exception as e:
+        logger.warning(
+            f"Failed to publish Cloudwatch EMF metrics with name: {metrics_name_with_type}, "
+            f"type: {metrics_type}, with exception: {e}"
+        )
+
+
 METRICS_TARGET_TO_EMITTER_DICT: Dict[str, Callable] = {
     MetricsTarget.CLOUDWATCH: _emit_cloudwatch_metrics,
+    MetricsTarget.CLOUDWATCH_EMF: _emit_cloudwatch_emf_metrics,
 }
 
 
@@ -128,5 +181,4 @@ def emit_timer_metrics(metrics_name, value, metrics_config, **kwargs):
         metrics_type=MetricsType.TIMER,
         metrics_config=metrics_config,
         value=value,
-        **kwargs,
     )

--- a/deltacat/utils/metrics.py
+++ b/deltacat/utils/metrics.py
@@ -136,12 +136,13 @@ def _emit_cloudwatch_emf_metrics(
     metrics_config: MetricsConfig,
     value: str,
 ) -> None:
+    ct = datetime.now()
     dimensions = dict(
         [(dim["Name"], dim["Value"]) for dim in metrics_config.metrics_dimensions]
     )
     metrics_name_with_type = _build_metrics_name(metrics_type, metrics_name)
     try:
-        # TODO: Check if use_default should be set to false
+        metrics.set_timestamp(ct)
         metrics.set_dimensions(dimensions)
         metrics.set_namespace(metrics_config.metrics_namespace)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # setup.py install_requires
 # any changes here should also be reflected in setup.py "install_requires"
+aws-embedded-metrics == 3.1.1
 boto3 ~= 1.20
 getdaft==0.1.17
 numpy == 1.21.5

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where=".", include="deltacat*"),
     install_requires=[
         # any changes here should also be reflected in requirements.txt
+        "aws-embedded-metrics == 3.1.1",
         "boto3 ~= 1.20",
         "numpy == 1.21.5",
         "pandas == 1.3.5",


### PR DESCRIPTION
CloudWatch Embedded Metric Format (EMF) allows for emitting metrics through logs. Using the `aws_embedded_metrics` library, the CloudWatch agent is leveraged to emit EMF logs. This PR adds this metrics option to deltacat.

Testing
 - Tested locally by varying/omitting each field