### PR TITLE
Gracefully handle case where no new input deltas to compact

### DIFF
--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -378,13 +378,15 @@ def _discover_deltas(
     )
     deltas = deltas_list_result.all_items()
     if not deltas:
-        raise RuntimeError(
+        logger.info(
             f"Unexpected Error: Couldn't find any deltas to "
             f"compact in delta stream position range "
             f"('{start_position_exclusive}', "
             f"'{end_position_inclusive}']. Source partition: "
             f"{source_partition_locator}"
         )
+        return []
+
     if start_position_exclusive == deltas[0].stream_position:
         first_delta = deltas.pop(0)
         logger.info(

--- a/deltacat/compute/compactor/utils/io.py
+++ b/deltacat/compute/compactor/utils/io.py
@@ -378,8 +378,8 @@ def _discover_deltas(
     )
     deltas = deltas_list_result.all_items()
     if not deltas:
-        logger.info(
-            f"Unexpected Error: Couldn't find any deltas to "
+        logger.warn(
+            f"Couldn't find any deltas to "
             f"compact in delta stream position range "
             f"('{start_position_exclusive}', "
             f"'{end_position_inclusive}']. Source partition: "

--- a/deltacat/compute/compactor_v2/utils/io.py
+++ b/deltacat/compute/compactor_v2/utils/io.py
@@ -126,9 +126,6 @@ def create_uniform_input_deltas(
     logger.info(f"Input delta bytes to compact: {delta_bytes}")
     logger.info(f"Input delta files to compact: {delta_manifest_entries_count}")
 
-    if not input_da_list:
-        raise RuntimeError("No input deltas to compact!")
-
     size_estimation_function = functools.partial(
         estimate_manifest_entry_size_bytes, previous_inflation=previous_inflation
     )

--- a/deltacat/tests/compute/compactor_v2/steps/test_merge.py
+++ b/deltacat/tests/compute/compactor_v2/steps/test_merge.py
@@ -18,7 +18,7 @@ from deltacat.types.media import ContentType
 
 from deltacat.tests.test_utils.pyarrow import (
     create_delta_from_csv_file,
-    stage_partition_from_csv_file,
+    stage_partition_from_file_paths,
     commit_delta_to_staged_partition,
 )
 
@@ -55,7 +55,7 @@ class TestMerge(unittest.TestCase):
     def test_merge_multiple_hash_group_string_pk(self):
         number_of_hash_group = 2
         number_of_hash_bucket = 2
-        partition = stage_partition_from_csv_file(
+        partition = stage_partition_from_file_paths(
             self.MERGE_NAMESPACE,
             [self.DEDUPE_BASE_COMPACTED_TABLE_STRING_PK],
             **self.kwargs,
@@ -95,7 +95,7 @@ class TestMerge(unittest.TestCase):
     def test_merge_multiple_hash_group_multiple_pk(self):
         number_of_hash_group = 2
         number_of_hash_bucket = 2
-        partition = stage_partition_from_csv_file(
+        partition = stage_partition_from_file_paths(
             self.MERGE_NAMESPACE,
             [self.DEDUPE_WITH_DUPLICATION_MULTIPLE_PK],
             **self.kwargs,
@@ -139,7 +139,7 @@ class TestMerge(unittest.TestCase):
     def test_merge_multiple_hash_group_no_pk(self):
         number_of_hash_group = 2
         number_of_hash_bucket = 2
-        partition = stage_partition_from_csv_file(
+        partition = stage_partition_from_file_paths(
             self.MERGE_NAMESPACE,
             [self.NO_PK_TABLE],
             **self.kwargs,
@@ -184,7 +184,7 @@ class TestMerge(unittest.TestCase):
     def test_merge_multiple_hash_group_with_can_duplicate_false(self):
         number_of_hash_group = 2
         number_of_hash_bucket = 2
-        partition = stage_partition_from_csv_file(
+        partition = stage_partition_from_file_paths(
             self._testMethodName,
             [self.DEDUPE_WITH_DUPLICATION_MULTIPLE_PK],
             **self.kwargs,
@@ -229,7 +229,7 @@ class TestMerge(unittest.TestCase):
     def test_merge_when_delete_type_deltas_are_merged(self):
         number_of_hash_group = 1
         number_of_hash_bucket = 1
-        partition = stage_partition_from_csv_file(
+        partition = stage_partition_from_file_paths(
             self._testMethodName,
             [self.DEDUPE_BASE_COMPACTED_TABLE_MULTIPLE_PK],
             **self.kwargs,
@@ -298,7 +298,7 @@ class TestMerge(unittest.TestCase):
     def test_merge_incrementa_copy_by_reference_date_pk(self):
         number_of_hash_group = 2
         number_of_hash_bucket = 10
-        partition = stage_partition_from_csv_file(
+        partition = stage_partition_from_file_paths(
             self.MERGE_NAMESPACE,
             [self.DEDUPE_BASE_COMPACTED_TABLE_DATE_PK],
             **self.kwargs,

--- a/deltacat/tests/compute/compactor_v2/test_compaction_session.py
+++ b/deltacat/tests/compute/compactor_v2/test_compaction_session.py
@@ -1,0 +1,86 @@
+import unittest
+import sqlite3
+import ray
+import os
+from unittest.mock import patch
+import deltacat.tests.local_deltacat_storage as ds
+from deltacat.types.media import ContentType
+from deltacat.compute.compactor_v2.compaction_session import compact_partition
+from deltacat.compute.compactor.model.compact_partition_params import (
+    CompactPartitionParams,
+)
+from deltacat.utils.common import current_time_ms
+from deltacat.tests.test_utils.pyarrow import stage_partition_from_file_paths
+
+
+class TestCompactionSession(unittest.TestCase):
+    """
+    This class adds specific tests that aren't part of the parametrized test suite.
+    """
+
+    DB_FILE_PATH = f"{current_time_ms()}.db"
+    NAMESPACE = "compact_partition_v2_namespace"
+
+    @classmethod
+    def setUpClass(cls):
+        ray.init(local_mode=True, ignore_reinit_error=True)
+
+        con = sqlite3.connect(cls.DB_FILE_PATH)
+        cur = con.cursor()
+        cls.kwargs = {ds.SQLITE_CON_ARG: con, ds.SQLITE_CUR_ARG: cur}
+        cls.deltacat_storage_kwargs = {ds.DB_FILE_PATH_ARG: cls.DB_FILE_PATH}
+
+        super().setUpClass()
+
+    @classmethod
+    def doClassCleanups(cls) -> None:
+        os.remove(cls.DB_FILE_PATH)
+
+    @patch("deltacat.compute.compactor_v2.compaction_session.rcf")
+    @patch("deltacat.compute.compactor_v2.compaction_session.s3_utils")
+    def test_compact_partition_when_no_input_deltas_to_compact(self, s3_utils, rcf_url):
+        # setup
+        rcf_url.read_round_completion_file.return_value = None
+        staged_source = stage_partition_from_file_paths(
+            self.NAMESPACE, ["test"], **self.deltacat_storage_kwargs
+        )
+        source_partition = ds.commit_partition(
+            staged_source, **self.deltacat_storage_kwargs
+        )
+
+        staged_dest = stage_partition_from_file_paths(
+            self.NAMESPACE, ["destination"], **self.deltacat_storage_kwargs
+        )
+        dest_partition = ds.commit_partition(
+            staged_dest, **self.deltacat_storage_kwargs
+        )
+
+        # action
+        rcf_url = compact_partition(
+            CompactPartitionParams.of(
+                {
+                    "compaction_artifact_s3_bucket": "test_bucket",
+                    "compacted_file_content_type": ContentType.PARQUET,
+                    "dd_max_parallelism_ratio": 1.0,
+                    "deltacat_storage": ds,
+                    "deltacat_storage_kwargs": self.deltacat_storage_kwargs,
+                    "destination_partition_locator": dest_partition.locator,
+                    "drop_duplicates": True,
+                    "hash_bucket_count": 1,
+                    "last_stream_position_to_compact": source_partition.stream_position,
+                    "list_deltas_kwargs": {
+                        **self.deltacat_storage_kwargs,
+                        **{"equivalent_table_types": []},
+                    },
+                    "primary_keys": [],
+                    "rebase_source_partition_locator": None,
+                    "rebase_source_partition_high_watermark": None,
+                    "records_per_compacted_file": 4000,
+                    "s3_client_kwargs": {},
+                    "source_partition_locator": source_partition.locator,
+                }
+            )
+        )
+
+        # verify that no RCF is written
+        self.assertIsNone(rcf_url)

--- a/deltacat/tests/test_utils/pyarrow.py
+++ b/deltacat/tests/test_utils/pyarrow.py
@@ -7,7 +7,7 @@ import deltacat.tests.local_deltacat_storage as ds
 def create_delta_from_csv_file(
     namespace: str, file_paths: List[str], *args, **kwargs
 ) -> Delta:
-    staged_partition = stage_partition_from_csv_file(
+    staged_partition = stage_partition_from_file_paths(
         namespace, file_paths, *args, **kwargs
     )
 
@@ -18,7 +18,7 @@ def create_delta_from_csv_file(
     return committed_delta
 
 
-def stage_partition_from_csv_file(
+def stage_partition_from_file_paths(
     namespace: str, file_paths: List[str], *args, **kwargs
 ) -> Partition:
     ds.create_namespace(namespace, {}, **kwargs)


### PR DESCRIPTION
#150 

This commit aims to gracefully handle the case when there are not input deltas to compact. The added test case ensures that calling compact_partition when there are no new deltas to compact just returns `None`, in other words, is a NoOp. 