### PR TITLE
Provide resource estimates for local merge

### DIFF
--- a/deltacat/compute/compactor/model/compact_partition_params.py
+++ b/deltacat/compute/compactor/model/compact_partition_params.py
@@ -95,6 +95,8 @@ class CompactPartitionParams(dict):
         result.drop_duplicates = params.get("drop_duplicates", DROP_DUPLICATES)
         result.ray_custom_resources = params.get("ray_custom_resources")
 
+        result.memory_logs_enabled = params.get("memory_logs_enabled", False)
+
         result.metrics_config = params.get("metrics_config")
 
         if not importlib.util.find_spec("memray"):
@@ -366,6 +368,14 @@ class CompactPartitionParams(dict):
     @sort_keys.setter
     def sort_keys(self, keys: List[SortKey]) -> None:
         self["sort_keys"] = keys
+
+    @property
+    def memory_logs_enabled(self) -> bool:
+        return self.get("memory_logs_enabled")
+
+    @memory_logs_enabled.setter
+    def memory_logs_enabled(self, value: bool) -> None:
+        self["memory_logs_enabled"] = value
 
     @property
     def metrics_config(self) -> Optional[MetricsConfig]:

--- a/deltacat/compute/compactor/model/compact_partition_params.py
+++ b/deltacat/compute/compactor/model/compact_partition_params.py
@@ -201,7 +201,9 @@ class CompactPartitionParams(dict):
         return self["total_memory_buffer_percentage"]
 
     @total_memory_buffer_percentage.setter
-    def total_memory_buffer_percentage(self, total_memory_buffer_percentage: int) -> None:
+    def total_memory_buffer_percentage(
+        self, total_memory_buffer_percentage: int
+    ) -> None:
         self["total_memory_buffer_percentage"] = total_memory_buffer_percentage
 
     @property

--- a/deltacat/compute/compactor/model/compact_partition_params.py
+++ b/deltacat/compute/compactor/model/compact_partition_params.py
@@ -20,6 +20,7 @@ from deltacat.compute.compactor_v2.constants import (
     AVERAGE_RECORD_SIZE_BYTES,
     TASK_MAX_PARALLELISM,
     DROP_DUPLICATES,
+    TOTAL_MEMORY_BUFFER_PERCENTAGE,
 )
 from deltacat.constants import PYARROW_INFLATION_MULTIPLIER
 from deltacat.compute.compactor.utils.sort_key import validate_sort_keys
@@ -84,6 +85,9 @@ class CompactPartitionParams(dict):
         )
         result.average_record_size_bytes = params.get(
             "average_record_size_bytes", AVERAGE_RECORD_SIZE_BYTES
+        )
+        result.total_memory_buffer_percentage = params.get(
+            "total_memory_buffer_percentage", TOTAL_MEMORY_BUFFER_PERCENTAGE
         )
         result.hash_group_count = params.get(
             "hash_group_count", result.hash_bucket_count
@@ -189,6 +193,14 @@ class CompactPartitionParams(dict):
     @average_record_size_bytes.setter
     def average_record_size_bytes(self, average_record_size_bytes: float) -> None:
         self["average_record_size_bytes"] = average_record_size_bytes
+
+    @property
+    def total_memory_buffer_percentage(self) -> int:
+        return self["total_memory_buffer_percentage"]
+
+    @total_memory_buffer_percentage.setter
+    def total_memory_buffer_percentage(self, total_memory_buffer_percentage: int) -> None:
+        self["total_memory_buffer_percentage"] = total_memory_buffer_percentage
 
     @property
     def min_files_in_batch(self) -> float:

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -261,6 +261,7 @@ def _execute_compaction(
         average_record_size_bytes=params.average_record_size_bytes,
         primary_keys=params.primary_keys,
         ray_custom_resources=params.ray_custom_resources,
+        memory_logs_enabled=params.memory_logs_enabled,
     )
 
     total_input_records_count = np.int64(0)
@@ -318,6 +319,7 @@ def _execute_compaction(
                     object_store=params.object_store,
                     deltacat_storage=params.deltacat_storage,
                     deltacat_storage_kwargs=params.deltacat_storage_kwargs,
+                    memory_logs_enabled=params.memory_logs_enabled,
                 )
             }
 
