### PR TITLE
Remove cluster_util from deltacat

### DIFF
--- a/deltacat/compute/compactor/compaction_session.py
+++ b/deltacat/compute/compactor/compaction_session.py
@@ -293,7 +293,6 @@ def _execute_compaction_round(
             f"{node_resource_keys}"
         )
 
-    compaction_audit.set_cluster_cpu_max(cluster_cpus)
     # create a remote options provider to round-robin tasks across all nodes or allocated bundles
     logger.info(f"Setting round robin scheduling with node id:{node_resource_keys}")
     round_robin_opt_provider = functools.partial(

--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -99,14 +99,6 @@ class CompactionSessionAuditInfo(dict):
         return self.get("hashBucketCount")
 
     @property
-    def cluster_cpu_max(self) -> float:
-        """
-        Total cluster cpu allocated for the compaction job. If it is autoscaling cluster,
-        max cpu at any time will be reported.
-        """
-        return self.get("clusterCpuMax")
-
-    @property
     def compaction_time_in_seconds(self) -> float:
         """
         The total time taken by the compaction session to complete.
@@ -424,35 +416,6 @@ class CompactionSessionAuditInfo(dict):
         return self.get("hashBucketProcessedSizeBytes")
 
     @property
-    def total_cpu_seconds(self) -> float:
-        """
-        Total number of vCPUs provisioned in the cluster weighted over time.
-        """
-        return self.get("totalCPUSeconds")
-
-    @property
-    def used_cpu_seconds(self) -> float:
-        """
-        Total used vCPU in the cluster weighted over time.
-        """
-        return self.get("usedCPUSeconds")
-
-    @property
-    def used_memory_gb_seconds(self) -> float:
-        """
-        The used memory in the cluster weighted over time. This
-        determines opportunities for better memory estimation.
-        """
-        return self.get("usedMemoryGBSeconds")
-
-    @property
-    def total_memory_gb_seconds(self) -> float:
-        """
-        Total memory in the cluster weighted over time in GB.
-        """
-        return self.get("totalMemoryGBSeconds")
-
-    @property
     def pyarrow_version(self) -> str:
         """
         The version of PyArrow used.
@@ -508,10 +471,6 @@ class CompactionSessionAuditInfo(dict):
         self, hash_bucket_count: int
     ) -> CompactionSessionAuditInfo:
         self["hashBucketCount"] = hash_bucket_count
-        return self
-
-    def set_cluster_cpu_max(self, cluster_cpu_max: float) -> CompactionSessionAuditInfo:
-        self["clusterCpuMax"] = cluster_cpu_max
         return self
 
     def set_compaction_time_in_seconds(
@@ -776,22 +735,6 @@ class CompactionSessionAuditInfo(dict):
         self, size: int
     ) -> CompactionSessionAuditInfo:
         self["hashBucketProcessedSizeBytes"] = size
-        return self
-
-    def set_total_cpu_seconds(self, value: float) -> CompactionSessionAuditInfo:
-        self["totalCPUSeconds"] = value
-        return self
-
-    def set_used_cpu_seconds(self, value: float) -> CompactionSessionAuditInfo:
-        self["usedCPUSeconds"] = value
-        return self
-
-    def set_used_memory_gb_seconds(self, value: float) -> CompactionSessionAuditInfo:
-        self["usedMemoryGBSeconds"] = value
-        return self
-
-    def set_total_memory_gb_seconds(self, value: float) -> CompactionSessionAuditInfo:
-        self["totalMemoryGBSeconds"] = value
         return self
 
     def set_pyarrow_version(self, value: str) -> CompactionSessionAuditInfo:

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -47,7 +47,6 @@ from deltacat.compute.compactor_v2.utils.task_options import (
     hash_bucket_resource_options_provider,
     merge_resource_options_provider,
 )
-from deltacat.utils.resources import ClusterUtilizationOverTimeRange
 from deltacat.compute.compactor.model.compactor_version import CompactorVersion
 
 if importlib.util.find_spec("memray"):
@@ -65,10 +64,9 @@ def compact_partition(params: CompactPartitionParams, **kwargs) -> Optional[str]
 
     with memray.Tracker(
         f"compaction_partition.bin"
-    ) if params.enable_profiler else nullcontext(), ClusterUtilizationOverTimeRange() as cluster_util:
+    ) if params.enable_profiler else nullcontext():
         (new_partition, new_rci, new_rcf_partition_locator,) = _execute_compaction(
             params,
-            cluster_util=cluster_util,
             **kwargs,
         )
 
@@ -477,17 +475,6 @@ def _execute_compaction(
     compaction_audit.save_round_completion_stats(
         mat_results, telemetry_time_hb + telemetry_time_merge
     )
-
-    cluster_util: ClusterUtilizationOverTimeRange = kwargs.get("cluster_util")
-
-    if cluster_util:
-        compaction_audit.set_total_cpu_seconds(cluster_util.total_vcpu_seconds)
-        compaction_audit.set_used_cpu_seconds(cluster_util.used_vcpu_seconds)
-        compaction_audit.set_used_memory_gb_seconds(cluster_util.used_memory_gb_seconds)
-        compaction_audit.set_total_memory_gb_seconds(
-            cluster_util.total_memory_gb_seconds
-        )
-        compaction_audit.set_cluster_cpu_max(cluster_util.max_cpu)
 
     input_inflation = None
     input_average_record_size_bytes = None


### PR DESCRIPTION
`ClusterUtilizationOverTimeRange` provides misleading behavior when used within deltacat. This is because it estimates cluster-level resource usage rather than partition-specific usage. As a result, it's better to use `ClusterUtilizationOverTimeRange` from within the driver class that calls deltacat functions.

Testing:
 - Tested on personal stack