### PR TITLE
Add task index into logs for hb and merge

### DIFF
--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -227,6 +227,7 @@ def _execute_compaction(
             "input": HashBucketInput.of(
                 item,
                 primary_keys=params.primary_keys,
+                hb_task_index=index,
                 num_hash_buckets=params.hash_bucket_count,
                 num_hash_groups=params.hash_group_count,
                 enable_profiler=params.enable_profiler,

--- a/deltacat/compute/compactor_v2/model/hash_bucket_input.py
+++ b/deltacat/compute/compactor_v2/model/hash_bucket_input.py
@@ -15,6 +15,7 @@ class HashBucketInput(Dict):
         primary_keys: List[str],
         num_hash_buckets: int,
         num_hash_groups: int,
+        hb_task_index: Optional[int] = 0,
         enable_profiler: Optional[bool] = False,
         metrics_config: Optional[MetricsConfig] = None,
         read_kwargs_provider: Optional[ReadKwargsProvider] = None,
@@ -26,6 +27,7 @@ class HashBucketInput(Dict):
         result = HashBucketInput()
         result["annotated_delta"] = annotated_delta
         result["primary_keys"] = primary_keys
+        result["hb_task_index"] = hb_task_index
         result["num_hash_buckets"] = num_hash_buckets
         result["num_hash_groups"] = num_hash_groups
         result["enable_profiler"] = enable_profiler
@@ -44,6 +46,10 @@ class HashBucketInput(Dict):
     @property
     def primary_keys(self) -> List[str]:
         return self["primary_keys"]
+
+    @property
+    def hb_task_index(self) -> List[str]:
+        return self["hb_task_index"]
 
     @property
     def num_hash_buckets(self) -> int:

--- a/deltacat/compute/compactor_v2/steps/hash_bucket.py
+++ b/deltacat/compute/compactor_v2/steps/hash_bucket.py
@@ -187,7 +187,7 @@ def _timed_hash_bucket(input: HashBucketInput):
 @ray.remote
 def hash_bucket(input: HashBucketInput) -> HashBucketResult:
     with ProcessUtilizationOverTimeRange() as process_util:
-        logger.info(f"Starting hash bucket task...")
+        logger.info(f"Starting hash bucket task {input.hb_task_index}...")
 
         # Log node peak memory utilization every 10 seconds
         def log_peak_memory():
@@ -212,7 +212,7 @@ def hash_bucket(input: HashBucketInput) -> HashBucketResult:
             )
             emit_metrics_time = latency
 
-        logger.info(f"Finished hash bucket task...")
+        logger.info(f"Finished hash bucket task {input.hb_task_index}...")
         return HashBucketResult(
             hash_bucket_result[0],
             hash_bucket_result[1],

--- a/deltacat/compute/compactor_v2/steps/merge.py
+++ b/deltacat/compute/compactor_v2/steps/merge.py
@@ -457,7 +457,7 @@ def _timed_merge(input: MergeInput) -> MergeResult:
 @ray.remote
 def merge(input: MergeInput) -> MergeResult:
     with ProcessUtilizationOverTimeRange() as process_util:
-        logger.info(f"Starting merge task...")
+        logger.info(f"Starting merge task {input.merge_task_index}...")
 
         # Log node peak memory utilization every 10 seconds
         def log_peak_memory():
@@ -480,7 +480,7 @@ def merge(input: MergeInput) -> MergeResult:
             )
             emit_metrics_time = latency
 
-        logger.info(f"Finished merge task...")
+        logger.info(f"Finished merge task {input.merge_task_index}...")
         return MergeResult(
             merge_result[0],
             merge_result[1],

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -178,6 +178,9 @@ def hash_bucket_resource_options_provider(
     debug_memory_params["total_pk_size"] = total_pk_size
     debug_memory_params["total_memory"] = total_memory
 
+    debug_memory_params["previous_inflation"] = previous_inflation
+    debug_memory_params["average_record_size_bytes"] = average_record_size_bytes
+
     # Consider buffer
     total_memory = total_memory * (1 + TOTAL_MEMORY_BUFFER_PERCENTAGE / 100.0)
     debug_memory_params["total_memory_with_buffer"] = total_memory


### PR DESCRIPTION
Add the task index into the hb and merge logs. This makes which tasks have started/ended clearer while also logging the hb task index, which was not logged before.