@@ -411,6 +413,7 @@ def _execute_compaction(
             deltacat_storage=params.deltacat_storage,
             deltacat_storage_kwargs=params.deltacat_storage_kwargs,
             ray_custom_resources=params.ray_custom_resources,
+            memory_logs_enabled=params.memory_logs_enabled,
         )
 
         def merge_input_provider(index, item):
@@ -440,6 +443,7 @@ def _execute_compaction(
                     deltacat_storage_kwargs=params.deltacat_storage_kwargs,
                     delete_strategy=delete_strategy,
                     delete_file_envelopes=delete_file_envelopes,
+                    memory_logs_enabled=params.memory_logs_enabled,
                 )
             }
 

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -295,6 +295,7 @@ def _execute_compaction(
             compacted_delta_manifest=previous_compacted_delta_manifest,
             ray_custom_resources=params.ray_custom_resources,
             primary_keys=params.primary_keys,
+            memory_logs_enabled=params.memory_logs_enabled,
         )
         local_merge_result = ray.get(
             mg.merge.options(**local_merge_options).remote(local_merge_input)

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -289,6 +289,7 @@ def _execute_compaction(
         local_merge_options = local_merge_resource_options_provider(
             estimated_da_size=estimated_da_bytes,
             estimated_num_rows=estimated_num_records,
+            total_memory_buffer_percentage=params.total_memory_buffer_percentage,
             round_completion_info=round_completion_info,
             compacted_delta_manifest=previous_compacted_delta_manifest,
             ray_custom_resources=params.ray_custom_resources,
@@ -403,6 +404,7 @@ def _execute_compaction(
             num_hash_groups=params.hash_group_count,
             hash_group_size_bytes=all_hash_group_idx_to_size_bytes,
             hash_group_num_rows=all_hash_group_idx_to_num_rows,
+            total_memory_buffer_percentage=params.total_memory_buffer_percentage,
             round_completion_info=round_completion_info,
             compacted_delta_manifest=previous_compacted_delta_manifest,
             primary_keys=params.primary_keys,

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -259,6 +259,7 @@ def _execute_compaction(
         resource_amount_provider=hash_bucket_resource_options_provider,
         previous_inflation=params.previous_inflation,
         average_record_size_bytes=params.average_record_size_bytes,
+        total_memory_buffer_percentage=params.total_memory_buffer_percentage,
         primary_keys=params.primary_keys,
         ray_custom_resources=params.ray_custom_resources,
         memory_logs_enabled=params.memory_logs_enabled,

--- a/deltacat/compute/compactor_v2/model/hash_bucket_input.py
+++ b/deltacat/compute/compactor_v2/model/hash_bucket_input.py
@@ -22,6 +22,7 @@ class HashBucketInput(Dict):
         object_store: Optional[IObjectStore] = None,
         deltacat_storage=unimplemented_deltacat_storage,
         deltacat_storage_kwargs: Optional[Dict[str, Any]] = None,
+        memory_logs_enabled: Optional[bool] = None,
     ) -> HashBucketInput:
 
         result = HashBucketInput()
@@ -36,6 +37,7 @@ class HashBucketInput(Dict):
         result["object_store"] = object_store
         result["deltacat_storage"] = deltacat_storage
         result["deltacat_storage_kwargs"] = deltacat_storage_kwargs or {}
+        result["memory_logs_enabled"] = memory_logs_enabled
 
         return result
 
@@ -82,3 +84,7 @@ class HashBucketInput(Dict):
     @property
     def deltacat_storage_kwargs(self) -> Optional[Dict[str, Any]]:
         return self.get("deltacat_storage_kwargs")
+
+    @property
+    def memory_logs_enabled(self) -> Optional[bool]:
+        return self.get("memory_logs_enabled")

--- a/deltacat/compute/compactor_v2/model/merge_input.py
+++ b/deltacat/compute/compactor_v2/model/merge_input.py
@@ -46,6 +46,7 @@ class MergeInput(Dict):
         delete_file_envelopes: Optional[List] = None,
         deltacat_storage=unimplemented_deltacat_storage,
         deltacat_storage_kwargs: Optional[Dict[str, Any]] = None,
+        memory_logs_enabled: Optional[bool] = None,
     ) -> MergeInput:
 
         result = MergeInput()
@@ -67,6 +68,7 @@ class MergeInput(Dict):
         result["delete_strategy"] = delete_strategy
         result["deltacat_storage"] = deltacat_storage
         result["deltacat_storage_kwargs"] = deltacat_storage_kwargs or {}
+        result["memory_logs_enabled"] = memory_logs_enabled
         return result
 
     @property
@@ -132,6 +134,10 @@ class MergeInput(Dict):
     @property
     def deltacat_storage_kwargs(self) -> Optional[Dict[str, Any]]:
         return self.get("deltacat_storage_kwargs")
+
+    @property
+    def memory_logs_enabled(self) -> Optional[bool]:
+        return self.get("memory_logs_enabled")
 
     @property
     def delete_file_envelopes(

--- a/deltacat/compute/compactor_v2/steps/hash_bucket.py
+++ b/deltacat/compute/compactor_v2/steps/hash_bucket.py
@@ -142,7 +142,8 @@ def hash_bucket(input: HashBucketInput) -> HashBucketResult:
                 f"({process_util.max_memory/BYTES_PER_GIBIBYTE} GB)"
             )
 
-        process_util.schedule_callback(log_peak_memory, 10)
+        if input.memory_logs_enabled:
+            process_util.schedule_callback(log_peak_memory, 10)
 
         hash_bucket_result, duration = timed_invocation(
             func=_timed_hash_bucket, input=input

--- a/deltacat/compute/compactor_v2/steps/merge.py
+++ b/deltacat/compute/compactor_v2/steps/merge.py
@@ -548,7 +548,8 @@ def merge(input: MergeInput) -> MergeResult:
                 f"({process_util.max_memory/BYTES_PER_GIBIBYTE} GB)"
             )
 
-        process_util.schedule_callback(log_peak_memory, 10)
+        if input.memory_logs_enabled:
+            process_util.schedule_callback(log_peak_memory, 10)
 
         merge_result, duration = timed_invocation(func=_timed_merge, input=input)
 

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -207,6 +207,7 @@ def merge_resource_options_provider(
     num_hash_groups: int,
     hash_group_size_bytes: Dict[int, int],
     hash_group_num_rows: Dict[int, int],
+    total_memory_buffer_percentage: int,
     round_completion_info: Optional[RoundCompletionInfo] = None,
     compacted_delta_manifest: Optional[Manifest] = None,
     ray_custom_resources: Optional[Dict] = None,
@@ -227,21 +228,95 @@ def merge_resource_options_provider(
     pk_size_bytes = data_size
     incremental_index_array_size = num_rows * 4
 
+    return get_merge_task_options(
+        index,
+        hb_group_idx,
+        data_size,
+        pk_size_bytes,
+        num_rows,
+        num_hash_groups,
+        total_memory_buffer_percentage,
+        incremental_index_array_size,
+        debug_memory_params,
+        ray_custom_resources,
+        round_completion_info=round_completion_info,
+        compacted_delta_manifest=compacted_delta_manifest,
+        primary_keys=primary_keys,
+        deltacat_storage=deltacat_storage,
+        deltacat_storage_kwargs=deltacat_storage_kwargs
+    )
+
+
+def local_merge_resource_options_provider(
+    estimated_da_size: float,
+    estimated_num_rows: int,
+    total_memory_buffer_percentage: int,
+    round_completion_info: Optional[RoundCompletionInfo] = None,
+    compacted_delta_manifest: Optional[Manifest] = None,
+    ray_custom_resources: Optional[Dict] = None,
+    primary_keys: Optional[List[str]] = None,
+    deltacat_storage=unimplemented_deltacat_storage,
+    deltacat_storage_kwargs: Optional[Dict] = {},
+    **kwargs,
+) -> Dict:
+    index = hb_group_idx = LocalMergeFileGroupsProvider.LOCAL_HASH_BUCKET_INDEX
+    debug_memory_params = {"merge_task_index": index}
+    
+    # upper bound for pk size of incremental
+    pk_size_bytes = estimated_da_size
+    incremental_index_array_size = estimated_num_rows * 4
+
+    return get_merge_task_options(
+        index=index,
+        hb_group_idx=hb_group_idx,
+        data_size=estimated_da_size,
+        pk_size_bytes=pk_size_bytes,
+        num_rows=estimated_num_rows,
+        num_hash_groups=1,
+        incremental_index_array_size=incremental_index_array_size,
+        total_memory_buffer_percentage=total_memory_buffer_percentage,
+        debug_memory_params=debug_memory_params,
+        ray_custom_resources=ray_custom_resources,
+        round_completion_info=round_completion_info,
+        compacted_delta_manifest=compacted_delta_manifest,
+        primary_keys=primary_keys,
+        deltacat_storage=deltacat_storage,
+        deltacat_storage_kwargs=deltacat_storage_kwargs
+    )
+
+
+def get_merge_task_options(
+    index: int,
+    hb_group_idx: int,
+    data_size: float,
+    pk_size_bytes: float,
+    num_rows: int,
+    num_hash_groups: int,
+    total_memory_buffer_percentage: int,
+    incremental_index_array_size: int,
+    debug_memory_params: Dict[str, Any],
+    ray_custom_resources: Optional[Dict],
+    round_completion_info: Optional[RoundCompletionInfo] = None,
+    compacted_delta_manifest: Optional[Manifest] = None,
+    primary_keys: Optional[List[str]] = None,
+    deltacat_storage=unimplemented_deltacat_storage,
+    deltacat_storage_kwargs: Optional[Dict] = {},
+) -> Dict[str, Any]:
     if (
-        round_completion_info
-        and compacted_delta_manifest
-        and round_completion_info.hb_index_to_entry_range
+            round_completion_info
+            and compacted_delta_manifest
+            and round_completion_info.hb_index_to_entry_range
     ):
 
         previous_inflation = (
-            round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
-            / round_completion_info.compacted_pyarrow_write_result.file_bytes
+                round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
+                / round_completion_info.compacted_pyarrow_write_result.file_bytes
         )
         debug_memory_params["previous_inflation"] = previous_inflation
 
         average_record_size = (
-            round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
-            / round_completion_info.compacted_pyarrow_write_result.records
+                round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
+                / round_completion_info.compacted_pyarrow_write_result.records
         )
         debug_memory_params["average_record_size"] = average_record_size
 
@@ -282,91 +357,7 @@ def merge_resource_options_provider(
                     else:
                         pk_size_bytes += pk_size
 
-    return merge_estimate_task_options(
-        index,
-        data_size,
-        pk_size_bytes,
-        num_rows,
-        incremental_index_array_size,
-        debug_memory_params,
-        ray_custom_resources,
-    )
 
-
-def local_merge_resource_options_provider(
-    estimated_da_size: float,
-    estimated_num_rows: int,
-    round_completion_info: Optional[RoundCompletionInfo] = None,
-    compacted_delta_manifest: Optional[Manifest] = None,
-    ray_custom_resources: Optional[Dict] = None,
-    primary_keys: Optional[List[str]] = None,
-    deltacat_storage=unimplemented_deltacat_storage,
-    deltacat_storage_kwargs: Optional[Dict] = {},
-    **kwargs,
-) -> Dict:
-    index = LocalMergeFileGroupsProvider.LOCAL_HASH_BUCKET_INDEX
-    debug_memory_params = {"merge_task_index": index}
-
-    # upper bound for pk size of incremental
-    pk_size_bytes = estimated_da_size
-    incremental_index_array_size = estimated_num_rows * 4
-
-    if round_completion_info and compacted_delta_manifest:
-        previous_inflation = (
-            round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
-            / round_completion_info.compacted_pyarrow_write_result.file_bytes
-        )
-        debug_memory_params["previous_inflation"] = previous_inflation
-
-        average_record_size = (
-            round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
-            / round_completion_info.compacted_pyarrow_write_result.records
-        )
-        debug_memory_params["average_record_size"] = average_record_size
-        for entry in compacted_delta_manifest.entries:
-            current_entry_size = estimate_manifest_entry_size_bytes(
-                entry=entry, previous_inflation=previous_inflation
-            )
-            current_entry_rows = estimate_manifest_entry_num_rows(
-                entry=entry,
-                average_record_size_bytes=average_record_size,
-                previous_inflation=previous_inflation,
-            )
-
-            estimated_da_size += current_entry_size
-            estimated_num_rows += current_entry_rows
-
-            if primary_keys:
-                pk_size = estimate_manifest_entry_column_size_bytes(
-                    entry=entry,
-                    columns=primary_keys,
-                )
-
-                if pk_size is None:
-                    pk_size_bytes += current_entry_size
-                else:
-                    pk_size_bytes += pk_size
-
-    return merge_estimate_task_options(
-        index,
-        estimated_da_size,
-        pk_size_bytes,
-        estimated_num_rows,
-        incremental_index_array_size,
-        debug_memory_params,
-        ray_custom_resources,
-    )
-
-
-def merge_estimate_task_options(
-    index: int,
-    data_size: float,
-    pk_size_bytes: float,
-    num_rows: int,
-    incremental_index_array_size: int,
-    debug_memory_params: Dict[str, Any],
-    ray_custom_resources: Optional[Dict],
-) -> Dict[str, Any]:
     # total data downloaded + primary key hash column + pyarrow-to-numpy conversion
     # + primary key column + hashlib inefficiency + dict size for merge + incremental index array size
     total_memory = (
@@ -384,7 +375,7 @@ def merge_estimate_task_options(
     debug_memory_params["incremental_index_array_size"] = incremental_index_array_size
     debug_memory_params["total_memory"] = total_memory
 
-    total_memory = total_memory * (1 + TOTAL_MEMORY_BUFFER_PERCENTAGE / 100.0)
+    total_memory = total_memory * (1 + total_memory_buffer_percentage / 100.0)
     debug_memory_params["total_memory_with_buffer"] = total_memory
     logger.debug(
         f"[Merge task {index}]: Params used for calculating merge memory: {debug_memory_params}"

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -246,7 +246,8 @@ def merge_resource_options_provider(
         compacted_delta_manifest=compacted_delta_manifest,
         primary_keys=primary_keys,
         deltacat_storage=deltacat_storage,
-        deltacat_storage_kwargs=deltacat_storage_kwargs
+        deltacat_storage_kwargs=deltacat_storage_kwargs,
+        memory_logs_enabled=memory_logs_enabled,
     )
 
 
@@ -260,11 +261,12 @@ def local_merge_resource_options_provider(
     primary_keys: Optional[List[str]] = None,
     deltacat_storage=unimplemented_deltacat_storage,
     deltacat_storage_kwargs: Optional[Dict] = {},
+    memory_logs_enabled: Optional[bool] = None,
     **kwargs,
 ) -> Dict:
     index = hb_group_idx = LocalMergeFileGroupsProvider.LOCAL_HASH_BUCKET_INDEX
     debug_memory_params = {"merge_task_index": index}
-    
+
     # upper bound for pk size of incremental
     pk_size_bytes = estimated_da_size
     incremental_index_array_size = estimated_num_rows * 4
@@ -284,7 +286,8 @@ def local_merge_resource_options_provider(
         compacted_delta_manifest=compacted_delta_manifest,
         primary_keys=primary_keys,
         deltacat_storage=deltacat_storage,
-        deltacat_storage_kwargs=deltacat_storage_kwargs
+        deltacat_storage_kwargs=deltacat_storage_kwargs,
+        memory_logs_enabled=memory_logs_enabled,
     )
 
 
@@ -304,22 +307,23 @@ def get_merge_task_options(
     primary_keys: Optional[List[str]] = None,
     deltacat_storage=unimplemented_deltacat_storage,
     deltacat_storage_kwargs: Optional[Dict] = {},
+    memory_logs_enabled: Optional[bool] = None,
 ) -> Dict[str, Any]:
     if (
-            round_completion_info
-            and compacted_delta_manifest
-            and round_completion_info.hb_index_to_entry_range
+        round_completion_info
+        and compacted_delta_manifest
+        and round_completion_info.hb_index_to_entry_range
     ):
 
         previous_inflation = (
-                round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
-                / round_completion_info.compacted_pyarrow_write_result.file_bytes
+            round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
+            / round_completion_info.compacted_pyarrow_write_result.file_bytes
         )
         debug_memory_params["previous_inflation"] = previous_inflation
 
         average_record_size = (
-                round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
-                / round_completion_info.compacted_pyarrow_write_result.records
+            round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
+            / round_completion_info.compacted_pyarrow_write_result.records
         )
         debug_memory_params["average_record_size"] = average_record_size
 
@@ -359,7 +363,6 @@ def get_merge_task_options(
                         pk_size_bytes += current_entry_size
                     else:
                         pk_size_bytes += pk_size
-
 
     # total data downloaded + primary key hash column + pyarrow-to-numpy conversion
     # + primary key column + hashlib inefficiency + dict size for merge + incremental index array size

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -138,6 +138,7 @@ def hash_bucket_resource_options_provider(
     average_record_size_bytes: float,
     primary_keys: List[str] = None,
     ray_custom_resources: Optional[Dict] = None,
+    memory_logs_enabled: Optional[bool] = None,
     **kwargs,
 ) -> Dict:
     debug_memory_params = {"hash_bucket_task_index": index}
@@ -194,8 +195,9 @@ def hash_bucket_resource_options_provider(
     # Consider buffer
     total_memory = total_memory * (1 + TOTAL_MEMORY_BUFFER_PERCENTAGE / 100.0)
     debug_memory_params["total_memory_with_buffer"] = total_memory
-    logger.debug(
-        f"[Hash bucket task {index}]: Params used for calculating hash bucketing memory: {debug_memory_params}"
+    logger.debug_conditional(
+        f"[Hash bucket task {index}]: Params used for calculating hash bucketing memory: {debug_memory_params}",
+        memory_logs_enabled,
     )
 
     return get_task_options(0.01, total_memory, ray_custom_resources)
@@ -214,6 +216,7 @@ def merge_resource_options_provider(
     primary_keys: Optional[List[str]] = None,
     deltacat_storage=unimplemented_deltacat_storage,
     deltacat_storage_kwargs: Optional[Dict] = {},
+    memory_logs_enabled: Optional[bool] = None,
     **kwargs,
 ) -> Dict:
     debug_memory_params = {"merge_task_index": index}
@@ -377,8 +380,9 @@ def get_merge_task_options(
 
     total_memory = total_memory * (1 + total_memory_buffer_percentage / 100.0)
     debug_memory_params["total_memory_with_buffer"] = total_memory
-    logger.debug(
-        f"[Merge task {index}]: Params used for calculating merge memory: {debug_memory_params}"
+    logger.debug_conditional(
+        f"[Merge task {index}]: Params used for calculating merge memory: {debug_memory_params}",
+        memory_logs_enabled,
     )
 
     return get_task_options(0.01, total_memory, ray_custom_resources)

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -18,7 +18,6 @@ from deltacat.compute.compactor_v2.utils.primary_key_index import (
     hash_group_index_to_hash_bucket_indices,
 )
 from deltacat.compute.compactor_v2.constants import (
-    TOTAL_MEMORY_BUFFER_PERCENTAGE,
     PARQUET_TO_PYARROW_INFLATION,
 )
 

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -136,6 +136,7 @@ def hash_bucket_resource_options_provider(
     item: DeltaAnnotated,
     previous_inflation: float,
     average_record_size_bytes: float,
+    total_memory_buffer_percentage: int,
     primary_keys: List[str] = None,
     ray_custom_resources: Optional[Dict] = None,
     memory_logs_enabled: Optional[bool] = None,
@@ -193,7 +194,7 @@ def hash_bucket_resource_options_provider(
     debug_memory_params["average_record_size_bytes"] = average_record_size_bytes
 
     # Consider buffer
-    total_memory = total_memory * (1 + TOTAL_MEMORY_BUFFER_PERCENTAGE / 100.0)
+    total_memory = total_memory * (1 + total_memory_buffer_percentage / 100.0)
     debug_memory_params["total_memory_with_buffer"] = total_memory
     logger.debug_conditional(
         f"[Hash bucket task {index}]: Params used for calculating hash bucketing memory: {debug_memory_params}",

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -306,6 +306,8 @@ def local_merge_resource_options_provider(
 ) -> Dict:
     index = LocalMergeFileGroupsProvider.LOCAL_HASH_BUCKET_INDEX
     debug_memory_params = {"merge_task_index": index}
+
+    # upper bound for pk size of incremental
     pk_size_bytes = estimated_da_size
     incremental_index_array_size = estimated_num_rows * 4
 

--- a/deltacat/tests/compute/test_compact_partition_params.py
+++ b/deltacat/tests/compute/test_compact_partition_params.py
@@ -72,6 +72,7 @@ class TestCompactPartitionParams(unittest.TestCase):
                 "partitionValues": [],
                 "partitionId": "79612ea39ac5493eae925abe60767d42",
             },
+            "memory_logs_enabled": True,
             "metrics_config": MetricsConfig("us-east-1", MetricsTarget.CLOUDWATCH_EMF),
         }
 
@@ -134,6 +135,10 @@ class TestCompactPartitionParams(unittest.TestCase):
         assert (
             json.loads(serialized_params)["destination_partition_locator"]
             == params.destination_partition_locator
+        )
+        assert (
+            json.loads(serialized_params)["memory_logs_enabled"]
+            == params.memory_logs_enabled
         )
         assert (
             json.loads(serialized_params)["metrics_config"]["metrics_target"]

--- a/deltacat/utils/resources.py
+++ b/deltacat/utils/resources.py
@@ -36,13 +36,15 @@ class ClusterUtilization:
                 used_resources[key] = cluster_resources[key] - available_resources[key]
 
         self.total_memory_bytes = cluster_resources.get("memory")
-        self.used_memory_bytes = used_resources.get("memory")
+        self.used_memory_bytes = used_resources.get("memory", 0.0)
         self.total_cpu = cluster_resources.get("CPU")
-        self.used_cpu = used_resources.get("CPU")
+        self.used_cpu = used_resources.get("CPU", 0)
         self.total_object_store_memory_bytes = cluster_resources.get(
             "object_store_memory"
         )
-        self.used_object_store_memory_bytes = used_resources.get("object_store_memory")
+        self.used_object_store_memory_bytes = used_resources.get(
+            "object_store_memory", 0.0
+        )
         self.used_memory_percent = (
             self.used_memory_bytes / self.total_memory_bytes
         ) * 100


### PR DESCRIPTION
This change provides resource estimates for input deltas during local merge, so that Ray can schedule tasks responsibly when there are many concurrent jobs. It also addresses a bug where in some instances, `ray.available_resources()` may not yet report anything, causing the ClusterUtilization to throw exceptions during resource calculation and fail jobs prematurely.