### PR TITLE
Instrumenting granular metrics to understand the RCA quickly

### DIFF
--- a/deltacat/aws/constants.py
+++ b/deltacat/aws/constants.py
@@ -3,6 +3,10 @@ from typing import List
 from deltacat.utils.common import env_integer, env_string
 
 DAFT_MAX_S3_CONNECTIONS_PER_FILE = env_integer("DAFT_MAX_S3_CONNECTIONS_PER_FILE", 8)
-BOTO_MAX_RETRIES = env_integer("BOTO_MAX_RETRIES", 15)
+BOTO_MAX_RETRIES = env_integer("BOTO_MAX_RETRIES", 5)
 TIMEOUT_ERROR_CODES: List[str] = ["ReadTimeoutError", "ConnectTimeoutError"]
 AWS_REGION = env_string("AWS_REGION", "us-east-1")
+
+# Metric Names
+DOWNLOAD_MANIFEST_ENTRY_METRIC_PREFIX = "download_manifest_entry"
+UPLOAD_SLICED_TABLE_METRIC_PREFIX = "upload_local_table"

--- a/deltacat/aws/constants.py
+++ b/deltacat/aws/constants.py
@@ -9,4 +9,4 @@ AWS_REGION = env_string("AWS_REGION", "us-east-1")
 
 # Metric Names
 DOWNLOAD_MANIFEST_ENTRY_METRIC_PREFIX = "download_manifest_entry"
-UPLOAD_SLICED_TABLE_METRIC_PREFIX = "upload_local_table"
+UPLOAD_SLICED_TABLE_METRIC_PREFIX = "upload_sliced_table"

