### PR TITLE
Simplify the hash initialization in the memcached object store

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 
 __all__ = [

--- a/deltacat/compute/compactor_v2/utils/primary_key_index.py
+++ b/deltacat/compute/compactor_v2/utils/primary_key_index.py
@@ -317,6 +317,10 @@ def group_hash_bucket_indices(
             hash_group_to_num_rows[hb_group],
         )
         del object_ref
+
+    _, close_latency = timed_invocation(object_store.close)
+    logger.info(f"Active connections to the object store closed in {close_latency}")
+
     return hash_bucket_group_to_obj_id_size_tuple
 
 

--- a/deltacat/io/memcached_object_store.py
+++ b/deltacat/io/memcached_object_store.py
@@ -73,7 +73,7 @@ class MemcachedObjectStore(IObjectStore):
             if client.set(uid.__str__(), serialized, noreply=self.noreply):
                 return ref
             else:
-                raise RuntimeError("Unable to write to cache")
+                raise RuntimeError(f"Unable to write {ref} to cache")
         except BaseException as e:
             raise RuntimeError(
                 f"Received {e} while writing ref={ref} and obj size={len(serialized)}"

--- a/deltacat/io/object_store.py
+++ b/deltacat/io/object_store.py
@@ -49,3 +49,10 @@ class IObjectStore:
         """
         Clears the object store and all the associated data in it.
         """
+
+    def close(self, *args, **kwargs) -> None:
+        ...
+        """
+        Closes all the active connections to object store without clearing
+        the data in the object store.
+        """


### PR DESCRIPTION
#150 

This commit simplifies the hasher initialization. This also introduces a new method using which we can close all active connections to the object store. This method is particularly helpful whether we are done with the `object_store` object. 