### PR TITLE
Leverage Daft Transient Errors to retry tasks on ray and drop timeout times

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 
 
 __all__ = [

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -21,6 +21,9 @@ from deltacat.compute.compactor_v2.constants import (
     PARQUET_TO_PYARROW_INFLATION,
 )
 
+from daft.exceptions import DaftTransientError
+
+
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
@@ -76,6 +79,7 @@ def get_task_options(
         botocore.exceptions.HTTPClientError,
         ConnectionError,
         TimeoutError,
+        DaftTransientError,
     ]
 
     return task_opts

--- a/deltacat/utils/daft.py
+++ b/deltacat/utils/daft.py
@@ -163,5 +163,7 @@ def _get_s3_io_config(s3_client_kwargs) -> IOConfig:
             retry_mode="adaptive",
             num_tries=BOTO_MAX_RETRIES,
             max_connections=DAFT_MAX_S3_CONNECTIONS_PER_FILE,
+            connect_timeout_ms=5_000,  # Timeout to connect to server
+            read_timeout_ms=10_000,  # Timeout for first byte from server
         )
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # any changes here should also be reflected in setup.py "install_requires"
 aws-embedded-metrics == 3.2.0
 boto3 ~= 1.20
-getdaft==0.2.22
+getdaft==0.2.23
 numpy == 1.21.5
 pandas == 1.3.5
 pyarrow == 12.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # any changes here should also be reflected in setup.py "install_requires"
 aws-embedded-metrics == 3.2.0
 boto3 ~= 1.20
-getdaft==0.2.16
+getdaft==0.2.22
 numpy == 1.21.5
 pandas == 1.3.5
 pyarrow == 12.0.1

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         "typing-extensions == 4.4.0",
         "pymemcache == 4.0.0",
         "redis == 4.6.0",
-        "getdaft == 0.2.17",
+        "getdaft == 0.2.23",
         "schedule == 1.2.0",
     ],
     setup_requires=["wheel"],


### PR DESCRIPTION
* Upgrade Daft to 0.2.23
* Cut down connect timeout to 5 seconds and read timeout to 10 seconds
* Add Daft Transient error to retry list for ray
* This version of daft also will not panic on connection issues.