### PR TITLE
Audit logging records deleted (`recordsDeleted`)

### DIFF
--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -85,11 +85,11 @@ class CompactionSessionAuditInfo(dict):
         return self.get("recordsDeduped")
 
     @property
-    def records_dropped(self) -> int:
+    def records_deleted(self) -> int:
         """
         The total count of dropped records in a compaction session if delete deltas are present.
         """
-        return self.get("recordsDropped")
+        return self.get("recordsDeleted")
 
     @property
     def input_size_bytes(self) -> float:
@@ -468,8 +468,8 @@ class CompactionSessionAuditInfo(dict):
         self["recordsDeduped"] = records_deduped
         return self
 
-    def set_records_dropped(self, records_dropped: int) -> CompactionSessionAuditInfo:
-        self["recordsDropped"] = records_dropped
+    def set_records_deleted(self, records_deleted: int) -> CompactionSessionAuditInfo:
+        self["recordsDeleted"] = records_deleted
         return self
 
     def set_input_size_bytes(

--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -87,8 +87,7 @@ class CompactionSessionAuditInfo(dict):
     @property
     def records_dropped(self) -> int:
         """
-        The total number of records that were dropped during compaction session
-        will be deduplicated.
+        The total count of dropped records in a compaction session if delete deltas are present.
         """
         return self.get("recordsDropped")
 

--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -85,6 +85,14 @@ class CompactionSessionAuditInfo(dict):
         return self.get("recordsDeduped")
 
     @property
+    def records_dropped(self) -> int:
+        """
+        The total number of records that were dropped during compaction session
+        will be deduplicated.
+        """
+        return self.get("recordsDropped")
+
+    @property
     def input_size_bytes(self) -> float:
         """
         The on-disk size in bytes of the input. Analogous to bytes scanned
@@ -459,6 +467,10 @@ class CompactionSessionAuditInfo(dict):
 
     def set_records_deduped(self, records_deduped: int) -> CompactionSessionAuditInfo:
         self["recordsDeduped"] = records_deduped
+        return self
+
+    def set_records_dropped(self, records_dropped: int) -> CompactionSessionAuditInfo:
+        self["recordsDropped"] = records_dropped
         return self
 
     def set_input_size_bytes(

--- a/deltacat/compute/compactor/model/compaction_session_audit_info.py
+++ b/deltacat/compute/compactor/model/compaction_session_audit_info.py
@@ -87,7 +87,7 @@ class CompactionSessionAuditInfo(dict):
     @property
     def records_deleted(self) -> int:
         """
-        The total count of dropped records in a compaction session if delete deltas are present.
+        The total count of deleted records in a compaction session if delete deltas are present.
         """
         return self.get("recordsDeleted")
 

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -467,11 +467,11 @@ def _execute_compaction(
     merge_end = time.monotonic()
 
     total_dd_record_count = sum([ddr.deduped_record_count for ddr in merge_results])
-    total_dropped_record_count = sum(
+    total_deleted_record_count = sum(
         [ddr.deleted_record_count for ddr in merge_results]
     )
     logger.info(
-        f"Deduped {total_dd_record_count} records and dropped {total_dropped_record_count} records..."
+        f"Deduped {total_dd_record_count} records and deleted {total_deleted_record_count} records..."
     )
 
     compaction_audit.set_input_records(total_input_records_count.item())
@@ -485,7 +485,7 @@ def _execute_compaction(
     )
 
     compaction_audit.set_records_deduped(total_dd_record_count.item())
-    compaction_audit.set_records_deleted(total_dropped_record_count.item())
+    compaction_audit.set_records_deleted(total_deleted_record_count.item())
     mat_results = []
     for merge_result in merge_results:
         mat_results.extend(merge_result.materialize_results)
@@ -532,7 +532,7 @@ def _execute_compaction(
     record_info_msg = (
         f"Hash bucket records: {total_hb_record_count},"
         f" Deduped records: {total_dd_record_count}, "
-        f" Dropped records: {total_dropped_record_count}, "
+        f" Dropped records: {total_deleted_record_count}, "
         f" Materialized records: {merged_delta.meta.record_count}"
     )
     logger.info(record_info_msg)

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -532,7 +532,7 @@ def _execute_compaction(
     record_info_msg = (
         f"Hash bucket records: {total_hb_record_count},"
         f" Deduped records: {total_dd_record_count}, "
-        f" Dropped records: {total_deleted_record_count}, "
+        f" Deleted records: {total_deleted_record_count}, "
         f" Materialized records: {merged_delta.meta.record_count}"
     )
     logger.info(record_info_msg)
@@ -632,7 +632,6 @@ def _execute_compaction(
         f"partition-{params.source_partition_locator.partition_values},"
         f"compacted at: {params.last_stream_position_to_compact},"
     )
-
     return (
         compacted_partition,
         new_round_completion_info,

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -485,7 +485,7 @@ def _execute_compaction(
     )
 
     compaction_audit.set_records_deduped(total_dd_record_count.item())
-
+    compaction_audit.set_records_dropped(total_dropped_record_count.item())
     mat_results = []
     for merge_result in merge_results:
         mat_results.extend(merge_result.materialize_results)

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -485,7 +485,7 @@ def _execute_compaction(
     )
 
     compaction_audit.set_records_deduped(total_dd_record_count.item())
-    compaction_audit.set_records_dropped(total_dropped_record_count.item())
+    compaction_audit.set_records_deleted(total_dropped_record_count.item())
     mat_results = []
     for merge_result in merge_results:
         mat_results.extend(merge_result.materialize_results)

--- a/deltacat/compute/compactor_v2/steps/merge.py
+++ b/deltacat/compute/compactor_v2/steps/merge.py
@@ -349,7 +349,7 @@ def _compact_tables(
             1. The compacted PyArrow table.
             2. The total number of records in the incremental data.
             3. The total number of deduplicated records.
-            4. The total number of dropped records due to DELETE operations.
+            4. The total number of deleted records due to DELETE operations.
     """
     df_envelopes: List[DeltaFileEnvelope] = _flatten_dfe_list(dfe_list)
     delete_file_envelopes = input.delete_file_envelopes or []


### PR DESCRIPTION
## Description
- With the changes in compactor v2 delete algorithm introduced in https://github.com/ray-project/deltacat/pull/280, the total number of records dropped is now returned from the `merge` step. This should be audit logged like record deduped (`recordsDeduped`)