### PR TITLE
Pass region into daft io-config to prevent s3 client hitting imds

### DIFF
--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -12,7 +12,11 @@ from deltacat.utils.common import ReadKwargsProvider
 from deltacat.utils.schema import coerce_pyarrow_table_to_schema
 
 from deltacat.types.media import ContentType, ContentEncoding
-from deltacat.aws.constants import BOTO_MAX_RETRIES, DAFT_MAX_S3_CONNECTIONS_PER_FILE
+from deltacat.aws.constants import (
+    BOTO_MAX_RETRIES,
+    DAFT_MAX_S3_CONNECTIONS_PER_FILE,
+    AWS_REGION,
+)
 from deltacat.utils.performance import timed_invocation
 
 from deltacat.types.partial_download import (
@@ -155,6 +159,7 @@ def _get_s3_io_config(s3_client_kwargs) -> IOConfig:
             key_id=s3_client_kwargs.get("aws_access_key_id"),
             access_key=s3_client_kwargs.get("aws_secret_access_key"),
             session_token=s3_client_kwargs.get("aws_session_token"),
+            region_name=AWS_REGION,
             retry_mode="adaptive",
             num_tries=BOTO_MAX_RETRIES,
             max_connections=DAFT_MAX_S3_CONNECTIONS_PER_FILE,


### PR DESCRIPTION
* Pass AWS region into Daft `IOConfig` which will allow daft to avoid hitting the local IMDS.
* Hitting the IMDS server under load has yielded errors such as `hyper::Error(Connect, ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: Temporary failure in name resolution" }))`
* However to skip IMDS, we have to use a version of daft that was build after this merged https://github.com/Eventual-Inc/Daft/pull/1886 which should be `getdaft== 0.2.15`
* I will make a follow on PR that upgrades daft to this version as well