### PR TITLE
Bump daft to 0.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # any changes here should also be reflected in setup.py "install_requires"
 aws-embedded-metrics == 3.2.0
 boto3 ~= 1.20
-getdaft==0.1.17
+getdaft==0.2.4
 numpy == 1.21.5
 pandas == 1.3.5
 pyarrow == 12.0.1

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         "typing-extensions == 4.4.0",
         "pymemcache == 4.0.0",
         "redis == 4.6.0",
-        "getdaft == 0.1.17",
+        "getdaft == 0.2.4",
         "schedule == 1.2.0",
     ],
     setup_requires=["wheel"],


### PR DESCRIPTION
Bumping daft to include fix issue when reading empty parquet files with daft
```
pyarrow.lib.ArrowInvalid: cannot construct ChunkedArray from empty vector and omitted type
```

And when parquet page header is really big
```
ValueError: DaftError::ArrowError External format error: Operation would exceed memory use threshold
```