### PR TITLE
Fix EC2 instance metadata queries not getting caught by the retry handler

### DIFF
--- a/deltacat/aws/clients.py
+++ b/deltacat/aws/clients.py
@@ -1,6 +1,6 @@
 import logging
 from functools import lru_cache
-from typing import Optional, FrozenSet
+from typing import Optional
 from http import HTTPStatus
 
 import boto3
@@ -72,7 +72,6 @@ def retrying_get(
     retry_strategy,
     wait_strategy,
     stop_strategy,
-    short_circuit_on_status: FrozenSet[int] = {HTTPStatus.OK},
 ) -> Optional[Response]:
     """Retries a request to the given URL until it succeeds.
 
@@ -87,9 +86,6 @@ def retrying_get(
             failed after the maximum number of retries.
     """
     try:
-        resp = _get_url(url)
-        if resp.status_code in short_circuit_on_status:
-            return resp
         for attempt in Retrying(
             retry=retry_strategy(),
             wait=wait_strategy,
@@ -131,7 +127,6 @@ def block_until_instance_metadata_service_returns_success(
         retry_strategy,
         wait_strategy,
         stop_strategy,
-        short_circuit_on_status={HTTPStatus.OK, HTTPStatus.FORBIDDEN},
     )
 
 

--- a/deltacat/tests/aws/test_clients.py
+++ b/deltacat/tests/aws/test_clients.py
@@ -1,7 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 import unittest
 from http import HTTPStatus
 import requests
+from requests import HTTPError
 
 HAPPY_RESPONSE = {
     "AccessKeyId": "ASIA123456789",
@@ -65,6 +66,33 @@ class TestBlockUntilInstanceMetadataServiceReturnsSuccess(unittest.TestCase):
         self.assertEqual(
             block_until_instance_metadata_service_returns_success().status_code, 200
         )
+
+    @patch("deltacat.aws.clients.requests.get")
+    def test_retrying_on_initial_http_failures(self, requests_mock_get):
+        from deltacat.aws.clients import (
+            block_until_instance_metadata_service_returns_success,
+        )
+
+        mock_success_response = Mock()
+        mock_success_response.raise_for_status.return_value = None
+        mock_success_response.status_code = 200
+
+        mock_service_unavailable_response = Mock()
+        mock_service_unavailable_response.status_code = 503
+
+        mock_errors = []
+        for err in range(3):
+            mock_error_response = Mock()
+            mock_error_response.raise_for_status.side_effect = HTTPError(
+                response=mock_service_unavailable_response
+            )
+            mock_errors.append(mock_error_response)
+
+        requests_mock_get.side_effect = [*mock_errors, mock_success_response]
+        self.assertEqual(
+            block_until_instance_metadata_service_returns_success().status_code, 200
+        )
+        self.assertEqual(requests_mock_get.call_count, 4)
 
     @patch("deltacat.aws.clients.requests")
     def test_retrying_status_on_shortlist_returns_early(self, requests_mock):


### PR DESCRIPTION
The first call to `_get_url` may fail and raise an exception that is not caught by tenacity's retries.