### PR TITLE
Remove cluster_util from deltacat

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 
 __all__ = [

--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -1,5 +1,6 @@
 # Allow classes to use self-referencing Type hints in Python 3.7.
 from __future__ import annotations
+from typing import Optional
 import pyarrow as pa
 import logging
 from deltacat import logs
@@ -21,10 +22,18 @@ class CompactionSessionAuditInfo(dict):
     HASH_BUCKET_STEP_NAME = "hashBucket"
     MERGE_STEP_NAME = "merge"
 
-    def __init__(self, deltacat_version: str, ray_version: str, audit_url: str):
+    def __init__(
+        self,
+        deltacat_version: Optional[str] = None,
+        ray_version: Optional[str] = None,
+        audit_url: Optional[str] = None,
+        **kwargs,
+    ):
         self.set_deltacat_version(deltacat_version)
         self.set_ray_version(ray_version)
         self.set_audit_url(audit_url)
+        if kwargs:
+            self.update(kwargs)
 
     @property
     def audit_url(self) -> str:

--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 from typing import Tuple
 from deltacat.storage import DeltaLocator, PartitionLocator
 from deltacat.compute.compactor.model.pyarrow_write_result import PyArrowWriteResult
-from deltacat.compute.compactor.model.compaction_session_audit_info import (
-    CompactionSessionAuditInfo,
-)
 from typing import Any, Dict, Optional
 
 
@@ -98,8 +95,8 @@ class RoundCompletionInfo(dict):
         return self["sortKeysBitWidth"]
 
     @property
-    def compaction_audit(self) -> Optional[CompactionSessionAuditInfo]:
-        return self.get("compactionAudit")
+    def compaction_audit_url(self) -> Optional[str]:
+        return self.get("compactionAuditUrl")
 
     @property
     def rebase_source_partition_locator(self) -> Optional[PartitionLocator]:

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -489,12 +489,6 @@ def _execute_compaction(
         )
         compaction_audit.set_cluster_cpu_max(cluster_util.max_cpu)
 
-    s3_utils.upload(
-        compaction_audit.audit_url,
-        str(json.dumps(compaction_audit)),
-        **params.s3_client_kwargs,
-    )
-
     input_inflation = None
     input_average_record_size_bytes = None
     # Note: we only consider inflation for incremental delta
@@ -536,6 +530,12 @@ def _execute_compaction(
             (compaction_audit.input_records or 0)
             + round_completion_info.compacted_pyarrow_write_result.records
         )
+
+    s3_utils.upload(
+        compaction_audit.audit_url,
+        str(json.dumps(compaction_audit)),
+        **params.s3_client_kwargs,
+    )
 
     new_round_completion_info = RoundCompletionInfo.of(
         high_watermark=params.last_stream_position_to_compact,

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -47,7 +47,6 @@ from deltacat.compute.compactor_v2.utils.task_options import (
     hash_bucket_resource_options_provider,
     merge_resource_options_provider,
 )
-from deltacat.utils.resources import ClusterUtilizationOverTimeRange
 from deltacat.compute.compactor.model.compactor_version import CompactorVersion
 
 if importlib.util.find_spec("memray"):
@@ -65,10 +64,9 @@ def compact_partition(params: CompactPartitionParams, **kwargs) -> Optional[str]
 
     with memray.Tracker(
         f"compaction_partition.bin"
-    ) if params.enable_profiler else nullcontext(), ClusterUtilizationOverTimeRange() as cluster_util:
+    ) if params.enable_profiler else nullcontext():
         (new_partition, new_rci, new_rcf_partition_locator,) = _execute_compaction(
             params,
-            cluster_util=cluster_util,
             **kwargs,
         )
 
@@ -477,17 +475,6 @@ def _execute_compaction(
     compaction_audit.save_round_completion_stats(
         mat_results, telemetry_time_hb + telemetry_time_merge
     )
-
-    cluster_util: ClusterUtilizationOverTimeRange = kwargs.get("cluster_util")
-
-    if cluster_util:
-        compaction_audit.set_total_cpu_seconds(cluster_util.total_vcpu_seconds)
-        compaction_audit.set_used_cpu_seconds(cluster_util.used_vcpu_seconds)
-        compaction_audit.set_used_memory_gb_seconds(cluster_util.used_memory_gb_seconds)
-        compaction_audit.set_total_memory_gb_seconds(
-            cluster_util.total_memory_gb_seconds
-        )
-        compaction_audit.set_cluster_cpu_max(cluster_util.max_cpu)
 
     input_inflation = None
     input_average_record_size_bytes = None

--- a/deltacat/tests/compute/test_compact_partition_incremental.py
+++ b/deltacat/tests/compute/test_compact_partition_incremental.py
@@ -7,8 +7,9 @@ from typing import Any, Callable, Dict, List, Optional, Set
 from boto3.resources.base import ServiceResource
 import pyarrow as pa
 from deltacat.tests.compute.test_util_common import (
-    get_compacted_delta_locator_from_rcf,
+    get_rcf,
 )
+from deltacat.tests.test_utils.utils import read_s3_contents
 from deltacat.tests.compute.test_util_create_table_deltas_repo import (
     create_src_w_deltas_destination_plus_destination,
 )
@@ -167,6 +168,9 @@ def test_compact_partition_incremental(
         DeltaLocator,
         PartitionLocator,
     )
+    from deltacat.compute.compactor.model.compaction_session_audit_info import (
+        CompactionSessionAuditInfo,
+    )
     from deltacat.compute.compactor.model.compact_partition_params import (
         CompactPartitionParams,
     )
@@ -234,9 +238,20 @@ def test_compact_partition_incremental(
     # execute
     rcf_file_s3_uri = compact_partition_func(compact_partition_params)
     # validate
-    compacted_delta_locator: DeltaLocator = get_compacted_delta_locator_from_rcf(
-        setup_s3_resource, rcf_file_s3_uri
+    round_completion_info = get_rcf(setup_s3_resource, rcf_file_s3_uri)
+    compacted_delta_locator: DeltaLocator = (
+        round_completion_info.compacted_delta_locator
     )
+    audit_bucket, audit_key = round_completion_info.compaction_audit_url.replace(
+        "s3://", ""
+    ).split("/", 1)
+    compaction_audit_obj: dict = read_s3_contents(
+        setup_s3_resource, audit_bucket, audit_key
+    )
+    compaction_audit: CompactionSessionAuditInfo = CompactionSessionAuditInfo(
+        **compaction_audit_obj
+    )
+
     tables = ds.download_delta(compacted_delta_locator, **ds_mock_kwargs)
     actual_compacted_table = pa.concat_tables(tables)
     sorting_cols: List[Any] = [(val, "ascending") for val in primary_keys]
@@ -250,6 +265,11 @@ def test_compact_partition_incremental(
     actual_compacted_table = actual_compacted_table.combine_chunks().sort_by(
         sorting_cols
     )
+
+    assert compaction_audit.input_records == len(
+        input_deltas
+    ), "The input_records must be equal to total records in the input"
+
     assert actual_compacted_table.equals(
         expected_terminal_compact_partition_result
     ), f"{actual_compacted_table} does not match {expected_terminal_compact_partition_result}"

--- a/deltacat/tests/compute/test_util_common.py
+++ b/deltacat/tests/compute/test_util_common.py
@@ -134,20 +134,29 @@ def create_rebase_table(
     )
 
 
-def get_compacted_delta_locator_from_rcf(
-    s3_resource: ServiceResource, rcf_file_s3_uri: str
-):
+def get_rcf(s3_resource, rcf_file_s3_uri: str):
     from deltacat.tests.test_utils.utils import read_s3_contents
     from deltacat.compute.compactor import (
         RoundCompletionInfo,
     )
-    from deltacat.storage import DeltaLocator
 
     _, rcf_object_key = rcf_file_s3_uri.rsplit("/", 1)
     rcf_file_output: Dict[str, Any] = read_s3_contents(
         s3_resource, TEST_S3_RCF_BUCKET_NAME, rcf_object_key
     )
-    round_completion_info: RoundCompletionInfo = RoundCompletionInfo(**rcf_file_output)
+    return RoundCompletionInfo(**rcf_file_output)
+
+
+def get_compacted_delta_locator_from_rcf(
+    s3_resource: ServiceResource, rcf_file_s3_uri: str
+):
+    from deltacat.storage import DeltaLocator
+    from deltacat.compute.compactor import (
+        RoundCompletionInfo,
+    )
+
+    round_completion_info: RoundCompletionInfo = get_rcf(s3_resource, rcf_file_s3_uri)
+
     compacted_delta_locator: DeltaLocator = (
         round_completion_info.compacted_delta_locator
     )

--- a/deltacat/tests/compute/test_util_create_table_deltas_repo.py
+++ b/deltacat/tests/compute/test_util_create_table_deltas_repo.py
@@ -68,7 +68,6 @@ def create_src_w_deltas_destination_plus_destination(
     ds_mock_kwargs: Optional[Dict[str, Any]],
 ) -> Tuple[Stream, Stream, Optional[Stream]]:
     import deltacat.tests.local_deltacat_storage as ds
-    from deltacat.storage import Partition, Stream
 
     source_namespace, source_table_name, source_table_version = create_src_table(
         primary_keys, sort_keys, partition_keys, ds_mock_kwargs


### PR DESCRIPTION
`ClusterUtilizationOverTimeRange` provides misleading behavior when used within deltacat. This is because it estimates cluster-level resource usage rather than partition-specific usage. As a result, it's better to use `ClusterUtilizationOverTimeRange` from within the driver class that calls deltacat functions.