### PR TITLE
Fix compaction jobs latency increase due to changes in scheduling algo in ray 2.20.0

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 
 
 __all__ = [

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -20,7 +20,6 @@ from deltacat.compute.compactor_v2.utils.primary_key_index import (
 from deltacat.compute.compactor_v2.constants import (
     PARQUET_TO_PYARROW_INFLATION,
 )
-
 from daft.exceptions import DaftTransientError
 
 
@@ -65,7 +64,11 @@ def get_task_options(
     cpu: float, memory: float, ray_custom_resources: Optional[Dict] = None
 ) -> Dict:
 
-    task_opts = {"num_cpus": cpu, "memory": memory}
+    # NOTE: With DEFAULT scheduling strategy in Ray 2.20.0, autoscaler does
+    # not spin up enough nodes fast and hence we see only approximately
+    # 20 tasks get scheduled out of 100 tasks in queue.
+    # https://docs.ray.io/en/latest/ray-core/scheduling/index.html
+    task_opts = {"num_cpus": cpu, "memory": memory, "scheduling_strategy": "SPREAD"}
 
     if ray_custom_resources:
         task_opts["resources"] = ray_custom_resources


### PR DESCRIPTION
With Ray version 2.20.0, the scheduling strategy does not scale up to full utilization due the algorithm mentioned in https://docs.ray.io/en/latest/ray-core/scheduling/index.html for default strategy. We were seeing Ray only spinning up nodes to handle just 20% of tasks in queue. With this change we will be using SPREAD strategy which will proactively spin up nodes to handle all of the load in queue. Especially for merge tasks, SPREAD is the ideal strategy because we do not care about node locality. 

NOTE: Existing tests are exercised. 