--- a/deltacat/aws/s3u.py
+++ b/deltacat/aws/s3u.py
@@ -25,7 +25,11 @@ from tenacity import (
 from deltacat.utils.ray_utils.concurrency import invoke_parallel
 import deltacat.aws.clients as aws_utils
 from deltacat import logs
-from deltacat.aws.constants import TIMEOUT_ERROR_CODES
+from deltacat.aws.constants import (
+    TIMEOUT_ERROR_CODES,
+    DOWNLOAD_MANIFEST_ENTRY_METRIC_PREFIX,
+    UPLOAD_SLICED_TABLE_METRIC_PREFIX,
+)
 from deltacat.exceptions import NonRetryableError, RetryableError
 from deltacat.storage import (
     DistributedDataset,
@@ -50,6 +54,7 @@ from deltacat.types.tables import (
 )
 from deltacat.types.partial_download import PartialFileDownloadParams
 from deltacat.utils.common import ReadKwargsProvider
+from deltacat.utils.metrics import metrics
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
@@ -238,6 +243,7 @@ def read_file(
         raise e
 
 
+@metrics(prefix=UPLOAD_SLICED_TABLE_METRIC_PREFIX)
 def upload_sliced_table(
     table: Union[LocalTable, DistributedDataset],
     s3_url_prefix: str,
@@ -346,6 +352,7 @@ def upload_table(
     return manifest_entries
 
 
+@metrics(prefix=DOWNLOAD_MANIFEST_ENTRY_METRIC_PREFIX)
 def download_manifest_entry(
     manifest_entry: ManifestEntry,
     token_holder: Optional[Dict[str, Any]] = None,

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -65,6 +65,7 @@ from deltacat.compute.compactor_v2.utils.task_options import (
     local_merge_resource_options_provider,
 )
 from deltacat.compute.compactor.model.compactor_version import CompactorVersion
+from deltacat.utils.metrics import MetricsActor, METRICS_CONFIG_ACTOR_NAME
 
 if importlib.util.find_spec("memray"):
     import memray
@@ -117,6 +118,15 @@ def compact_partition(params: CompactPartitionParams, **kwargs) -> Optional[str]
 def _execute_compaction(
     params: CompactPartitionParams, **kwargs
 ) -> Tuple[Optional[Partition], Optional[RoundCompletionInfo], Optional[str]]:
+
+    if params.metrics_config:
+        logger.info(
+            f"Setting metrics config with target: {params.metrics_config.metrics_target}"
+        )
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        ray.get(metrics_actor.set_metrics_config.remote(params.metrics_config))
 
     rcf_source_partition_locator = (
         params.rebase_source_partition_locator or params.source_partition_locator

--- a/deltacat/compute/compactor_v2/constants.py
+++ b/deltacat/compute/compactor_v2/constants.py
@@ -40,3 +40,31 @@ DROP_DUPLICATES = True
 # This is the observed upper bound inflation for parquet
 # size in metadata to pyarrow table size.
 PARQUET_TO_PYARROW_INFLATION = 4
+
+# Metric Names
+# Time taken for a hash bucket task
+HASH_BUCKET_TIME_IN_SECONDS = "hash_bucket_time"
+
+# Hash bucket success count
+HASH_BUCKET_SUCCESS_COUNT = "hash_bucket_success_count"
+
+# Hash bucket failure count
+HASH_BUCKET_FAILURE_COUNT = "hash_bucket_failure_count"
+
+# Time taken for a merge task
+MERGE_TIME_IN_SECONDS = "merge_time"
+
+# Merge success count
+MERGE_SUCCESS_COUNT = "merge_success_count"
+
+# Merge failure count
+MERGE_FAILURE_COUNT = "merge_failure_count"
+
+# Metric prefix for discover deltas
+DISCOVER_DELTAS_METRIC_PREFIX = "discover_deltas"
+
+# Metric prefix for prepare deletes
+PREPARE_DELETES_METRIC_PREFIX = "prepare_deletes"
+
+# Metric prefix for materialize
+MATERIALIZE_METRIC_PREFIX = "delta_materialize"

--- a/deltacat/compute/compactor_v2/deletes/utils.py
+++ b/deltacat/compute/compactor_v2/deletes/utils.py
@@ -23,6 +23,8 @@ from deltacat.storage import (
     Delta,
 )
 from deltacat import logs
+from deltacat.utils.metrics import metrics
+from deltacat.compute.compactor_v2.constants import PREPARE_DELETES_METRIC_PREFIX
 
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
@@ -115,6 +117,7 @@ def _get_delete_file_envelopes(
     return delete_file_envelopes
 
 
+@metrics(prefix=PREPARE_DELETES_METRIC_PREFIX)
 def prepare_deletes(
     params: CompactPartitionParams,
     input_deltas: List[Delta],

--- a/deltacat/compute/compactor_v2/utils/io.py
+++ b/deltacat/compute/compactor_v2/utils/io.py
@@ -23,10 +23,13 @@ from deltacat.compute.compactor_v2.utils.task_options import (
 from deltacat.compute.compactor_v2.utils.content_type_params import (
     append_content_type_params,
 )
+from deltacat.utils.metrics import metrics
+from deltacat.compute.compactor_v2.constants import DISCOVER_DELTAS_METRIC_PREFIX
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
+@metrics(prefix=DISCOVER_DELTAS_METRIC_PREFIX)
 def discover_deltas(
     source_partition_locator: PartitionLocator,
     last_stream_position_to_compact: int,

--- a/deltacat/compute/compactor_v2/utils/merge.py
+++ b/deltacat/compute/compactor_v2/utils/merge.py
@@ -31,11 +31,14 @@ from deltacat.compute.compactor_v2.deletes.delete_strategy import (
 from deltacat.compute.compactor_v2.deletes.delete_file_envelope import (
     DeleteFileEnvelope,
 )
+from deltacat.utils.metrics import metrics
+from deltacat.compute.compactor_v2.constants import MATERIALIZE_METRIC_PREFIX
 
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
+@metrics(prefix=MATERIALIZE_METRIC_PREFIX)
 def materialize(
     input: MergeInput,
     task_index: int,

--- a/deltacat/tests/utils/test_metrics.py
+++ b/deltacat/tests/utils/test_metrics.py
@@ -1,0 +1,479 @@
+import unittest
+from unittest.mock import MagicMock, ANY, call
+import ray
+from deltacat.utils.metrics import (
+    metrics,
+    success_metric,
+    failure_metric,
+    latency_metric,
+    MetricsActor,
+    METRICS_CONFIG_ACTOR_NAME,
+    MetricsConfig,
+    MetricsTarget,
+    METRICS_TARGET_TO_EMITTER_DICT,
+)
+
+
+@metrics
+def metrics_annotated_method(mock_func):
+    mock_func("called")
+
+
+@metrics
+def metrics_annotated_method_error(mock_func):
+    raise ValueError()
+
+
+@metrics(prefix="test_prefix")
+def metrics_with_prefix_annotated_method(mock_func):
+    mock_func("called")
+
+
+@metrics(prefix="test_prefix")
+def metrics_with_prefix_annotated_method_error(mock_func):
+    raise ValueError()
+
+
+class TestMetricsAnnotation(unittest.TestCase):
+    def test_metrics_annotation_sanity(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        metrics_annotated_method(mock)
+
+        mock.assert_called_once()
+        self.assertEqual(2, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [
+                call(
+                    metrics_name="metrics_annotated_method_time",
+                    metrics_config=ANY,
+                    value=ANY,
+                ),
+                call(
+                    metrics_name="metrics_annotated_method_success_count",
+                    metrics_config=ANY,
+                    value=ANY,
+                ),
+            ],
+            any_order=True,
+        )
+
+    def test_metrics_annotation_when_error(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        self.assertRaises(ValueError, lambda: metrics_annotated_method_error(mock))
+
+        mock.assert_not_called()
+        self.assertEqual(3, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [
+                call(
+                    metrics_name="metrics_annotated_method_error_time",
+                    metrics_config=ANY,
+                    value=ANY,
+                ),
+                call(
+                    metrics_name="metrics_annotated_method_error_failure_count",
+                    metrics_config=ANY,
+                    value=ANY,
+                ),
+                call(
+                    metrics_name="metrics_annotated_method_error_failure_count.ValueError",
+                    metrics_config=ANY,
+                    value=ANY,
+                ),
+            ],
+            any_order=True,
+        )
+
+    def test_metrics_with_prefix_annotation_sanity(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        metrics_with_prefix_annotated_method(mock)
+
+        mock.assert_called_once()
+        self.assertEqual(2, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [
+                call(metrics_name="test_prefix_time", metrics_config=ANY, value=ANY),
+                call(
+                    metrics_name="test_prefix_success_count",
+                    metrics_config=ANY,
+                    value=ANY,
+                ),
+            ],
+            any_order=True,
+        )
+
+    def test_metrics_with_prefix_annotation_when_error(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        self.assertRaises(
+            ValueError, lambda: metrics_with_prefix_annotated_method_error(mock)
+        )
+
+        mock.assert_not_called()
+        self.assertEqual(3, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [
+                call(metrics_name="test_prefix_time", metrics_config=ANY, value=ANY),
+                call(
+                    metrics_name="test_prefix_failure_count",
+                    metrics_config=ANY,
+                    value=ANY,
+                ),
+                call(
+                    metrics_name="test_prefix_failure_count.ValueError",
+                    metrics_config=ANY,
+                    value=ANY,
+                ),
+            ],
+            any_order=True,
+        )
+
+
+@latency_metric
+def latency_metric_annotated_method(mock_func):
+    mock_func("called")
+
+
+@latency_metric
+def latency_metric_annotated_method_error(mock_func):
+    raise ValueError()
+
+
+@latency_metric(name="test")
+def latency_metric_with_name_annotated_method(mock_func):
+    mock_func("called")
+
+
+@latency_metric(name="test")
+def latency_metric_with_name_annotated_method_error(mock_func):
+    raise ValueError()
+
+
+class TestLatencyMetricAnnotation(unittest.TestCase):
+    def test_annotation_sanity(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        latency_metric_annotated_method(mock)
+
+        mock.assert_called_once()
+        self.assertEqual(1, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [
+                call(
+                    metrics_name="latency_metric_annotated_method_time",
+                    metrics_config=ANY,
+                    value=ANY,
+                )
+            ],
+            any_order=True,
+        )
+
+    def test_annotation_when_error(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        self.assertRaises(
+            ValueError, lambda: latency_metric_annotated_method_error(mock)
+        )
+
+        mock.assert_not_called()
+        self.assertEqual(1, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [
+                call(
+                    metrics_name="latency_metric_annotated_method_error_time",
+                    metrics_config=ANY,
+                    value=ANY,
+                )
+            ],
+            any_order=True,
+        )
+
+    def test_annotation_with_args_sanity(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        latency_metric_with_name_annotated_method(mock)
+
+        mock.assert_called_once()
+        self.assertEqual(1, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [call(metrics_name="test", metrics_config=ANY, value=ANY)], any_order=True
+        )
+
+    def test_annotation_with_args_when_error(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        self.assertRaises(
+            ValueError, lambda: latency_metric_with_name_annotated_method_error(mock)
+        )
+
+        mock.assert_not_called()
+        self.assertEqual(1, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [call(metrics_name="test", metrics_config=ANY, value=ANY)], any_order=True
+        )
+
+
+@success_metric
+def success_metric_annotated_method(mock_func):
+    mock_func("called")
+
+
+@success_metric
+def success_metric_annotated_method_error(mock_func):
+    raise ValueError()
+
+
+@success_metric(name="test")
+def success_metric_with_name_annotated_method(mock_func):
+    mock_func("called")
+
+
+@success_metric(name="test")
+def success_metric_with_name_annotated_method_error(mock_func):
+    raise ValueError()
+
+
+class TestSuccessMetricAnnotation(unittest.TestCase):
+    def test_annotation_sanity(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        success_metric_annotated_method(mock)
+
+        mock.assert_called_once()
+        self.assertEqual(1, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [
+                call(
+                    metrics_name="success_metric_annotated_method_success_count",
+                    metrics_config=ANY,
+                    value=ANY,
+                )
+            ],
+            any_order=True,
+        )
+
+    def test_annotation_when_error(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        self.assertRaises(
+            ValueError, lambda: success_metric_annotated_method_error(mock)
+        )
+
+        mock.assert_not_called()
+        mock_target.assert_not_called()
+
+    def test_annotation_with_args_sanity(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        success_metric_with_name_annotated_method(mock)
+
+        mock.assert_called_once()
+        self.assertEqual(1, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [call(metrics_name="test", metrics_config=ANY, value=ANY)], any_order=True
+        )
+
+    def test_annotation_with_args_when_error(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        self.assertRaises(
+            ValueError, lambda: success_metric_with_name_annotated_method_error(mock)
+        )
+
+        mock.assert_not_called()
+        mock_target.assert_not_called()
+
+
+@failure_metric
+def failure_metric_annotated_method(mock_func):
+    mock_func("called")
+
+
+@failure_metric
+def failure_metric_annotated_method_error(mock_func):
+    raise ValueError()
+
+
+@failure_metric(name="test")
+def failure_metric_with_name_annotated_method(mock_func):
+    mock_func("called")
+
+
+@failure_metric(name="test")
+def failure_metric_with_name_annotated_method_error(mock_func):
+    raise ValueError()
+
+
+class TestFailureMetricAnnotation(unittest.TestCase):
+    def test_annotation_sanity(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        failure_metric_annotated_method(mock)
+
+        mock.assert_called_once()
+        mock_target.assert_not_called()
+
+    def test_annotation_when_error(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        self.assertRaises(
+            ValueError, lambda: failure_metric_annotated_method_error(mock)
+        )
+
+        mock.assert_not_called()
+        self.assertEqual(2, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [
+                call(
+                    metrics_name="failure_metric_annotated_method_error_failure_count.ValueError",
+                    metrics_config=ANY,
+                    value=ANY,
+                ),
+                call(
+                    metrics_name="failure_metric_annotated_method_error_failure_count",
+                    metrics_config=ANY,
+                    value=ANY,
+                ),
+            ],
+            any_order=True,
+        )
+
+    def test_annotation_with_args_sanity(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        failure_metric_with_name_annotated_method(mock)
+
+        mock.assert_called_once()
+        mock_target.assert_not_called()
+
+    def test_annotation_with_args_when_error(self):
+        mock, mock_target = MagicMock(), MagicMock()
+        METRICS_TARGET_TO_EMITTER_DICT[MetricsTarget.NOOP] = mock_target
+        metrics_actor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = MetricsConfig("us-east-1", MetricsTarget.NOOP)
+        ray.get(metrics_actor.set_metrics_config.remote(config))
+
+        # action
+        self.assertRaises(
+            ValueError, lambda: failure_metric_with_name_annotated_method_error(mock)
+        )
+
+        mock.assert_not_called()
+        self.assertEqual(2, mock_target.call_count)
+        mock_target.assert_has_calls(
+            [
+                call(metrics_name="test.ValueError", metrics_config=ANY, value=ANY),
+                call(metrics_name="test", metrics_config=ANY, value=ANY),
+            ],
+            any_order=True,
+        )

--- a/deltacat/utils/metrics.py
+++ b/deltacat/utils/metrics.py
@@ -1,6 +1,10 @@
 from dataclasses import dataclass
+from typing import Optional
 
 import logging
+import ray
+import time
+import functools
 
 from aws_embedded_metrics import metric_scope
 from aws_embedded_metrics.config import get_config
@@ -18,11 +22,13 @@ logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 DEFAULT_DELTACAT_METRICS_NAMESPACE = "ray-deltacat-metrics"
 DEFAULT_DELTACAT_LOG_GROUP_NAME = "ray-deltacat-metrics-EMF-logs"
 DEFAULT_DELTACAT_LOG_STREAM_CALLABLE = get_node_ip_address
+METRICS_CONFIG_ACTOR_NAME = "metrics-config-actor"
 
 
 class MetricsTarget(str, Enum):
     CLOUDWATCH = "cloudwatch"
     CLOUDWATCH_EMF = "cloudwatch_emf"
+    NOOP = "noop"
 
 
 @dataclass
@@ -42,27 +48,16 @@ class MetricsConfig:
         self.metrics_kwargs = metrics_kwargs
 
 
-class MetricsType(str, Enum):
-    TIMER = "timer"
-
-
-def _build_metrics_name(metrics_type: Enum, metrics_name: str) -> str:
-    metrics_name_with_type = f"{metrics_name}_{metrics_type}"
-    return metrics_name_with_type
-
-
 def _build_cloudwatch_metrics(
     metrics_name: str,
-    metrics_type: Enum,
     value: str,
     metrics_dimensions: List[Dict[str, str]],
     timestamp: datetime,
     **kwargs,
 ) -> Dict[str, Any]:
-    metrics_name_with_type = _build_metrics_name(metrics_type, metrics_name)
     return [
         {
-            "MetricName": f"{metrics_name_with_type}",
+            "MetricName": metrics_name,
             "Dimensions": metrics_dimensions,
             "Timestamp": timestamp,
             "Value": value,
@@ -73,7 +68,6 @@ def _build_cloudwatch_metrics(
 
 def _emit_metrics(
     metrics_name: str,
-    metrics_type: Enum,
     metrics_config: MetricsConfig,
     value: str,
     **kwargs,
@@ -85,7 +79,6 @@ def _emit_metrics(
     if metrics_target in METRICS_TARGET_TO_EMITTER_DICT:
         METRICS_TARGET_TO_EMITTER_DICT.get(metrics_target)(
             metrics_name=metrics_name,
-            metrics_type=metrics_type,
             metrics_config=metrics_config,
             value=value,
             **kwargs,
@@ -94,9 +87,15 @@ def _emit_metrics(
         logger.warning(f"{metrics_target} is not a supported metrics target type.")
 
 
+def _emit_noop_metrics(
+    *args,
+    **kwargs,
+) -> None:
+    pass
+
+
 def _emit_cloudwatch_metrics(
     metrics_name: str,
-    metrics_type: Enum,
     metrics_config: MetricsConfig,
     value: str,
     **kwargs,
@@ -111,7 +110,6 @@ def _emit_cloudwatch_metrics(
 
     metrics_data = _build_cloudwatch_metrics(
         metrics_name,
-        metrics_type,
         value,
         metrics_dimensions,
         current_time,
@@ -128,14 +126,13 @@ def _emit_cloudwatch_metrics(
     except Exception as e:
         logger.warning(
             f"Failed to publish Cloudwatch metrics with name: {metrics_name}, "
-            f"type: {metrics_type}, with exception: {e}, response: {response}"
+            f"with exception: {e}, response: {response}"
         )
 
 
 @metric_scope
 def _emit_cloudwatch_emf_metrics(
     metrics_name: str,
-    metrics_type: Enum,
     metrics_config: MetricsConfig,
     value: str,
     metrics: MetricsLogger,
@@ -155,7 +152,6 @@ def _emit_cloudwatch_emf_metrics(
     dimensions = dict(
         [(dim["Name"], dim["Value"]) for dim in metrics_config.metrics_dimensions]
     )
-    metrics_name_with_type = _build_metrics_name(metrics_type, metrics_name)
     try:
         metrics.set_timestamp(current_time)
         metrics.set_dimensions(dimensions)
@@ -177,25 +173,162 @@ def _emit_cloudwatch_emf_metrics(
             else DEFAULT_DELTACAT_LOG_STREAM_CALLABLE()
         )
 
-        metrics.put_metric(metrics_name_with_type, value)
+        metrics.put_metric(metrics_name, value)
     except Exception as e:
         logger.warning(
-            f"Failed to publish Cloudwatch EMF metrics with name: {metrics_name_with_type}, "
-            f"type: {metrics_type}, with exception: {e}"
+            f"Failed to publish Cloudwatch EMF metrics with name: {metrics_name}", e
         )
 
 
 METRICS_TARGET_TO_EMITTER_DICT: Dict[str, Callable] = {
     MetricsTarget.CLOUDWATCH: _emit_cloudwatch_metrics,
     MetricsTarget.CLOUDWATCH_EMF: _emit_cloudwatch_emf_metrics,
+    MetricsTarget.NOOP: _emit_noop_metrics,
 }
+
+
+@ray.remote
+class MetricsActor:
+    metrics_config: MetricsConfig = None
+
+    def set_metrics_config(self, config: MetricsConfig) -> None:
+        self.metrics_config = config
+
+    def get_metrics_config(self) -> MetricsConfig:
+        return self.metrics_config
+
+
+def _emit_with_exception(name: Optional[str], value: Any):
+    try:
+        config_cache: MetricsActor = MetricsActor.options(
+            name=METRICS_CONFIG_ACTOR_NAME, get_if_exists=True
+        ).remote()
+        config = ray.get(config_cache.get_metrics_config.remote())
+        if config:
+            _emit_metrics(metrics_name=name, value=value, metrics_config=config)
+    except BaseException as ex:
+        logger.warning("Emitting metrics failed", ex)
 
 
 def emit_timer_metrics(metrics_name, value, metrics_config, **kwargs):
     _emit_metrics(
         metrics_name=metrics_name,
-        metrics_type=MetricsType.TIMER,
         metrics_config=metrics_config,
         value=value,
         **kwargs,
     )
+
+
+def latency_metric(original_func=None, name: Optional[str] = None):
+    """
+    A decorator that emits latency metrics of a function
+    based on configured metrics config.
+    """
+
+    def _decorate(func):
+        metrics_name = name or f"{func.__name__}_time"
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            start = time.monotonic()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                end = time.monotonic()
+                _emit_with_exception(name=metrics_name, value=end - start)
+
+        return wrapper
+
+    if original_func:
+        return _decorate(original_func)
+
+    return _decorate
+
+
+def success_metric(original_func=None, name: Optional[str] = None):
+    """
+    A decorator that emits success metrics of a function
+    based on configured metrics config.
+    """
+
+    def _decorate(func):
+        metrics_name = name or f"{func.__name__}_success_count"
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            result = func(*args, **kwargs)
+            _emit_with_exception(name=metrics_name, value=1)
+            return result
+
+        return wrapper
+
+    if original_func:
+        return _decorate(original_func)
+
+    return _decorate
+
+
+def failure_metric(original_func=None, name: Optional[str] = None):
+    """
+    A decorator that emits failure metrics of a function
+    based on configured metrics config.
+    """
+
+    def _decorate(func):
+        metrics_name = name or f"{func.__name__}_failure_count"
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except BaseException as ex:
+                exception_name = type(ex).__name__
+                # We emit two metrics, one for exception class and
+                # another for just the specified metric name.
+                _emit_with_exception(name=f"{metrics_name}.{exception_name}", value=1)
+                _emit_with_exception(name=metrics_name, value=1)
+                raise ex
+
+        return wrapper
+
+    if original_func:
+        return _decorate(original_func)
+
+    return _decorate
+
+
+def metrics(original_func=None, prefix: Optional[str] = None):
+    """
+    A decorator that emits all metrics for a function.
+    """
+
+    def _decorate(func):
+        name = prefix or func.__name__
+        failure_metrics_name = f"{name}_failure_count"
+        success_metrics_name = f"{name}_success_count"
+        latency_metrics_name = f"{name}_time"
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            start = time.monotonic()
+            try:
+                result = func(*args, **kwargs)
+                _emit_with_exception(name=success_metrics_name, value=1)
+                return result
+            except BaseException as ex:
+                exception_name = type(ex).__name__
+                _emit_with_exception(
+                    name=f"{failure_metrics_name}.{exception_name}", value=1
+                )
+                _emit_with_exception(name=failure_metrics_name, value=1)
+                raise ex
+            finally:
+                end = time.monotonic()
+                _emit_with_exception(name=latency_metrics_name, value=end - start)
+
+        return wrapper
+
+    if original_func:
+        return _decorate(original_func)
+
+    return _decorate


### PR DESCRIPTION
This commit adds low level metrics to deltacat. Below are the metrics covered as part of this PR:
- Download (latency, failure, success)
- Upload (latency, failure, success)
- Hash bucket (latency, failure, success)
- Merge (latency, failure, success)
- Prepare Deletes (latency, failure, success)
- Discover Deltas (latency, failure, success)
- Materialize (latency, failure, success)

Observed an overhead of 0.02s when actor is not yet available on the node and 0.009s when actor is already available. 