### PR TITLE
Increase memory allocation calculation based on missed memory inefficiencies

### DIFF
--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -170,9 +170,16 @@ def hash_bucket_resource_options_provider(
             else:
                 total_pk_size += pk_size
 
-    # total size + pk size + pk hash column + hash bucket index column
+    # total size + pk size + pyarrow-to-numpy conversion + pk hash column + hashlib inefficiency + hash bucket index column
     # Refer to hash_bucket step for more details.
-    total_memory = size_bytes + total_pk_size + num_rows * 20 + num_rows * 4
+    total_memory = (
+        size_bytes
+        + total_pk_size
+        + total_pk_size
+        + num_rows * 20
+        + num_rows * 20
+        + num_rows * 4
+    )
     debug_memory_params["size_bytes"] = size_bytes
     debug_memory_params["num_rows"] = num_rows
     debug_memory_params["total_pk_size"] = total_pk_size
@@ -272,11 +279,13 @@ def merge_resource_options_provider(
                     else:
                         pk_size_bytes += pk_size
 
-    # total data downloaded + primary key hash column + primary key column
-    # + dict size for merge + incremental index array size
+    # total data downloaded + primary key hash column + pyarrow-to-numpy conversion
+    # + primary key column + hashlib inefficiency + dict size for merge + incremental index array size
     total_memory = (
         data_size
         + pk_size_bytes
+        + pk_size_bytes
+        + num_rows * 20
         + num_rows * 20
         + num_rows * 20
         + incremental_index_array_size


### PR DESCRIPTION
The existing memory allocation logic does not account for several unexpected inefficiencies. 

These inefficiencies are:

1. When converting the pyarrow table to numpy, the process memory usage is doubling, indicating that pyarrow is not performing a zero-copy conversion like we expected. To account for this, we add the pk_size_bytes attribute again.
2. When generating sha1 hashes using hashlib, the memory inefficiencies of the library accumulate for tables with large numbers of primary keys. To account for this, we add num_rows * 20 again.

Testing:
 - These changes were tested by running on personal stack and verifying the memory allocation limit was increased.