### PR TITLE
Skip hash bucketing for small partitions

### DIFF
--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -6,18 +6,25 @@ import logging
 import ray
 import time
 import json
+
+from deltacat.compute.compactor_v2.model.merge_file_group import (
+    RemoteMergeFileGroupsFactory,
+)
+from deltacat.compute.compactor_v2.model.hash_bucket_input import HashBucketInput
+
+from deltacat.compute.compactor_v2.model.merge_input import MergeInput
+
 from deltacat.aws import s3u as s3_utils
 import deltacat
 from deltacat import logs
-from deltacat.compute.compactor import (
-    PyArrowWriteResult,
-    RoundCompletionInfo,
-)
-from deltacat.compute.compactor_v2.model.merge_input import MergeInput
+from deltacat.compute.compactor import PyArrowWriteResult, RoundCompletionInfo
 from deltacat.compute.compactor_v2.model.merge_result import MergeResult
-from deltacat.compute.compactor_v2.model.hash_bucket_input import HashBucketInput
 from deltacat.compute.compactor_v2.model.hash_bucket_result import HashBucketResult
 from deltacat.compute.compactor.model.materialize_result import MaterializeResult
+from deltacat.compute.compactor_v2.utils.delta import get_local_delta_file_envelopes
+from deltacat.compute.compactor_v2.utils.merge import (
+    generate_local_merge_input,
+)
 from deltacat.storage import (
     Delta,
     DeltaLocator,
@@ -210,107 +217,6 @@ def _execute_compaction(
         logger.info("No input deltas found to compact.")
         return None, None, None
 
-    hb_options_provider = functools.partial(
-        task_resource_options_provider,
-        pg_config=params.pg_config,
-        resource_amount_provider=hash_bucket_resource_options_provider,
-        previous_inflation=params.previous_inflation,
-        average_record_size_bytes=params.average_record_size_bytes,
-        primary_keys=params.primary_keys,
-        ray_custom_resources=params.ray_custom_resources,
-    )
-
-    hb_start = time.monotonic()
-
-    def hash_bucket_input_provider(index, item):
-        return {
-            "input": HashBucketInput.of(
-                item,
-                primary_keys=params.primary_keys,
-                num_hash_buckets=params.hash_bucket_count,
-                num_hash_groups=params.hash_group_count,
-                enable_profiler=params.enable_profiler,
-                metrics_config=params.metrics_config,
-                read_kwargs_provider=params.read_kwargs_provider,
-                object_store=params.object_store,
-                deltacat_storage=params.deltacat_storage,
-                deltacat_storage_kwargs=params.deltacat_storage_kwargs,
-            )
-        }
-
-    hb_tasks_pending = invoke_parallel(
-        items=uniform_deltas,
-        ray_task=hb.hash_bucket,
-        max_parallelism=task_max_parallelism,
-        options_provider=hb_options_provider,
-        kwargs_provider=hash_bucket_input_provider,
-    )
-
-    hb_invoke_end = time.monotonic()
-
-    logger.info(f"Getting {len(hb_tasks_pending)} hash bucket results...")
-    hb_results: List[HashBucketResult] = ray.get(hb_tasks_pending)
-    logger.info(f"Got {len(hb_results)} hash bucket results.")
-    hb_end = time.monotonic()
-
-    # we use time.time() here because time.monotonic() has no reference point
-    # whereas time.time() measures epoch seconds. Hence, it will be reasonable
-    # to compare time.time()s captured in different nodes.
-    hb_results_retrieved_at = time.time()
-
-    telemetry_time_hb = compaction_audit.save_step_stats(
-        CompactionSessionAuditInfo.HASH_BUCKET_STEP_NAME,
-        hb_results,
-        hb_results_retrieved_at,
-        hb_invoke_end - hb_start,
-        hb_end - hb_start,
-    )
-
-    s3_utils.upload(
-        compaction_audit.audit_url,
-        str(json.dumps(compaction_audit)),
-        **params.s3_client_kwargs,
-    )
-
-    all_hash_group_idx_to_obj_id = defaultdict(list)
-    all_hash_group_idx_to_size_bytes = defaultdict(int)
-    all_hash_group_idx_to_num_rows = defaultdict(int)
-    hb_data_processed_size_bytes = np.int64(0)
-    total_hb_record_count = np.int64(0)
-
-    # initialize all hash groups
-    for hb_group in range(params.hash_group_count):
-        all_hash_group_idx_to_num_rows[hb_group] = 0
-        all_hash_group_idx_to_obj_id[hb_group] = []
-        all_hash_group_idx_to_size_bytes[hb_group] = 0
-
-    for hb_result in hb_results:
-        hb_data_processed_size_bytes += hb_result.hb_size_bytes
-        total_hb_record_count += hb_result.hb_record_count
-
-        for hash_group_index, object_id_size_tuple in enumerate(
-            hb_result.hash_bucket_group_to_obj_id_tuple
-        ):
-            if object_id_size_tuple:
-                all_hash_group_idx_to_obj_id[hash_group_index].append(
-                    object_id_size_tuple[0]
-                )
-                all_hash_group_idx_to_size_bytes[
-                    hash_group_index
-                ] += object_id_size_tuple[1].item()
-                all_hash_group_idx_to_num_rows[
-                    hash_group_index
-                ] += object_id_size_tuple[2].item()
-
-    logger.info(
-        f"Got {total_hb_record_count} hash bucket records from hash bucketing step..."
-    )
-
-    compaction_audit.set_input_records(total_hb_record_count.item())
-    compaction_audit.set_hash_bucket_processed_size_bytes(
-        hb_data_processed_size_bytes.item()
-    )
-
     # create a new stream for this round
     compacted_stream_locator = params.destination_partition_locator.stream_locator
     compacted_stream = params.deltacat_storage.get_stream(
@@ -325,60 +231,181 @@ def _execute_compaction(
         **params.deltacat_storage_kwargs,
     )
 
-    # BSP Step 2: Merge
-    merge_options_provider = functools.partial(
+    hb_options_provider = functools.partial(
         task_resource_options_provider,
         pg_config=params.pg_config,
-        resource_amount_provider=merge_resource_options_provider,
-        num_hash_groups=params.hash_group_count,
-        hash_group_size_bytes=all_hash_group_idx_to_size_bytes,
-        hash_group_num_rows=all_hash_group_idx_to_num_rows,
-        round_completion_info=round_completion_info,
-        compacted_delta_manifest=previous_compacted_delta_manifest,
+        resource_amount_provider=hash_bucket_resource_options_provider,
+        previous_inflation=params.previous_inflation,
+        average_record_size_bytes=params.average_record_size_bytes,
         primary_keys=params.primary_keys,
-        deltacat_storage=params.deltacat_storage,
-        deltacat_storage_kwargs=params.deltacat_storage_kwargs,
         ray_custom_resources=params.ray_custom_resources,
     )
 
-    def merge_input_provider(index, item):
-        return {
-            "input": MergeInput.of(
-                dfe_groups_refs=item[1],
-                write_to_partition=compacted_partition,
-                compacted_file_content_type=params.compacted_file_content_type,
-                primary_keys=params.primary_keys,
-                sort_keys=params.sort_keys,
-                merge_task_index=index,
-                hash_bucket_count=params.hash_bucket_count,
-                drop_duplicates=params.drop_duplicates,
-                hash_group_index=item[0],
-                num_hash_groups=params.hash_group_count,
-                max_records_per_output_file=params.records_per_compacted_file,
-                enable_profiler=params.enable_profiler,
-                metrics_config=params.metrics_config,
-                s3_table_writer_kwargs=params.s3_table_writer_kwargs,
-                read_kwargs_provider=params.read_kwargs_provider,
-                round_completion_info=round_completion_info,
-                object_store=params.object_store,
-                deltacat_storage=params.deltacat_storage,
-                deltacat_storage_kwargs=params.deltacat_storage_kwargs,
-            )
-        }
+    total_input_records_count = np.int64(0)
+    total_hb_record_count = np.int64(0)
+    telemetry_time_hb = 0
+    if params.hash_bucket_count == 1:
+        local_dfe_list, input_records_count = get_local_delta_file_envelopes(
+            uniform_deltas,
+            params.read_kwargs_provider,
+            params.deltacat_storage,
+            params.deltacat_storage_kwargs,
+        )
 
-    merge_start = time.monotonic()
+        total_input_records_count += input_records_count
+        merge_start = time.monotonic()
+        local_merge_input = generate_local_merge_input(
+            params, local_dfe_list, compacted_partition, round_completion_info
+        )
+        merge_results = ray.get([mg.merge.remote(local_merge_input)])
+        merge_invoke_end = time.monotonic()
+    else:
+        hb_start = time.monotonic()
 
-    merge_tasks_pending = invoke_parallel(
-        items=all_hash_group_idx_to_obj_id.items(),
-        ray_task=mg.merge,
-        max_parallelism=task_max_parallelism,
-        options_provider=merge_options_provider,
-        kwargs_provider=merge_input_provider,
-    )
+        def hash_bucket_input_provider(index, item):
+            return {
+                "input": HashBucketInput.of(
+                    item,
+                    primary_keys=params.primary_keys,
+                    num_hash_buckets=params.hash_bucket_count,
+                    num_hash_groups=params.hash_group_count,
+                    enable_profiler=params.enable_profiler,
+                    metrics_config=params.metrics_config,
+                    read_kwargs_provider=params.read_kwargs_provider,
+                    object_store=params.object_store,
+                    deltacat_storage=params.deltacat_storage,
+                    deltacat_storage_kwargs=params.deltacat_storage_kwargs,
+                )
+            }
 
-    merge_invoke_end = time.monotonic()
-    logger.info(f"Getting {len(merge_tasks_pending)} merge results...")
-    merge_results: List[MergeResult] = ray.get(merge_tasks_pending)
+        all_hash_group_idx_to_obj_id = defaultdict(list)
+        all_hash_group_idx_to_size_bytes = defaultdict(int)
+        all_hash_group_idx_to_num_rows = defaultdict(int)
+        hb_tasks_pending = invoke_parallel(
+            items=uniform_deltas,
+            ray_task=hb.hash_bucket,
+            max_parallelism=task_max_parallelism,
+            options_provider=hb_options_provider,
+            kwargs_provider=hash_bucket_input_provider,
+        )
+
+        hb_invoke_end = time.monotonic()
+
+        logger.info(f"Getting {len(hb_tasks_pending)} hash bucket results...")
+        hb_results: List[HashBucketResult] = ray.get(hb_tasks_pending)
+        logger.info(f"Got {len(hb_results)} hash bucket results.")
+        hb_end = time.monotonic()
+
+        # we use time.time() here because time.monotonic() has no reference point
+        # whereas time.time() measures epoch seconds. Hence, it will be reasonable
+        # to compare time.time()s captured in different nodes.
+        hb_results_retrieved_at = time.time()
+
+        telemetry_time_hb = compaction_audit.save_step_stats(
+            CompactionSessionAuditInfo.HASH_BUCKET_STEP_NAME,
+            hb_results,
+            hb_results_retrieved_at,
+            hb_invoke_end - hb_start,
+            hb_end - hb_start,
+        )
+
+        s3_utils.upload(
+            compaction_audit.audit_url,
+            str(json.dumps(compaction_audit)),
+            **params.s3_client_kwargs,
+        )
+
+        hb_data_processed_size_bytes = np.int64(0)
+
+        # initialize all hash groups
+        for hb_group in range(params.hash_group_count):
+            all_hash_group_idx_to_num_rows[hb_group] = 0
+            all_hash_group_idx_to_obj_id[hb_group] = []
+            all_hash_group_idx_to_size_bytes[hb_group] = 0
+
+        for hb_result in hb_results:
+            hb_data_processed_size_bytes += hb_result.hb_size_bytes
+            total_input_records_count += hb_result.hb_record_count
+
+            for hash_group_index, object_id_size_tuple in enumerate(
+                hb_result.hash_bucket_group_to_obj_id_tuple
+            ):
+                if object_id_size_tuple:
+                    all_hash_group_idx_to_obj_id[hash_group_index].append(
+                        object_id_size_tuple[0],
+                    )
+                    all_hash_group_idx_to_size_bytes[
+                        hash_group_index
+                    ] += object_id_size_tuple[1].item()
+                    all_hash_group_idx_to_num_rows[
+                        hash_group_index
+                    ] += object_id_size_tuple[2].item()
+
+        logger.info(
+            f"Got {total_input_records_count} hash bucket records from hash bucketing step..."
+        )
+
+        total_hb_record_count = total_input_records_count
+        compaction_audit.set_hash_bucket_processed_size_bytes(
+            hb_data_processed_size_bytes.item()
+        )
+
+        # BSP Step 2: Merge
+        merge_options_provider = functools.partial(
+            task_resource_options_provider,
+            pg_config=params.pg_config,
+            resource_amount_provider=merge_resource_options_provider,
+            num_hash_groups=params.hash_group_count,
+            hash_group_size_bytes=all_hash_group_idx_to_size_bytes,
+            hash_group_num_rows=all_hash_group_idx_to_num_rows,
+            round_completion_info=round_completion_info,
+            compacted_delta_manifest=previous_compacted_delta_manifest,
+            primary_keys=params.primary_keys,
+            deltacat_storage=params.deltacat_storage,
+            deltacat_storage_kwargs=params.deltacat_storage_kwargs,
+            ray_custom_resources=params.ray_custom_resources,
+        )
+
+        def merge_input_provider(index, item):
+            return {
+                "input": MergeInput.of(
+                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                        hash_group_index=item[0],
+                        dfe_groups_refs=item[1],
+                        hash_bucket_count=params.hash_bucket_count,
+                        num_hash_groups=params.hash_group_count,
+                        object_store=params.object_store,
+                    ),
+                    write_to_partition=compacted_partition,
+                    compacted_file_content_type=params.compacted_file_content_type,
+                    primary_keys=params.primary_keys,
+                    sort_keys=params.sort_keys,
+                    merge_task_index=index,
+                    drop_duplicates=params.drop_duplicates,
+                    max_records_per_output_file=params.records_per_compacted_file,
+                    enable_profiler=params.enable_profiler,
+                    metrics_config=params.metrics_config,
+                    s3_table_writer_kwargs=params.s3_table_writer_kwargs,
+                    read_kwargs_provider=params.read_kwargs_provider,
+                    round_completion_info=round_completion_info,
+                    object_store=params.object_store,
+                    deltacat_storage=params.deltacat_storage,
+                    deltacat_storage_kwargs=params.deltacat_storage_kwargs,
+                )
+            }
+
+        merge_start = time.monotonic()
+        merge_tasks_pending = invoke_parallel(
+            items=all_hash_group_idx_to_obj_id.items(),
+            ray_task=mg.merge,
+            max_parallelism=task_max_parallelism,
+            options_provider=merge_options_provider,
+            kwargs_provider=merge_input_provider,
+        )
+        merge_invoke_end = time.monotonic()
+        logger.info(f"Getting {len(merge_tasks_pending)} merge results...")
+        merge_results: List[MergeResult] = ray.get(merge_tasks_pending)
+
     logger.info(f"Got {len(merge_results)} merge results.")
 
     merge_results_retrieved_at = time.time()
@@ -386,6 +413,8 @@ def _execute_compaction(
 
     total_dd_record_count = sum([ddr.deduped_record_count for ddr in merge_results])
     logger.info(f"Deduped {total_dd_record_count} records...")
+
+    compaction_audit.set_input_records(total_input_records_count.item())
 
     telemetry_time_merge = compaction_audit.save_step_stats(
         CompactionSessionAuditInfo.MERGE_STEP_NAME,

--- a/deltacat/compute/compactor_v2/model/merge_file_group.py
+++ b/deltacat/compute/compactor_v2/model/merge_file_group.py
@@ -1,0 +1,157 @@
+# Allow classes to use self-referencing Type hints in Python 3.7.
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections import defaultdict
+
+from ray.types import ObjectRef
+
+from deltacat.compute.compactor.model.delta_file_envelope import DeltaFileEnvelopeGroups
+
+from deltacat.compute.compactor_v2.utils.primary_key_index import (
+    hash_group_index_to_hash_bucket_indices,
+)
+
+from deltacat.io.object_store import IObjectStore
+
+from deltacat import logs
+
+from deltacat.compute.compactor import DeltaFileEnvelope
+
+from typing import List, Optional
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
+
+
+class MergeFileGroup(dict):
+    @staticmethod
+    def of(dfe_groups: List[List[DeltaFileEnvelope]], hb_index: Optional[int] = None):
+        """
+        Creates a container with delta file envelope groupings and other
+        additional properties used primarily for the merging step.
+
+        Args:
+            dfe_groups: A list of delta file envelope groups.
+            hb_index: If present, this signifies the hash bucket index corresponding to the envelope delta file groups.
+
+        Returns:
+            A dict
+
+        """
+        d = MergeFileGroup()
+        d["dfe_groups"] = dfe_groups
+        d["hb_index"] = hb_index
+        return d
+
+    @property
+    def dfe_groups(self) -> List[List[DeltaFileEnvelope]]:
+        return self["dfe_groups"]
+
+    @property
+    def hb_index(self) -> Optional[int]:
+        return self["hb_index"]
+
+
+class MergeFileGroupsFactory(ABC):
+    @abstractmethod
+    def create(self) -> List[MergeFileGroup]:
+        """
+        Creates a list of merge file groups.
+
+        Returns: a list of merge file groups.
+
+        """
+        raise NotImplementedError("Method not implemented")
+
+
+class LocalMergeFileGroupsFactory(MergeFileGroupsFactory):
+    """
+    A factory class for producing merge file groups given local delta file envelopes.
+    """
+
+    def __init__(self, delta_file_envelopes: List[DeltaFileEnvelope]):
+        self._dfe_groups = (
+            [delta_file_envelopes] if len(delta_file_envelopes) > 0 else None
+        )
+        self.copy_by_reference_ids = []
+
+    def create(self) -> List[MergeFileGroup]:
+        if not self._dfe_groups:
+            return []
+
+        return [MergeFileGroup.of(self._dfe_groups)]
+
+
+class RemoteMergeFileGroupsFactory(MergeFileGroupsFactory):
+    """
+    A factory class for producing merge file groups given delta file envelope object refs
+        and hash bucketing parameters. Delta file envelopes are pulled from the object store
+        remotely and loaded with in-memory pyarrow tables.
+    """
+
+    def __init__(
+        self,
+        hash_group_index: int,
+        dfe_groups_refs: List[ObjectRef[DeltaFileEnvelopeGroups]],
+        hash_bucket_count: int,
+        num_hash_groups: int,
+        object_store: IObjectStore,
+    ):
+        self.hash_group_index = hash_group_index
+        self.hash_bucket_count = hash_bucket_count
+        self.num_hash_groups = num_hash_groups
+        self.object_store = object_store
+        self.hb_index_to_delta_file_envelopes_list = None
+        self.dfe_groups_list = []
+        self._dfe_groups_refs = dfe_groups_refs
+        self._hb_index_copy_by_reference_ids = []
+        self._loaded_from_object_store = False
+
+    def _load_deltas_from_object_store(self):
+        delta_file_envelope_groups_list = self.object_store.get_many(
+            self._dfe_groups_refs
+        )
+        hb_index_to_delta_file_envelopes_list = defaultdict(list)
+        for delta_file_envelope_groups in delta_file_envelope_groups_list:
+            assert self.hash_bucket_count == len(delta_file_envelope_groups), (
+                f"The hash bucket count must match the dfe size as {self.hash_bucket_count}"
+                f" != {len(delta_file_envelope_groups)}"
+            )
+
+            for hb_idx, dfes in enumerate(delta_file_envelope_groups):
+                if dfes:
+                    hb_index_to_delta_file_envelopes_list[hb_idx].append(dfes)
+        self.hb_index_to_delta_file_envelopes_list = (
+            hb_index_to_delta_file_envelopes_list
+        )
+
+        valid_hb_indices_iterable = hash_group_index_to_hash_bucket_indices(
+            self.hash_group_index, self.hash_bucket_count, self.num_hash_groups
+        )
+
+        dfe_list_groups = []
+        hb_index_copy_by_reference = []
+        for hb_idx in valid_hb_indices_iterable:
+            dfe_list = hb_index_to_delta_file_envelopes_list.get(hb_idx)
+            if dfe_list:
+                dfe_list_groups.append(MergeFileGroup.of(dfe_list, hb_idx))
+            else:
+                hb_index_copy_by_reference.append(hb_idx)
+
+        self.dfe_groups_list = dfe_list_groups
+        self._hb_index_copy_by_reference_ids = hb_index_copy_by_reference
+        self._loaded_from_object_store = True
+
+    def create(self) -> List[MergeFileGroup]:
+        if not self._loaded_from_object_store:
+            self._load_deltas_from_object_store()
+
+        return self.dfe_groups_list
+
+    @property
+    def hb_index_copy_by_reference_ids(self) -> List[int]:
+        if not self._loaded_from_object_store:
+            self._load_deltas_from_object_store()
+
+        return self._hb_index_copy_by_reference_ids

--- a/deltacat/compute/compactor_v2/model/merge_file_group.py
+++ b/deltacat/compute/compactor_v2/model/merge_file_group.py
@@ -2,22 +2,27 @@
 from __future__ import annotations
 
 import logging
+import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
 
+from deltacat.utils.common import ReadKwargsProvider
 from ray.types import ObjectRef
 
 from deltacat.compute.compactor.model.delta_file_envelope import DeltaFileEnvelopeGroups
+from deltacat.compute.compactor_v2.utils.delta import read_delta_file_envelopes
 
 from deltacat.compute.compactor_v2.utils.primary_key_index import (
     hash_group_index_to_hash_bucket_indices,
 )
 
+from deltacat.storage import interface as unimplemented_deltacat_storage
+
 from deltacat.io.object_store import IObjectStore
 
 from deltacat import logs
 
-from deltacat.compute.compactor import DeltaFileEnvelope
+from deltacat.compute.compactor import DeltaFileEnvelope, DeltaAnnotated
 
 from typing import List, Optional
 
@@ -26,34 +31,35 @@ logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 class MergeFileGroup(dict):
     @staticmethod
-    def of(dfe_groups: List[List[DeltaFileEnvelope]], hb_index: Optional[int] = None):
+    def of(hb_index: int, dfe_groups: Optional[List[List[DeltaFileEnvelope]]] = None):
         """
         Creates a container with delta file envelope groupings and other
         additional properties used primarily for the merging step.
 
         Args:
+            hb_index: This signifies the hash bucket index corresponding to the envelope delta file groups.
             dfe_groups: A list of delta file envelope groups.
-            hb_index: If present, this signifies the hash bucket index corresponding to the envelope delta file groups.
+                If not present, the provided hash bucket index is a copy by reference candidate during the merge step.
 
         Returns:
             A dict
 
         """
         d = MergeFileGroup()
-        d["dfe_groups"] = dfe_groups
         d["hb_index"] = hb_index
+        d["dfe_groups"] = dfe_groups
         return d
 
     @property
-    def dfe_groups(self) -> List[List[DeltaFileEnvelope]]:
+    def dfe_groups(self) -> Optional[List[List[DeltaFileEnvelope]]]:
         return self["dfe_groups"]
 
     @property
-    def hb_index(self) -> Optional[int]:
+    def hb_index(self) -> int:
         return self["hb_index"]
 
 
-class MergeFileGroupsFactory(ABC):
+class MergeFileGroupsProvider(ABC):
     @abstractmethod
     def create(self) -> List[MergeFileGroup]:
         """
@@ -64,26 +70,82 @@ class MergeFileGroupsFactory(ABC):
         """
         raise NotImplementedError("Method not implemented")
 
+    @property
+    @abstractmethod
+    def hash_group_index(self):
+        raise NotImplementedError("Method not implemented")
 
-class LocalMergeFileGroupsFactory(MergeFileGroupsFactory):
+
+class LocalMergeFileGroupsProvider(MergeFileGroupsProvider):
     """
     A factory class for producing merge file groups given local delta file envelopes.
     """
 
-    def __init__(self, delta_file_envelopes: List[DeltaFileEnvelope]):
-        self._dfe_groups = (
-            [delta_file_envelopes] if len(delta_file_envelopes) > 0 else None
+    LOCAL_HASH_BUCKET_INDEX = 0
+    LOCAL_HASH_GROUP_INDEX = 0
+
+    def __init__(
+        self,
+        uniform_deltas: List[DeltaAnnotated],
+        read_kwargs_provider: Optional[ReadKwargsProvider],
+        deltacat_storage=unimplemented_deltacat_storage,
+        deltacat_storage_kwargs: Optional[dict] = None,
+    ):
+        self._deltas = uniform_deltas
+        self._read_kwargs_provider = read_kwargs_provider
+        self._deltacat_storage = deltacat_storage
+        self._deltacat_storage_kwargs = deltacat_storage_kwargs
+        self._loaded_deltas = False
+
+    def _read_deltas_locally(self):
+        local_dfe_list = []
+        input_records_count = 0
+        uniform_deltas = self._deltas
+        logger.info(f"Getting {len(uniform_deltas)} DFE Tasks.")
+        dfe_start = time.monotonic()
+        for annotated_delta in uniform_deltas:
+            (
+                delta_file_envelopes,
+                total_record_count,
+                total_size_bytes,
+            ) = read_delta_file_envelopes(
+                annotated_delta,
+                self._read_kwargs_provider,
+                self._deltacat_storage,
+                self._deltacat_storage_kwargs,
+            )
+            if delta_file_envelopes:
+                local_dfe_list.extend(delta_file_envelopes)
+                input_records_count += total_record_count
+        dfe_end = time.monotonic()
+        logger.info(
+            f"Retrieved {len(local_dfe_list)} DFE Tasks in {dfe_end - dfe_start}s."
         )
-        self.copy_by_reference_ids = []
+
+        self._dfe_groups = [local_dfe_list] if len(local_dfe_list) > 0 else None
+        self._loaded_deltas = True
 
     def create(self) -> List[MergeFileGroup]:
+        if not self._loaded_deltas:
+            self._read_deltas_locally()
+
         if not self._dfe_groups:
             return []
 
-        return [MergeFileGroup.of(self._dfe_groups)]
+        # Since hash bucketing is skipped for local merges, we use a fixed index here.
+        return [
+            MergeFileGroup.of(
+                hb_index=LocalMergeFileGroupsProvider.LOCAL_HASH_BUCKET_INDEX,
+                dfe_groups=self._dfe_groups,
+            )
+        ]
+
+    @property
+    def hash_group_index(self):
+        return LocalMergeFileGroupsProvider.LOCAL_HASH_GROUP_INDEX
 
 
-class RemoteMergeFileGroupsFactory(MergeFileGroupsFactory):
+class RemoteMergeFileGroupsProvider(MergeFileGroupsProvider):
     """
     A factory class for producing merge file groups given delta file envelope object refs
         and hash bucketing parameters. Delta file envelopes are pulled from the object store
@@ -98,14 +160,12 @@ class RemoteMergeFileGroupsFactory(MergeFileGroupsFactory):
         num_hash_groups: int,
         object_store: IObjectStore,
     ):
-        self.hash_group_index = hash_group_index
         self.hash_bucket_count = hash_bucket_count
         self.num_hash_groups = num_hash_groups
         self.object_store = object_store
-        self.hb_index_to_delta_file_envelopes_list = None
-        self.dfe_groups_list = []
+        self._hash_group_index = hash_group_index
         self._dfe_groups_refs = dfe_groups_refs
-        self._hb_index_copy_by_reference_ids = []
+        self._dfe_groups = []
         self._loaded_from_object_store = False
 
     def _load_deltas_from_object_store(self):
@@ -122,36 +182,35 @@ class RemoteMergeFileGroupsFactory(MergeFileGroupsFactory):
             for hb_idx, dfes in enumerate(delta_file_envelope_groups):
                 if dfes:
                     hb_index_to_delta_file_envelopes_list[hb_idx].append(dfes)
-        self.hb_index_to_delta_file_envelopes_list = (
-            hb_index_to_delta_file_envelopes_list
-        )
-
         valid_hb_indices_iterable = hash_group_index_to_hash_bucket_indices(
             self.hash_group_index, self.hash_bucket_count, self.num_hash_groups
         )
 
+        total_dfes_found = 0
         dfe_list_groups = []
-        hb_index_copy_by_reference = []
         for hb_idx in valid_hb_indices_iterable:
             dfe_list = hb_index_to_delta_file_envelopes_list.get(hb_idx)
             if dfe_list:
-                dfe_list_groups.append(MergeFileGroup.of(dfe_list, hb_idx))
+                total_dfes_found += 1
+                dfe_list_groups.append(
+                    MergeFileGroup.of(hb_index=hb_idx, dfe_groups=dfe_list)
+                )
             else:
-                hb_index_copy_by_reference.append(hb_idx)
+                dfe_list_groups.append(MergeFileGroup.of(hb_index=hb_idx))
 
-        self.dfe_groups_list = dfe_list_groups
-        self._hb_index_copy_by_reference_ids = hb_index_copy_by_reference
+        assert total_dfes_found == len(hb_index_to_delta_file_envelopes_list), (
+            "The total dfe list does not match the input dfes from hash bucket as "
+            f"{total_dfes_found} != {len(hb_index_to_delta_file_envelopes_list)}"
+        )
+        self._dfe_groups = dfe_list_groups
         self._loaded_from_object_store = True
 
     def create(self) -> List[MergeFileGroup]:
         if not self._loaded_from_object_store:
             self._load_deltas_from_object_store()
 
-        return self.dfe_groups_list
+        return self._dfe_groups
 
     @property
-    def hb_index_copy_by_reference_ids(self) -> List[int]:
-        if not self._loaded_from_object_store:
-            self._load_deltas_from_object_store()
-
-        return self._hb_index_copy_by_reference_ids
+    def hash_group_index(self):
+        return self._hash_group_index

--- a/deltacat/compute/compactor_v2/model/merge_file_group.py
+++ b/deltacat/compute/compactor_v2/model/merge_file_group.py
@@ -129,9 +129,6 @@ class LocalMergeFileGroupsProvider(MergeFileGroupsProvider):
         if not self._loaded_deltas:
             self._read_deltas_locally()
 
-        if not self._dfe_groups:
-            return []
-
         # Since hash bucketing is skipped for local merges, we use a fixed index here.
         return [
             MergeFileGroup.of(

--- a/deltacat/compute/compactor_v2/model/merge_input.py
+++ b/deltacat/compute/compactor_v2/model/merge_input.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from ray.types import ObjectRef
 from typing import Dict, List, Optional, Any
+
+from deltacat.compute.compactor_v2.model.merge_file_group import (
+    MergeFileGroupsFactory,
+)
 from deltacat.utils.metrics import MetricsConfig
 from deltacat.utils.common import ReadKwargsProvider
 from deltacat.io.object_store import IObjectStore
@@ -16,19 +19,15 @@ from deltacat.compute.compactor_v2.constants import (
 )
 from deltacat.types.media import ContentType
 from deltacat.compute.compactor.model.round_completion_info import RoundCompletionInfo
-from deltacat.compute.compactor.model.delta_file_envelope import DeltaFileEnvelopeGroups
 
 
 class MergeInput(Dict):
     @staticmethod
     def of(
-        dfe_groups_refs: List[ObjectRef[DeltaFileEnvelopeGroups]],
+        merge_file_groups_factory: MergeFileGroupsFactory,
         write_to_partition: Partition,
         compacted_file_content_type: ContentType,
         primary_keys: List[str],
-        hash_group_index: int,
-        num_hash_groups: int,
-        hash_bucket_count: int,
         drop_duplicates: Optional[bool] = DROP_DUPLICATES,
         sort_keys: Optional[List[SortKey]] = None,
         merge_task_index: Optional[int] = 0,
@@ -44,13 +43,10 @@ class MergeInput(Dict):
     ) -> MergeInput:
 
         result = MergeInput()
-        result["dfe_groups_refs"] = dfe_groups_refs
+        result["merge_file_groups_factory"] = merge_file_groups_factory
         result["write_to_partition"] = write_to_partition
         result["compacted_file_content_type"] = compacted_file_content_type
         result["primary_keys"] = primary_keys
-        result["hash_group_index"] = hash_group_index
-        result["num_hash_groups"] = num_hash_groups
-        result["hash_bucket_count"] = hash_bucket_count
         result["drop_duplicates"] = drop_duplicates
         result["sort_keys"] = sort_keys
         result["merge_task_index"] = merge_task_index
@@ -67,8 +63,8 @@ class MergeInput(Dict):
         return result
 
     @property
-    def dfe_groups_refs(self) -> List[ObjectRef[DeltaFileEnvelopeGroups]]:
-        return self["dfe_groups_refs"]
+    def merge_file_groups_factory(self) -> MergeFileGroupsFactory:
+        return self["merge_file_groups_factory"]
 
     @property
     def write_to_partition(self) -> Partition:
@@ -81,18 +77,6 @@ class MergeInput(Dict):
     @property
     def primary_keys(self) -> List[str]:
         return self["primary_keys"]
-
-    @property
-    def hash_group_index(self) -> int:
-        return self["hash_group_index"]
-
-    @property
-    def num_hash_groups(self) -> int:
-        return self["num_hash_groups"]
-
-    @property
-    def hash_bucket_count(self) -> int:
-        return self["hash_bucket_count"]
 
     @property
     def drop_duplicates(self) -> int:

--- a/deltacat/compute/compactor_v2/model/merge_input.py
+++ b/deltacat/compute/compactor_v2/model/merge_input.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Any
 
 from deltacat.compute.compactor_v2.model.merge_file_group import (
-    MergeFileGroupsFactory,
+    MergeFileGroupsProvider,
 )
 from deltacat.utils.metrics import MetricsConfig
 from deltacat.utils.common import ReadKwargsProvider
@@ -24,7 +24,7 @@ from deltacat.compute.compactor.model.round_completion_info import RoundCompleti
 class MergeInput(Dict):
     @staticmethod
     def of(
-        merge_file_groups_factory: MergeFileGroupsFactory,
+        merge_file_groups_provider: MergeFileGroupsProvider,
         write_to_partition: Partition,
         compacted_file_content_type: ContentType,
         primary_keys: List[str],
@@ -43,7 +43,7 @@ class MergeInput(Dict):
     ) -> MergeInput:
 
         result = MergeInput()
-        result["merge_file_groups_factory"] = merge_file_groups_factory
+        result["merge_file_groups_provider"] = merge_file_groups_provider
         result["write_to_partition"] = write_to_partition
         result["compacted_file_content_type"] = compacted_file_content_type
         result["primary_keys"] = primary_keys
@@ -63,8 +63,8 @@ class MergeInput(Dict):
         return result
 
     @property
-    def merge_file_groups_factory(self) -> MergeFileGroupsFactory:
-        return self["merge_file_groups_factory"]
+    def merge_file_groups_provider(self) -> MergeFileGroupsProvider:
+        return self["merge_file_groups_provider"]
 
     @property
     def write_to_partition(self) -> Partition:

--- a/deltacat/compute/compactor_v2/model/merge_result.py
+++ b/deltacat/compute/compactor_v2/model/merge_result.py
@@ -6,6 +6,7 @@ import numpy as np
 
 class MergeResult(NamedTuple):
     materialize_results: List[MaterializeResult]
+    input_record_count: np.int64
     deduped_record_count: np.int64
     peak_memory_usage_bytes: np.double
     telemetry_time_in_seconds: np.double

--- a/deltacat/compute/compactor_v2/steps/hash_bucket.py
+++ b/deltacat/compute/compactor_v2/steps/hash_bucket.py
@@ -5,7 +5,6 @@ from contextlib import nullcontext
 from typing import List, Optional, Tuple
 from deltacat.compute.compactor_v2.model.hash_bucket_input import HashBucketInput
 import numpy as np
-import pyarrow as pa
 import ray
 from deltacat import logs
 from deltacat.compute.compactor import (
@@ -14,12 +13,12 @@ from deltacat.compute.compactor import (
 )
 from deltacat.compute.compactor.model.delta_file_envelope import DeltaFileEnvelopeGroups
 from deltacat.compute.compactor_v2.model.hash_bucket_result import HashBucketResult
+from deltacat.compute.compactor_v2.utils.delta import read_delta_file_envelopes
 from deltacat.compute.compactor_v2.utils.primary_key_index import (
     group_hash_bucket_indices,
     group_by_pk_hash_bucket,
 )
 from deltacat.storage import interface as unimplemented_deltacat_storage
-from deltacat.types.media import StorageType
 from deltacat.utils.ray_utils.runtime import (
     get_current_ray_task_id,
     get_current_ray_worker_id,
@@ -39,57 +38,6 @@ if importlib.util.find_spec("memray"):
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
-def _read_delta_file_envelopes(
-    annotated_delta: DeltaAnnotated,
-    read_kwargs_provider: Optional[ReadKwargsProvider],
-    deltacat_storage=unimplemented_deltacat_storage,
-    deltacat_storage_kwargs: Optional[dict] = None,
-) -> Tuple[Optional[List[DeltaFileEnvelope]], int, int]:
-
-    tables = deltacat_storage.download_delta(
-        annotated_delta,
-        max_parallelism=1,
-        file_reader_kwargs_provider=read_kwargs_provider,
-        storage_type=StorageType.LOCAL,
-        **deltacat_storage_kwargs,
-    )
-    annotations = annotated_delta.annotations
-    assert (
-        len(tables) == len(annotations),
-        f"Unexpected Error: Length of downloaded delta manifest tables "
-        f"({len(tables)}) doesn't match the length of delta manifest "
-        f"annotations ({len(annotations)}).",
-    )
-    if not tables:
-        return None, 0, 0
-
-    delta_stream_position = annotations[0].annotation_stream_position
-    delta_type = annotations[0].annotation_delta_type
-
-    for annotation in annotations:
-        assert annotation.annotation_stream_position == delta_stream_position, (
-            f"Annotation stream position does not match - {annotation.annotation_stream_position} "
-            f"!= {delta_stream_position}"
-        )
-        assert annotation.annotation_delta_type == delta_type, (
-            f"Annotation delta type does not match - {annotation.annotation_delta_type} "
-            f"!= {delta_type}"
-        )
-
-    delta_file_envelopes = []
-    table = pa.concat_tables(tables)
-    total_record_count = len(table)
-    total_size_bytes = int(table.nbytes)
-
-    delta_file = DeltaFileEnvelope.of(
-        stream_position=delta_stream_position,
-        delta_type=delta_type,
-        table=table,
-    )
-    delta_file_envelopes.append(delta_file)
-    return delta_file_envelopes, total_record_count, total_size_bytes
-
-
 def _group_file_records_by_pk_hash_bucket(
     annotated_delta: DeltaAnnotated,
     num_hash_buckets: int,
@@ -103,7 +51,7 @@ def _group_file_records_by_pk_hash_bucket(
         delta_file_envelopes,
         total_record_count,
         total_size_bytes,
-    ) = _read_delta_file_envelopes(
+    ) = read_delta_file_envelopes(
         annotated_delta,
         read_kwargs_provider,
         deltacat_storage,

--- a/deltacat/compute/compactor_v2/steps/merge.py
+++ b/deltacat/compute/compactor_v2/steps/merge.py
@@ -1,5 +1,10 @@
 import logging
 import importlib
+
+from deltacat.compute.compactor_v2.model.merge_file_group import (
+    RemoteMergeFileGroupsFactory,
+    LocalMergeFileGroupsFactory,
+)
 from deltacat.compute.compactor_v2.model.merge_input import MergeInput
 import numpy as np
 import pyarrow as pa
@@ -7,27 +12,22 @@ import ray
 import time
 import pyarrow.compute as pc
 from uuid import uuid4
-from collections import defaultdict
 from deltacat import logs
-from typing import List, Optional
-from deltacat.types.media import DELIMITED_TEXT_CONTENT_TYPES
+from typing import List, Optional, Tuple
+from deltacat.compute.compactor_v2.utils.merge import (
+    materialize,
+)
 from deltacat.compute.compactor_v2.model.merge_result import MergeResult
 from deltacat.compute.compactor.model.materialize_result import MaterializeResult
 from deltacat.compute.compactor.model.pyarrow_write_result import PyArrowWriteResult
-from deltacat.compute.compactor import (
-    RoundCompletionInfo,
-    DeltaFileEnvelope,
-)
+from deltacat.compute.compactor import RoundCompletionInfo, DeltaFileEnvelope
 from deltacat.utils.common import ReadKwargsProvider
-
 from contextlib import nullcontext
-from deltacat.types.tables import TABLE_CLASS_TO_SIZE_FUNC
 from deltacat.utils.ray_utils.runtime import (
     get_current_ray_task_id,
     get_current_ray_worker_id,
 )
 from deltacat.compute.compactor.utils import system_columns as sc
-
 from deltacat.utils.performance import timed_invocation
 from deltacat.utils.metrics import emit_timer_metrics
 from deltacat.utils.resources import (
@@ -36,7 +36,6 @@ from deltacat.utils.resources import (
 )
 from deltacat.compute.compactor_v2.utils.primary_key_index import (
     generate_pk_hash_column,
-    hash_group_index_to_hash_bucket_indices,
 )
 from deltacat.storage import (
     Delta,
@@ -77,14 +76,9 @@ def _drop_delta_type_rows(table: pa.Table, delta_type: DeltaType) -> pa.Table:
 
 
 def _build_incremental_table(
-    hash_bucket_index: int,
     df_envelopes_list: List[List[DeltaFileEnvelope]],
 ) -> pa.Table:
 
-    logger.info(
-        f"[Hash bucket index {hash_bucket_index}] Reading dedupe input for "
-        f"{len(df_envelopes_list)} delta file envelope lists..."
-    )
     hb_tables = []
     # sort by delta file stream position now instead of sorting every row later
     df_envelopes = [d for dfe_list in df_envelopes_list for d in dfe_list]
@@ -270,174 +264,178 @@ def _copy_all_manifest_files_from_old_hash_buckets(
     return materialize_result_list
 
 
-def _timed_merge(input: MergeInput) -> MergeResult:
-    def _materialize(
-        hash_bucket_index,
-        compacted_tables: List[pa.Table],
-    ) -> MaterializeResult:
-        compacted_table = pa.concat_tables(compacted_tables)
-        if input.compacted_file_content_type in DELIMITED_TEXT_CONTENT_TYPES:
-            # TODO (rkenmi): Investigate if we still need to convert this table to pandas DataFrame
-            # TODO (pdames): compare performance to pandas-native materialize path
-            df = compacted_table.to_pandas(split_blocks=True, self_destruct=True)
-            compacted_table = df
-        delta, stage_delta_time = timed_invocation(
-            input.deltacat_storage.stage_delta,
-            compacted_table,
-            input.write_to_partition,
-            max_records_per_entry=input.max_records_per_output_file,
-            content_type=input.compacted_file_content_type,
-            s3_table_writer_kwargs=input.s3_table_writer_kwargs,
+def _compact_tables(
+    input: MergeInput, dfe_list: List[List[DeltaFileEnvelope]], hb_idx: Optional[int]
+) -> Tuple[pa.Table, int]:
+    hb_prefix_log_statement = f"[Hash bucket index {hb_idx}]" if hb_idx else "[Local]"
+    logger.info(
+        f"{hb_prefix_log_statement} Reading dedupe input for "
+        f"{len(dfe_list)} delta file envelope lists..."
+    )
+    table = _build_incremental_table(dfe_list)
+
+    incremental_len = len(table)
+    logger.info(
+        f"{hb_prefix_log_statement}Got the incremental table of length {incremental_len}"
+    )
+
+    if input.sort_keys:
+        # Incremental is sorted and merged, as sorting
+        # on non event based sort key does not produce consistent
+        # compaction results. E.g., compaction(delta1, delta2, delta3)
+        # will not be equal to compaction(compaction(delta1, delta2), delta3).
+        table = table.sort_by(input.sort_keys)
+
+    compacted_table = None
+
+    if input.round_completion_info and hb_idx is None:
+        compacted_dataset = input.deltacat_storage.download_delta(
+            input.round_completion_info.compacted_delta_locator,
+            file_reader_kwargs_provider=input.read_kwargs_provider,
             **input.deltacat_storage_kwargs,
         )
-        compacted_table_size = TABLE_CLASS_TO_SIZE_FUNC[type(compacted_table)](
-            compacted_table
+        if compacted_dataset:
+            compacted_table = pa.concat_tables(compacted_dataset)
+    elif (
+        input.round_completion_info
+        and input.round_completion_info.hb_index_to_entry_range
+        and input.round_completion_info.hb_index_to_entry_range.get(str(hb_idx))
+        is not None
+    ):
+        compacted_table = _download_compacted_table(
+            hb_index=hb_idx,
+            rcf=input.round_completion_info,
+            read_kwargs_provider=input.read_kwargs_provider,
+            deltacat_storage=input.deltacat_storage,
+            deltacat_storage_kwargs=input.deltacat_storage_kwargs,
         )
-        logger.debug(
-            f"Time taken for materialize task"
-            f" to upload {len(compacted_table)} records"
-            f" of size {compacted_table_size} is: {stage_delta_time}s"
+
+    hb_table_record_count = len(table) + (
+        len(compacted_table) if compacted_table else 0
+    )
+
+    table, merge_time = timed_invocation(
+        func=_merge_tables,
+        table=table,
+        primary_keys=input.primary_keys,
+        can_drop_duplicates=input.drop_duplicates,
+        compacted_table=compacted_table,
+    )
+    total_deduped_records = hb_table_record_count - len(table)
+
+    logger.info(
+        f"[Merge task index {input.merge_task_index}] Merged "
+        f"record count: {len(table)}, size={table.nbytes} took: {merge_time}s"
+    )
+
+    return table, total_deduped_records
+
+
+def _copy_previous_compacted_table(input: MergeInput) -> List[MaterializeResult]:
+    materialized_results: List[MaterializeResult] = []
+    if input.round_completion_info:
+        old_manifest = input.deltacat_storage.get_delta_manifest(
+            input.round_completion_info.compacted_delta_locator,
+            **input.deltacat_storage_kwargs,
         )
-        manifest = delta.manifest
-        manifest_records = manifest.meta.record_count
-        assert manifest_records == len(compacted_table), (
-            f"Unexpected Error: Materialized delta manifest record count "
-            f"({manifest_records}) does not equal compacted table record count "
-            f"({len(compacted_table)})"
+
+        new_manifest = Manifest.of(entries=old_manifest.entries, uuid=str(uuid4()))
+        delta = Delta.of(
+            locator=DeltaLocator.of(input.write_to_partition.locator),
+            delta_type=DeltaType.UPSERT,
+            meta=new_manifest.meta,
+            manifest=new_manifest,
+            previous_stream_position=input.write_to_partition.stream_position,
+            properties={},
+        )
+        referenced_pyarrow_write_result = PyArrowWriteResult.of(
+            len(new_manifest.entries),
+            new_manifest.meta.source_content_length,
+            new_manifest.meta.content_length,
+            new_manifest.meta.record_count,
         )
         materialize_result = MaterializeResult.of(
             delta=delta,
-            task_index=hash_bucket_index,
-            # TODO (pdames): Generalize WriteResult to contain in-memory-table-type
-            #  and in-memory-table-bytes instead of tight coupling to paBytes
-            pyarrow_write_result=PyArrowWriteResult.of(
-                len(manifest.entries),
-                TABLE_CLASS_TO_SIZE_FUNC[type(compacted_table)](compacted_table),
-                manifest.meta.content_length,
-                len(compacted_table),
-            ),
+            task_index=input.merge_task_index,
+            pyarrow_write_result=referenced_pyarrow_write_result,
+            referenced_pyarrow_write_result=referenced_pyarrow_write_result,
         )
-        logger.info(f"Materialize result: {materialize_result}")
-        return materialize_result
 
+        materialized_results.append(materialize_result)
+    return materialized_results
+
+
+def _copy_manifests_from_hash_bucketing(input: MergeInput) -> List[MaterializeResult]:
+    materialized_results: List[MaterializeResult] = []
+    hb_dfp_factory = input.merge_file_groups_factory
+
+    if (
+        input.round_completion_info
+        and isinstance(hb_dfp_factory, RemoteMergeFileGroupsFactory)
+        and hb_dfp_factory.hb_index_copy_by_reference_ids
+    ):
+        referenced_materialized_results = (
+            _copy_all_manifest_files_from_old_hash_buckets(
+                hb_dfp_factory.hb_index_copy_by_reference_ids,
+                input.round_completion_info,
+                input.write_to_partition,
+                input.deltacat_storage,
+                input.deltacat_storage_kwargs,
+            )
+        )
+        logger.info(
+            f"Copying {len(referenced_materialized_results)} manifest files by reference..."
+        )
+        materialized_results.extend(referenced_materialized_results)
+
+    return materialized_results
+
+
+def _timed_merge(input: MergeInput) -> MergeResult:
     task_id = get_current_ray_task_id()
     worker_id = get_current_ray_worker_id()
     with memray.Tracker(
         f"merge_{worker_id}_{task_id}.bin"
     ) if input.enable_profiler else nullcontext():
-        # In V2, we need to mitigate risk of running out of memory here in cases of
-        #  severe skew of primary key updates in deltas. By severe skew, we mean
-        #  one hash bucket require more memory than a worker instance have.
-        logger.info(
-            f"[Merge task {input.merge_task_index}] Getting delta file envelope "
-            f"groups for {len(input.dfe_groups_refs)} object refs..."
-        )
-
-        delta_file_envelope_groups_list = input.object_store.get_many(
-            input.dfe_groups_refs
-        )
-        hb_index_to_delta_file_envelopes_list = defaultdict(list)
-        for delta_file_envelope_groups in delta_file_envelope_groups_list:
-            assert input.hash_bucket_count == len(delta_file_envelope_groups), (
-                f"The hash bucket count must match the dfe size as {input.hash_bucket_count}"
-                f" != {len(delta_file_envelope_groups)}"
-            )
-
-            for hb_idx, dfes in enumerate(delta_file_envelope_groups):
-                if dfes:
-                    hb_index_to_delta_file_envelopes_list[hb_idx].append(dfes)
-
-        valid_hb_indices_iterable = hash_group_index_to_hash_bucket_indices(
-            input.hash_group_index, input.hash_bucket_count, input.num_hash_groups
-        )
-
         total_deduped_records = 0
         total_dfes_found = 0
-
         materialized_results: List[MaterializeResult] = []
-        hb_index_copy_by_reference = []
-        for hb_idx in valid_hb_indices_iterable:
-            dfe_list = hb_index_to_delta_file_envelopes_list.get(hb_idx)
+        merge_file_groups = input.merge_file_groups_factory.create()
+        hash_group_index = None
 
-            if dfe_list:
-                total_dfes_found += 1
-                table = _build_incremental_table(hb_idx, dfe_list)
-
-                incremental_len = len(table)
-                logger.info(
-                    f"Got the incremental table of length {incremental_len} for hash bucket {hb_idx}"
-                )
-
-                if input.sort_keys:
-                    # Incremental is sorted and merged, as sorting
-                    # on non event based sort key does not produce consistent
-                    # compaction results. E.g., compaction(delta1, delta2, delta3)
-                    # will not be equal to compaction(compaction(delta1, delta2), delta3).
-                    table = table.sort_by(input.sort_keys)
-
-                compacted_table = None
-                if (
-                    input.round_completion_info
-                    and input.round_completion_info.hb_index_to_entry_range
-                    and input.round_completion_info.hb_index_to_entry_range.get(
-                        str(hb_idx)
-                    )
-                    is not None
-                ):
-
-                    compacted_table = _download_compacted_table(
-                        hb_index=hb_idx,
-                        rcf=input.round_completion_info,
-                        read_kwargs_provider=input.read_kwargs_provider,
-                        deltacat_storage=input.deltacat_storage,
-                        deltacat_storage_kwargs=input.deltacat_storage_kwargs,
-                    )
-
-                hb_table_record_count = len(table) + (
-                    len(compacted_table) if compacted_table else 0
-                )
-
-                table, merge_time = timed_invocation(
-                    func=_merge_tables,
-                    table=table,
-                    primary_keys=input.primary_keys,
-                    can_drop_duplicates=input.drop_duplicates,
-                    compacted_table=compacted_table,
-                )
-                total_deduped_records += hb_table_record_count - len(table)
-
-                logger.info(
-                    f"[Merge task index {input.merge_task_index}] Merged "
-                    f"record count: {len(table)}, size={table.nbytes} took: {merge_time}s"
-                )
-
-                materialized_results.append(_materialize(hb_idx, [table]))
-            else:
-                hb_index_copy_by_reference.append(hb_idx)
-
-        if input.round_completion_info and hb_index_copy_by_reference:
-            referenced_materialized_results = (
-                _copy_all_manifest_files_from_old_hash_buckets(
-                    hb_index_copy_by_reference,
-                    input.round_completion_info,
-                    input.write_to_partition,
-                    input.deltacat_storage,
-                    input.deltacat_storage_kwargs,
-                )
+        for merge_file_group in merge_file_groups:
+            total_dfes_found += 1
+            table, deduped_records = _compact_tables(
+                input, merge_file_group.dfe_groups, merge_file_group.hb_index
             )
-            logger.info(
-                f"Copying {len(referenced_materialized_results)} manifest files by reference..."
+            total_deduped_records += deduped_records
+            merge_task_index = (
+                merge_file_group.hb_index
+                if merge_file_group.hb_index is not None
+                else input.merge_task_index
             )
-            materialized_results.extend(referenced_materialized_results)
+            materialized_results.append(materialize(input, merge_task_index, [table]))
 
+        if (
+            isinstance(input.merge_file_groups_factory, LocalMergeFileGroupsFactory)
+            and not merge_file_groups
+        ):
+            materialized_results.extend(_copy_previous_compacted_table(input))
+
+        if isinstance(input.merge_file_groups_factory, RemoteMergeFileGroupsFactory):
+            hash_group_index = input.merge_file_groups_factory.hash_group_index
+            materialized_results.extend(_copy_manifests_from_hash_bucketing(input))
+
+        hg_prefix_log_statement = (
+            f"[Hash group index: {hash_group_index}]" if hash_group_index else "[Local]"
+        )
         logger.info(
-            "Total number of materialized results produced for "
-            f"hash group index: {input.hash_group_index} is {len(materialized_results)}"
+            f"{hg_prefix_log_statement} Total number of materialized results produced: {len(materialized_results)} "
         )
 
-        assert total_dfes_found == len(hb_index_to_delta_file_envelopes_list), (
-            "The total dfe list does not match the input dfes from hash bucket as "
-            f"{total_dfes_found} != {len(hb_index_to_delta_file_envelopes_list)}"
+        assert total_dfes_found == len(merge_file_groups), (
+            "The total dfe list does not match the input dfes "
+            f"{total_dfes_found} != {len(merge_file_groups)}"
         )
 
         peak_memory_usage_bytes = get_current_process_peak_memory_usage_in_bytes()

--- a/deltacat/compute/compactor_v2/utils/delta.py
+++ b/deltacat/compute/compactor_v2/utils/delta.py
@@ -1,0 +1,97 @@
+import time
+from typing import List, Optional, Tuple
+
+from deltacat.compute.compactor import (
+    DeltaAnnotated,
+    DeltaFileEnvelope,
+)
+
+from deltacat.storage import interface as unimplemented_deltacat_storage
+from deltacat.types.media import StorageType
+from deltacat.utils.common import ReadKwargsProvider
+from deltacat import logs
+
+import pyarrow as pa
+import logging
+
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
+
+
+def read_delta_file_envelopes(
+    annotated_delta: DeltaAnnotated,
+    read_kwargs_provider: Optional[ReadKwargsProvider],
+    deltacat_storage=unimplemented_deltacat_storage,
+    deltacat_storage_kwargs: Optional[dict] = None,
+) -> Tuple[Optional[List[DeltaFileEnvelope]], int, int]:
+    tables = deltacat_storage.download_delta(
+        annotated_delta,
+        max_parallelism=1,
+        file_reader_kwargs_provider=read_kwargs_provider,
+        storage_type=StorageType.LOCAL,
+        **deltacat_storage_kwargs,
+    )
+    annotations = annotated_delta.annotations
+    assert (
+        len(tables) == len(annotations),
+        f"Unexpected Error: Length of downloaded delta manifest tables "
+        f"({len(tables)}) doesn't match the length of delta manifest "
+        f"annotations ({len(annotations)}).",
+    )
+    if not tables:
+        return None, 0, 0
+
+    delta_stream_position = annotations[0].annotation_stream_position
+    delta_type = annotations[0].annotation_delta_type
+
+    for annotation in annotations:
+        assert annotation.annotation_stream_position == delta_stream_position, (
+            f"Annotation stream position does not match - {annotation.annotation_stream_position} "
+            f"!= {delta_stream_position}"
+        )
+        assert annotation.annotation_delta_type == delta_type, (
+            f"Annotation delta type does not match - {annotation.annotation_delta_type} "
+            f"!= {delta_type}"
+        )
+
+    delta_file_envelopes = []
+    table = pa.concat_tables(tables)
+    total_record_count = len(table)
+    total_size_bytes = int(table.nbytes)
+
+    delta_file = DeltaFileEnvelope.of(
+        stream_position=delta_stream_position,
+        delta_type=delta_type,
+        table=table,
+    )
+    delta_file_envelopes.append(delta_file)
+    return delta_file_envelopes, total_record_count, total_size_bytes
+
+
+def get_local_delta_file_envelopes(
+    uniform_deltas: List[DeltaAnnotated],
+    read_kwargs_provider: Optional[ReadKwargsProvider],
+    deltacat_storage=unimplemented_deltacat_storage,
+    deltacat_storage_kwargs: Optional[dict] = None,
+) -> Tuple[List[DeltaFileEnvelope], int]:
+    local_dfe_list = []
+    input_records_count = 0
+    logger.info(f"Getting {len(uniform_deltas)} DFE Tasks.")
+    dfe_start = time.monotonic()
+    for annotated_delta in uniform_deltas:
+        (
+            delta_file_envelopes,
+            total_record_count,
+            total_size_bytes,
+        ) = read_delta_file_envelopes(
+            annotated_delta,
+            read_kwargs_provider,
+            deltacat_storage,
+            deltacat_storage_kwargs,
+        )
+        if delta_file_envelopes:
+            local_dfe_list.extend(delta_file_envelopes)
+            input_records_count += total_record_count
+    dfe_end = time.monotonic()
+    logger.info(f"Retrieved {len(local_dfe_list)} DFE Tasks in {dfe_end - dfe_start}s.")
+    return local_dfe_list, input_records_count

--- a/deltacat/compute/compactor_v2/utils/merge.py
+++ b/deltacat/compute/compactor_v2/utils/merge.py
@@ -1,0 +1,118 @@
+import logging
+
+from deltacat.compute.compactor.model.compact_partition_params import (
+    CompactPartitionParams,
+)
+from deltacat.compute.compactor_v2.model.merge_file_group import (
+    LocalMergeFileGroupsFactory,
+)
+from deltacat.compute.compactor_v2.model.merge_input import MergeInput
+import pyarrow as pa
+from deltacat import logs
+from typing import List, Optional
+
+from deltacat.types.media import DELIMITED_TEXT_CONTENT_TYPES
+from deltacat.compute.compactor.model.materialize_result import MaterializeResult
+from deltacat.compute.compactor.model.pyarrow_write_result import PyArrowWriteResult
+from deltacat.compute.compactor import RoundCompletionInfo, DeltaFileEnvelope
+
+from deltacat.types.tables import TABLE_CLASS_TO_SIZE_FUNC
+
+from deltacat.utils.performance import timed_invocation
+from deltacat.storage import (
+    Partition,
+)
+
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
+
+
+def materialize(
+    input: MergeInput,
+    task_index: int,
+    compacted_tables: List[pa.Table],
+) -> MaterializeResult:
+    compacted_table = pa.concat_tables(compacted_tables)
+    if input.compacted_file_content_type in DELIMITED_TEXT_CONTENT_TYPES:
+        # TODO (rkenmi): Investigate if we still need to convert this table to pandas DataFrame
+        # TODO (pdames): compare performance to pandas-native materialize path
+        df = compacted_table.to_pandas(split_blocks=True, self_destruct=True)
+        compacted_table = df
+    delta, stage_delta_time = timed_invocation(
+        input.deltacat_storage.stage_delta,
+        compacted_table,
+        input.write_to_partition,
+        max_records_per_entry=input.max_records_per_output_file,
+        content_type=input.compacted_file_content_type,
+        s3_table_writer_kwargs=input.s3_table_writer_kwargs,
+        **input.deltacat_storage_kwargs,
+    )
+    compacted_table_size = TABLE_CLASS_TO_SIZE_FUNC[type(compacted_table)](
+        compacted_table
+    )
+    logger.debug(
+        f"Time taken for materialize task"
+        f" to upload {len(compacted_table)} records"
+        f" of size {compacted_table_size} is: {stage_delta_time}s"
+    )
+    manifest = delta.manifest
+    manifest_records = manifest.meta.record_count
+    assert manifest_records == len(compacted_table), (
+        f"Unexpected Error: Materialized delta manifest record count "
+        f"({manifest_records}) does not equal compacted table record count "
+        f"({len(compacted_table)})"
+    )
+    materialize_result = MaterializeResult.of(
+        delta=delta,
+        task_index=task_index,
+        # TODO (pdames): Generalize WriteResult to contain in-memory-table-type
+        #  and in-memory-table-bytes instead of tight coupling to paBytes
+        pyarrow_write_result=PyArrowWriteResult.of(
+            len(manifest.entries),
+            TABLE_CLASS_TO_SIZE_FUNC[type(compacted_table)](compacted_table),
+            manifest.meta.content_length,
+            len(compacted_table),
+        ),
+    )
+    logger.info(f"Materialize result: {materialize_result}")
+    return materialize_result
+
+
+def generate_local_merge_input(
+    params: CompactPartitionParams,
+    delta_file_envelopes: List[DeltaFileEnvelope],
+    compacted_partition: Partition,
+    round_completion_info: Optional[RoundCompletionInfo],
+):
+    """
+    Generates a merge input for local deltas that do not reside in the Ray object store and
+    have not been subject to the hash bucketing process.
+
+    Args:
+        params: parameters for compacting a partition
+        delta_file_envelopes: a list of delta file envelopes
+        compacted_partition: the compacted partition to write to
+        round_completion_info: keeps track of high watermarks and other metadata from previous compaction rounds
+
+    Returns:
+        A MergeInput object
+
+    """
+
+    return MergeInput.of(
+        merge_file_groups_factory=LocalMergeFileGroupsFactory(delta_file_envelopes),
+        write_to_partition=compacted_partition,
+        compacted_file_content_type=params.compacted_file_content_type,
+        primary_keys=params.primary_keys,
+        sort_keys=params.sort_keys,
+        drop_duplicates=params.drop_duplicates,
+        max_records_per_output_file=params.records_per_compacted_file,
+        enable_profiler=params.enable_profiler,
+        metrics_config=params.metrics_config,
+        s3_table_writer_kwargs=params.s3_table_writer_kwargs,
+        read_kwargs_provider=params.read_kwargs_provider,
+        round_completion_info=round_completion_info,
+        object_store=params.object_store,
+        deltacat_storage=params.deltacat_storage,
+        deltacat_storage_kwargs=params.deltacat_storage_kwargs,
+    )

--- a/deltacat/tests/compute/compact_partition_test_cases.py
+++ b/deltacat/tests/compute/compact_partition_test_cases.py
@@ -442,6 +442,33 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         drop_duplicates=True,
         skip_enabled_compact_partition_drivers=None,
     ),
+    "12-incremental-decimal-single-hash-bucket": IncrementalCompactionTestCaseParams(
+        primary_keys={"pk_col_1"},
+        sort_keys=[SortKey.of(key_name="sk_col_1")],
+        partition_keys=ZERO_VALUED_PARTITION_KEYS_PARAM,
+        partition_values=ZERO_VALUED_PARTITION_VALUES_PARAM,
+        input_deltas=pa.Table.from_arrays(
+            [
+                pa.array([0.1] * 4 + [0.2] * 4 + [0.3] * 4 + [0.4] * 4 + [0.5] * 4),
+                pa.array([i for i in range(20)]),
+            ],
+            names=["pk_col_1", "sk_col_1"],
+        ),
+        input_deltas_delta_type=DeltaType.UPSERT,
+        expected_terminal_compact_partition_result=pa.Table.from_arrays(
+            [
+                pa.array([0.1, 0.2, 0.3, 0.4, 0.5]),
+                pa.array([3, 7, 11, 15, 19]),
+            ],
+            names=["pk_col_1", "sk_col_1"],
+        ),
+        do_create_placement_group=False,
+        records_per_compacted_file=DEFAULT_MAX_RECORDS_PER_FILE,
+        hash_bucket_count=1,
+        read_kwargs_provider=None,
+        drop_duplicates=True,
+        skip_enabled_compact_partition_drivers=None,
+    ),
 }
 
 REBASE_THEN_INCREMENTAL_TEST_CASES = {
@@ -1130,6 +1157,104 @@ REBASE_THEN_INCREMENTAL_TEST_CASES = {
         ),
         do_create_placement_group=False,
         records_per_compacted_file=DEFAULT_MAX_RECORDS_PER_FILE,
+        hash_bucket_count=3,
+        read_kwargs_provider=None,
+        drop_duplicates=True,
+        skip_enabled_compact_partition_drivers=None,
+    ),
+    "15-rebase-then-incremental-hash-bucket-single": RebaseThenIncrementalCompactionTestCaseParams(
+        primary_keys={"pk_col_1"},
+        sort_keys=[
+            SortKey.of(key_name="sk_col_1"),
+            SortKey.of(key_name="sk_col_2"),
+        ],
+        partition_keys=[PartitionKey.of("region_id", PartitionKeyType.INT)],
+        partition_values=["1"],
+        input_deltas=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(0, 10)]),
+                pa.array(["foo"] * 10),
+                pa.array([i / 10 for i in range(10, 20)]),
+            ],
+            names=["pk_col_1", "sk_col_1", "sk_col_2", "col_1"],
+        ),
+        input_deltas_delta_type=DeltaType.UPSERT,
+        rebase_expected_compact_partition_result=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(0, 10)]),
+                pa.array(["foo"] * 10),
+                pa.array([i / 10 for i in range(10, 20)]),
+            ],
+            names=["pk_col_1", "sk_col_1", "sk_col_2", "col_1"],
+        ),
+        incremental_deltas=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(20, 30)]),
+                pa.array(["foo"] * 10),
+                pa.array([i / 10 for i in range(40, 50)]),
+            ],
+            names=["pk_col_1", "sk_col_1", "sk_col_2", "col_1"],
+        ),
+        incremental_deltas_delta_type=DeltaType.UPSERT,
+        expected_terminal_compact_partition_result=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(20, 30)]),
+                pa.array(["foo"] * 10),
+                pa.array([i / 10 for i in range(40, 50)]),
+            ],
+            names=["pk_col_1", "sk_col_1", "sk_col_2", "col_1"],
+        ),
+        do_create_placement_group=False,
+        records_per_compacted_file=DEFAULT_MAX_RECORDS_PER_FILE,
+        hash_bucket_count=1,
+        read_kwargs_provider=None,
+        drop_duplicates=True,
+        skip_enabled_compact_partition_drivers=None,
+    ),
+    "16-rebase-then-empty-incremental-delta-hash-bucket-single": RebaseThenIncrementalCompactionTestCaseParams(
+        primary_keys={"pk_col_1"},
+        sort_keys=[
+            SortKey.of(key_name="sk_col_1"),
+            SortKey.of(key_name="sk_col_2"),
+        ],
+        partition_keys=[PartitionKey.of("region_id", PartitionKeyType.INT)],
+        partition_values=["1"],
+        input_deltas=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(0, 10)]),
+                pa.array(["foo"] * 10),
+                pa.array([i / 10 for i in range(10, 20)]),
+            ],
+            names=["pk_col_1", "sk_col_1", "sk_col_2", "col_1"],
+        ),
+        input_deltas_delta_type=DeltaType.UPSERT,
+        rebase_expected_compact_partition_result=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(0, 10)]),
+                pa.array(["foo"] * 10),
+                pa.array([i / 10 for i in range(10, 20)]),
+            ],
+            names=["pk_col_1", "sk_col_1", "sk_col_2", "col_1"],
+        ),
+        incremental_deltas=None,
+        incremental_deltas_delta_type=DeltaType.UPSERT,
+        expected_terminal_compact_partition_result=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(0, 10)]),
+                pa.array(["foo"] * 10),
+                pa.array([i / 10 for i in range(10, 20)]),
+            ],
+            names=["pk_col_1", "sk_col_1", "sk_col_2", "col_1"],
+        ),
+        do_create_placement_group=False,
+        records_per_compacted_file=DEFAULT_MAX_RECORDS_PER_FILE,
         hash_bucket_count=1,
         read_kwargs_provider=None,
         drop_duplicates=True,
@@ -1137,8 +1262,8 @@ REBASE_THEN_INCREMENTAL_TEST_CASES = {
     ),
 }
 
-
 INCREMENTAL_TEST_CASES = with_compactor_version_func_test_param(INCREMENTAL_TEST_CASES)
+
 
 REBASE_THEN_INCREMENTAL_TEST_CASES = with_compactor_version_func_test_param(
     REBASE_THEN_INCREMENTAL_TEST_CASES

--- a/deltacat/tests/compute/compactor_v2/steps/test_merge.py
+++ b/deltacat/tests/compute/compactor_v2/steps/test_merge.py
@@ -6,8 +6,8 @@ from typing import List
 from collections import defaultdict
 
 from deltacat.compute.compactor_v2.model.merge_file_group import (
-    RemoteMergeFileGroupsFactory,
-    LocalMergeFileGroupsFactory,
+    RemoteMergeFileGroupsProvider,
+    LocalMergeFileGroupsProvider,
 )
 from deltacat.compute.compactor_v2.utils.delta import read_delta_file_envelopes
 from deltacat.storage import Delta, DeltaType
@@ -80,7 +80,7 @@ class TestMerge(unittest.TestCase):
             merge_input_list.append(
                 MergeInput.of(
                     compacted_file_content_type=ContentType.PARQUET,
-                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                    merge_file_groups_provider=RemoteMergeFileGroupsProvider(
                         hash_group_index=hg_index,
                         dfe_groups_refs=dfes,
                         hash_bucket_count=number_of_hash_bucket,
@@ -127,7 +127,7 @@ class TestMerge(unittest.TestCase):
             merge_input_list.append(
                 MergeInput.of(
                     compacted_file_content_type=ContentType.PARQUET,
-                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                    merge_file_groups_provider=RemoteMergeFileGroupsProvider(
                         hash_group_index=hg_index,
                         dfe_groups_refs=dfes,
                         hash_bucket_count=number_of_hash_bucket,
@@ -174,7 +174,7 @@ class TestMerge(unittest.TestCase):
             merge_input_list.append(
                 MergeInput.of(
                     compacted_file_content_type=ContentType.PARQUET,
-                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                    merge_file_groups_provider=RemoteMergeFileGroupsProvider(
                         hash_group_index=hg_index,
                         dfe_groups_refs=dfes,
                         hash_bucket_count=number_of_hash_bucket,
@@ -222,7 +222,7 @@ class TestMerge(unittest.TestCase):
             merge_input_list.append(
                 MergeInput.of(
                     compacted_file_content_type=ContentType.PARQUET,
-                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                    merge_file_groups_provider=RemoteMergeFileGroupsProvider(
                         hash_group_index=hg_index,
                         dfe_groups_refs=dfes,
                         hash_bucket_count=number_of_hash_bucket,
@@ -278,14 +278,14 @@ class TestMerge(unittest.TestCase):
             hb_index_to_entry_range=hb_id_to_entry_indices_range,
         )
 
-        new_da = DeltaAnnotated.of(new_delta)
-        dfes = self._prepare_merge_inputs_single_hb(new_da)
-
         merge_input = MergeInput.of(
             round_completion_info=rcf,
             compacted_file_content_type=ContentType.PARQUET,
-            merge_file_groups_factory=LocalMergeFileGroupsFactory(
-                delta_file_envelopes=dfes
+            merge_file_groups_provider=LocalMergeFileGroupsProvider(
+                uniform_deltas=[DeltaAnnotated.of(new_delta)],
+                read_kwargs_provider=None,
+                deltacat_storage=ds,
+                deltacat_storage_kwargs=self.deltacat_storage_kwargs,
             ),
             write_to_partition=partition,
             primary_keys=["pk1"],
@@ -352,7 +352,7 @@ class TestMerge(unittest.TestCase):
                 MergeInput.of(
                     round_completion_info=rcf,
                     compacted_file_content_type=ContentType.PARQUET,
-                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                    merge_file_groups_provider=RemoteMergeFileGroupsProvider(
                         hash_group_index=hg_index,
                         dfe_groups_refs=dfes,
                         hash_bucket_count=number_of_hash_bucket,
@@ -391,8 +391,11 @@ class TestMerge(unittest.TestCase):
 
         merge_input = MergeInput.of(
             compacted_file_content_type=ContentType.PARQUET,
-            merge_file_groups_factory=LocalMergeFileGroupsFactory(
-                delta_file_envelopes=dfes_groups
+            merge_file_groups_provider=LocalMergeFileGroupsProvider(
+                uniform_deltas=[DeltaAnnotated.of(old_delta)],
+                read_kwargs_provider=None,
+                deltacat_storage=ds,
+                deltacat_storage_kwargs=self.deltacat_storage_kwargs,
             ),
             write_to_partition=partition,
             primary_keys=["pk"],
@@ -420,8 +423,11 @@ class TestMerge(unittest.TestCase):
         dfes_groups, _, _ = self._extract_dfes_from_delta(new_delta)
         merge_input = MergeInput.of(
             compacted_file_content_type=ContentType.PARQUET,
-            merge_file_groups_factory=LocalMergeFileGroupsFactory(
-                delta_file_envelopes=dfes_groups
+            merge_file_groups_provider=LocalMergeFileGroupsProvider(
+                uniform_deltas=[DeltaAnnotated.of(new_delta)],
+                read_kwargs_provider=None,
+                deltacat_storage=ds,
+                deltacat_storage_kwargs=self.deltacat_storage_kwargs,
             ),
             write_to_partition=partition,
             primary_keys=["pk1", "pk2"],

--- a/deltacat/tests/compute/compactor_v2/steps/test_merge.py
+++ b/deltacat/tests/compute/compactor_v2/steps/test_merge.py
@@ -4,6 +4,12 @@ import ray
 import os
 from typing import List
 from collections import defaultdict
+
+from deltacat.compute.compactor_v2.model.merge_file_group import (
+    RemoteMergeFileGroupsFactory,
+    LocalMergeFileGroupsFactory,
+)
+from deltacat.compute.compactor_v2.utils.delta import read_delta_file_envelopes
 from deltacat.storage import Delta, DeltaType
 from deltacat.compute.compactor import DeltaAnnotated, RoundCompletionInfo
 import deltacat.tests.local_deltacat_storage as ds
@@ -15,7 +21,6 @@ from deltacat.compute.compactor_v2.steps.hash_bucket import hash_bucket
 from deltacat.compute.compactor_v2.steps.merge import merge
 from deltacat.utils.common import current_time_ms
 from deltacat.types.media import ContentType
-
 from deltacat.tests.test_utils.pyarrow import (
     create_delta_from_csv_file,
     stage_partition_from_file_paths,
@@ -41,15 +46,17 @@ class TestMerge(unittest.TestCase):
     def setUpClass(cls):
         ray.init(local_mode=True, ignore_reinit_error=True)
 
+        super().setUpClass()
+
+    @classmethod
+    def setUp(cls):
         con = sqlite3.connect(cls.DB_FILE_PATH)
         cur = con.cursor()
         cls.kwargs = {ds.SQLITE_CON_ARG: con, ds.SQLITE_CUR_ARG: cur}
         cls.deltacat_storage_kwargs = {ds.DB_FILE_PATH_ARG: cls.DB_FILE_PATH}
 
-        super().setUpClass()
-
     @classmethod
-    def doClassCleanups(cls) -> None:
+    def tearDown(cls):
         os.remove(cls.DB_FILE_PATH)
 
     def test_merge_multiple_hash_group_string_pk(self):
@@ -73,10 +80,13 @@ class TestMerge(unittest.TestCase):
             merge_input_list.append(
                 MergeInput.of(
                     compacted_file_content_type=ContentType.PARQUET,
-                    hash_group_index=hg_index,
-                    hash_bucket_count=number_of_hash_bucket,
-                    num_hash_groups=number_of_hash_group,
-                    dfe_groups_refs=dfes,
+                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                        hash_group_index=hg_index,
+                        dfe_groups_refs=dfes,
+                        hash_bucket_count=number_of_hash_bucket,
+                        num_hash_groups=number_of_hash_group,
+                        object_store=object_store,
+                    ),
                     write_to_partition=partition,
                     primary_keys=["pk"],
                     deltacat_storage=ds,
@@ -117,10 +127,13 @@ class TestMerge(unittest.TestCase):
             merge_input_list.append(
                 MergeInput.of(
                     compacted_file_content_type=ContentType.PARQUET,
-                    hash_group_index=hg_index,
-                    hash_bucket_count=number_of_hash_bucket,
-                    num_hash_groups=number_of_hash_group,
-                    dfe_groups_refs=dfes,
+                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                        hash_group_index=hg_index,
+                        dfe_groups_refs=dfes,
+                        hash_bucket_count=number_of_hash_bucket,
+                        num_hash_groups=number_of_hash_group,
+                        object_store=object_store,
+                    ),
                     write_to_partition=partition,
                     primary_keys=["pk1", "pk2"],
                     deltacat_storage=ds,
@@ -161,10 +174,13 @@ class TestMerge(unittest.TestCase):
             merge_input_list.append(
                 MergeInput.of(
                     compacted_file_content_type=ContentType.PARQUET,
-                    hash_group_index=hg_index,
-                    hash_bucket_count=number_of_hash_bucket,
-                    num_hash_groups=number_of_hash_group,
-                    dfe_groups_refs=dfes,
+                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                        hash_group_index=hg_index,
+                        dfe_groups_refs=dfes,
+                        hash_bucket_count=number_of_hash_bucket,
+                        num_hash_groups=number_of_hash_group,
+                        object_store=object_store,
+                    ),
                     write_to_partition=partition,
                     primary_keys=[],
                     deltacat_storage=ds,
@@ -206,10 +222,13 @@ class TestMerge(unittest.TestCase):
             merge_input_list.append(
                 MergeInput.of(
                     compacted_file_content_type=ContentType.PARQUET,
-                    hash_group_index=hg_index,
-                    hash_bucket_count=number_of_hash_bucket,
-                    num_hash_groups=number_of_hash_group,
-                    dfe_groups_refs=dfes,
+                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                        hash_group_index=hg_index,
+                        dfe_groups_refs=dfes,
+                        hash_bucket_count=number_of_hash_bucket,
+                        num_hash_groups=number_of_hash_group,
+                        object_store=object_store,
+                    ),
                     write_to_partition=partition,
                     drop_duplicates=False,
                     primary_keys=["pk1", "pk2"],
@@ -227,8 +246,6 @@ class TestMerge(unittest.TestCase):
         self._validate_merge_output(merge_res_list, 10)
 
     def test_merge_when_delete_type_deltas_are_merged(self):
-        number_of_hash_group = 1
-        number_of_hash_bucket = 1
         partition = stage_partition_from_file_paths(
             self._testMethodName,
             [self.DEDUPE_BASE_COMPACTED_TABLE_MULTIPLE_PK],
@@ -261,36 +278,25 @@ class TestMerge(unittest.TestCase):
             hb_index_to_entry_range=hb_id_to_entry_indices_range,
         )
 
-        all_hash_group_idx_to_obj_id_new = self._prepare_merge_inputs(
-            new_delta,
-            object_store,
-            number_of_hash_bucket,
-            number_of_hash_group,
-            ["pk1"],
-        )
+        new_da = DeltaAnnotated.of(new_delta)
+        dfes = self._prepare_merge_inputs_single_hb(new_da)
 
-        merge_input_list = []
-        for hg_index, dfes in all_hash_group_idx_to_obj_id_new.items():
-            merge_input_list.append(
-                MergeInput.of(
-                    round_completion_info=rcf,
-                    compacted_file_content_type=ContentType.PARQUET,
-                    hash_group_index=hg_index,
-                    hash_bucket_count=number_of_hash_bucket,
-                    num_hash_groups=number_of_hash_group,
-                    dfe_groups_refs=dfes,
-                    write_to_partition=partition,
-                    primary_keys=["pk1"],
-                    deltacat_storage=ds,
-                    deltacat_storage_kwargs=self.deltacat_storage_kwargs,
-                    object_store=object_store,
-                )
-            )
+        merge_input = MergeInput.of(
+            round_completion_info=rcf,
+            compacted_file_content_type=ContentType.PARQUET,
+            merge_file_groups_factory=LocalMergeFileGroupsFactory(
+                delta_file_envelopes=dfes
+            ),
+            write_to_partition=partition,
+            primary_keys=["pk1"],
+            deltacat_storage=ds,
+            deltacat_storage_kwargs=self.deltacat_storage_kwargs,
+            object_store=object_store,
+        )
         merge_res_list = []
-        for merge_input in merge_input_list:
-            merge_result_promise = merge.remote(merge_input)
-            merge_result = ray.get(merge_result_promise)
-            merge_res_list.append(merge_result)
+        merge_result_promise = merge.remote(merge_input)
+        merge_result = ray.get(merge_result_promise)
+        merge_res_list.append(merge_result)
 
         # All records vanish
         self._validate_merge_output(merge_res_list, 0)
@@ -346,10 +352,13 @@ class TestMerge(unittest.TestCase):
                 MergeInput.of(
                     round_completion_info=rcf,
                     compacted_file_content_type=ContentType.PARQUET,
-                    hash_group_index=hg_index,
-                    hash_bucket_count=number_of_hash_bucket,
-                    num_hash_groups=number_of_hash_group,
-                    dfe_groups_refs=dfes,
+                    merge_file_groups_factory=RemoteMergeFileGroupsFactory(
+                        hash_group_index=hg_index,
+                        dfe_groups_refs=dfes,
+                        hash_bucket_count=number_of_hash_bucket,
+                        num_hash_groups=number_of_hash_group,
+                        object_store=object_store,
+                    ),
                     write_to_partition=partition,
                     primary_keys=["pk"],
                     deltacat_storage=ds,
@@ -368,6 +377,75 @@ class TestMerge(unittest.TestCase):
         # result: 1 + 9 - 2 = 8
         self._validate_merge_output(merge_res_list, 8)
 
+    def test_merge_single_hash_bucket_string_pk(self):
+        partition = stage_partition_from_file_paths(
+            self.MERGE_NAMESPACE,
+            [self.DEDUPE_BASE_COMPACTED_TABLE_STRING_PK],
+            **self.kwargs,
+        )
+        old_delta = commit_delta_to_staged_partition(
+            partition, [self.DEDUPE_BASE_COMPACTED_TABLE_STRING_PK], **self.kwargs
+        )
+        object_store = RayPlasmaObjectStore()
+        dfes_groups, _, _ = self._extract_dfes_from_delta(old_delta)
+
+        merge_input = MergeInput.of(
+            compacted_file_content_type=ContentType.PARQUET,
+            merge_file_groups_factory=LocalMergeFileGroupsFactory(
+                delta_file_envelopes=dfes_groups
+            ),
+            write_to_partition=partition,
+            primary_keys=["pk"],
+            deltacat_storage=ds,
+            deltacat_storage_kwargs=self.deltacat_storage_kwargs,
+            object_store=object_store,
+        )
+        merge_res_list = []
+        merge_result_promise = merge.remote(merge_input)
+        merge_result = ray.get(merge_result_promise)
+        merge_res_list.append(merge_result)
+        # 8 unique pk, no duplication
+        self._validate_merge_output(merge_res_list, 8)
+
+    def test_merge_single_hash_bucket_multiple_pk(self):
+        partition = stage_partition_from_file_paths(
+            self.MERGE_NAMESPACE,
+            [self.DEDUPE_WITH_DUPLICATION_MULTIPLE_PK],
+            **self.kwargs,
+        )
+        new_delta = commit_delta_to_staged_partition(
+            partition, [self.DEDUPE_WITH_DUPLICATION_MULTIPLE_PK], **self.kwargs
+        )
+        object_store = RayPlasmaObjectStore()
+        dfes_groups, _, _ = self._extract_dfes_from_delta(new_delta)
+        merge_input = MergeInput.of(
+            compacted_file_content_type=ContentType.PARQUET,
+            merge_file_groups_factory=LocalMergeFileGroupsFactory(
+                delta_file_envelopes=dfes_groups
+            ),
+            write_to_partition=partition,
+            primary_keys=["pk1", "pk2"],
+            deltacat_storage=ds,
+            deltacat_storage_kwargs=self.deltacat_storage_kwargs,
+            object_store=object_store,
+        )
+        merge_res_list = []
+        merge_result_promise = merge.remote(merge_input)
+        merge_result = ray.get(merge_result_promise)
+        merge_res_list.append(merge_result)
+        # 10 records, 2 duplication, record count left should be 8
+        self._validate_merge_output(merge_res_list, 8)
+
+    def _extract_dfes_from_delta(self, delta_to_merge: Delta):
+        annotated_delta = DeltaAnnotated.of(delta_to_merge)
+        dfes = read_delta_file_envelopes(
+            annotated_delta,
+            read_kwargs_provider=None,
+            deltacat_storage=ds,
+            deltacat_storage_kwargs=self.deltacat_storage_kwargs,
+        )
+        return dfes
+
     def _prepare_merge_inputs(
         self, delta_to_merge, object_store, num_hash_bucket, num_hash_group, pk
     ):
@@ -376,6 +454,15 @@ class TestMerge(unittest.TestCase):
         )
         merge_input = self._hb_output_to_merge_input(hb_output, num_hash_group)
         return merge_input
+
+    def _prepare_merge_inputs_single_hb(self, delta_to_merge):
+        dfes, _, _ = read_delta_file_envelopes(
+            delta_to_merge,
+            read_kwargs_provider=None,
+            deltacat_storage=ds,
+            deltacat_storage_kwargs=self.deltacat_storage_kwargs,
+        )
+        return dfes
 
     def _run_hash_bucketing(
         self, delta_to_merge, object_store, num_hash_bucket, num_hash_group, pk


### PR DESCRIPTION
This PR adds a feature to skip hash bucketing if the user-supplied hash bucket count is set to 1.

Changes
- If hash bucket count is set to 1, delta file envelopes are loaded into the `merge` step directly to compact tables
- Since the `merge` step could be dealing with delta file envelope object refs (remote) or pure delta file envelopes (local), an abstraction layer is added for delta file envelope retrieval during invoke by `merge`.

Initial Benchmarks

Input Delta Size | Default Run 1 (secs) | Default Run 2 (secs) | Default Run 3 (secs) | Default Avg. (secs) | Skip HB Run 1 (secs) | Skip HB Run 2 (secs) | Skip HB Run 3 (secs) | Skip HB Avg. (secs) | Skip HB % Improvement
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1.2 GB | 196.80 | 194.44 | 194.91 | 195.38 | 80.54 | 79.88 | 78.95 | 79.79 | 59.16%
1.7 GB | 231.34 | 215.52 | 251.69 | 232.85 | 117.79 | 113.73 | 117.22 | 116.25 | 50.08%
3.5 GB | 259.40 | 304.18 | 264.16 | 275.91 | 249.14 | 257.83 | 231.42 | 246.13 | 10.79%
6.5 GB | 377.45 | 349.44 | 336.23 | 354.37 | 377.27 | 369.76 | 305.44 | 350.82 | 1%



