### PR TITLE
Additional retryable exceptions for s3 put/get

### DIFF
--- a/deltacat/aws/constants.py
+++ b/deltacat/aws/constants.py
@@ -1,13 +1,26 @@
-from typing import List, Set
-
-from botocore.exceptions import NoCredentialsError, ReadTimeoutError
+import botocore
+from typing import Set
 
 from deltacat.utils.common import env_integer, env_string
 
 DAFT_MAX_S3_CONNECTIONS_PER_FILE = env_integer("DAFT_MAX_S3_CONNECTIONS_PER_FILE", 8)
 BOTO_MAX_RETRIES = env_integer("BOTO_MAX_RETRIES", 5)
-TIMEOUT_ERROR_CODES: List[str] = ["ReadTimeoutError", "ConnectTimeoutError"]
-RETRYABLE_PUT_OBJECT_ERROR_CODES: Set[str] = {"Throttling", "SlowDown"}
-RETRYABLE_TRANSIENT_ERRORS = (NoCredentialsError, ReadTimeoutError, ConnectionError)
+TIMEOUT_ERROR_CODES: Set[str] = {"ReadTimeoutError", "ConnectTimeoutError"}
+THROTTLING_ERROR_CODES: Set[str] = {"Throttling", "SlowDown"}
+RETRYABLE_TRANSIENT_ERRORS = (
+    ConnectionError,
+    TimeoutError,
+    OSError,
+    botocore.exceptions.ConnectionError,
+    botocore.exceptions.HTTPClientError,
+    botocore.exceptions.NoCredentialsError,
+    botocore.exceptions.ConnectTimeoutError,
+    botocore.exceptions.ReadTimeoutError,
+)
 AWS_REGION = env_string("AWS_REGION", "us-east-1")
-RETRY_STOP_AFTER_DELAY = env_integer("RETRY_STOP_AFTER_DELAY", 10 * 60)
+UPLOAD_DOWNLOAD_RETRY_STOP_AFTER_DELAY = env_integer(
+    "UPLOAD_DOWNLOAD_RETRY_STOP_AFTER_DELAY", 10 * 60
+)
+UPLOAD_SLICED_TABLE_RETRY_STOP_AFTER_DELAY = env_integer(
+    "UPLOAD_SLICED_TABLE_RETRY_STOP_AFTER_DELAY", 30 * 60
+)

--- a/deltacat/aws/constants.py
+++ b/deltacat/aws/constants.py
@@ -5,11 +5,9 @@ from deltacat.utils.common import env_integer, env_string
 
 DAFT_MAX_S3_CONNECTIONS_PER_FILE = env_integer("DAFT_MAX_S3_CONNECTIONS_PER_FILE", 8)
 BOTO_MAX_RETRIES = env_integer("BOTO_MAX_RETRIES", 5)
-TIMEOUT_ERROR_CODES: Set[str] = {"ReadTimeoutError", "ConnectTimeoutError"}
-THROTTLING_ERROR_CODES: Set[str] = {"Throttling", "SlowDown"}
+BOTO_TIMEOUT_ERROR_CODES: Set[str] = {"ReadTimeoutError", "ConnectTimeoutError"}
+BOTO_THROTTLING_ERROR_CODES: Set[str] = {"Throttling", "SlowDown"}
 RETRYABLE_TRANSIENT_ERRORS = (
-    ConnectionError,
-    TimeoutError,
     OSError,
     botocore.exceptions.ConnectionError,
     botocore.exceptions.HTTPClientError,
@@ -23,4 +21,7 @@ UPLOAD_DOWNLOAD_RETRY_STOP_AFTER_DELAY = env_integer(
 )
 UPLOAD_SLICED_TABLE_RETRY_STOP_AFTER_DELAY = env_integer(
     "UPLOAD_SLICED_TABLE_RETRY_STOP_AFTER_DELAY", 30 * 60
+)
+DOWNLOAD_MANIFEST_ENTRY_RETRY_STOP_AFTER_DELAY = env_integer(
+    "DOWNLOAD_MANIFEST_ENTRY_RETRY_STOP_AFTER_DELAY", 30 * 60
 )

--- a/deltacat/aws/constants.py
+++ b/deltacat/aws/constants.py
@@ -1,10 +1,13 @@
 from typing import List, Set
 
+from botocore.exceptions import NoCredentialsError, ReadTimeoutError
+
 from deltacat.utils.common import env_integer, env_string
 
 DAFT_MAX_S3_CONNECTIONS_PER_FILE = env_integer("DAFT_MAX_S3_CONNECTIONS_PER_FILE", 8)
 BOTO_MAX_RETRIES = env_integer("BOTO_MAX_RETRIES", 5)
 TIMEOUT_ERROR_CODES: List[str] = ["ReadTimeoutError", "ConnectTimeoutError"]
 RETRYABLE_PUT_OBJECT_ERROR_CODES: Set[str] = {"Throttling", "SlowDown"}
+RETRYABLE_TRANSIENT_ERRORS = (NoCredentialsError, ReadTimeoutError, ConnectionError)
 AWS_REGION = env_string("AWS_REGION", "us-east-1")
 RETRY_STOP_AFTER_DELAY = env_integer("RETRY_STOP_AFTER_DELAY", 10 * 60)

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -1,5 +1,6 @@
 import botocore
 import logging
+import tenacity
 from typing import Dict, Optional, List, Tuple, Any
 from deltacat import logs
 from deltacat.compute.compactor_v2.model.merge_file_group import (
@@ -84,6 +85,7 @@ def get_task_options(
         ConnectionError,
         TimeoutError,
         DaftTransientError,
+        tenacity.RetryError,
     ]
 
     return task_opts

--- a/deltacat/tests/aws/test_s3u.py
+++ b/deltacat/tests/aws/test_s3u.py
@@ -1,5 +1,7 @@
 import unittest
 
+import botocore
+
 from deltacat.aws.constants import RETRYABLE_TRANSIENT_ERRORS
 from deltacat.aws.s3u import UuidBlockWritePathProvider, CapturedBlockWritePaths
 
@@ -11,7 +13,13 @@ from unittest.mock import patch
 import boto3
 import pytest
 from boto3.resources.base import ServiceResource
-from botocore.exceptions import ClientError, NoCredentialsError, ReadTimeoutError
+from botocore.exceptions import (
+    ClientError,
+    NoCredentialsError,
+    ReadTimeoutError,
+    ConnectTimeoutError,
+    HTTPClientError,
+)
 from deltacat.exceptions import NonRetryableError
 from moto import mock_s3
 from tenacity import RetryError
@@ -66,7 +74,7 @@ class TestDownloadUpload(unittest.TestCase):
         assert downloaded_file["ResponseMetadata"]["HTTPStatusCode"] == 200
         assert downloaded_body == body
 
-    @patch("deltacat.aws.s3u.RETRY_STOP_AFTER_DELAY", 1)
+    @patch("deltacat.aws.s3u.UPLOAD_DOWNLOAD_RETRY_STOP_AFTER_DELAY", 1)
     @patch("deltacat.aws.s3u.s3_client_cache")
     def test_upload_throttled(self, mock_s3_client_cache):
         uri = f"s3://{self.TEST_S3_BUCKET_NAME}/{self.TEST_S3_KEY}"
@@ -89,7 +97,35 @@ class TestDownloadUpload(unittest.TestCase):
 
         assert mock_s3.put_object.call_count > 3
 
-    @patch("deltacat.aws.s3u.RETRY_STOP_AFTER_DELAY", 1)
+    @patch("deltacat.aws.s3u.UPLOAD_SLICED_TABLE_RETRY_STOP_AFTER_DELAY", 1)
+    @patch("deltacat.aws.s3u.ManifestEntry")
+    @patch("deltacat.aws.s3u._get_metadata")
+    @patch("deltacat.aws.s3u.CapturedBlockWritePaths")
+    def test_upload_sliced_table_retry(
+        self,
+        mock_captured_block_write_paths,
+        mock_get_metadata,
+        mock_manifest_entry,
+    ):
+        mock_manifest_entry.from_s3_obj_url.side_effect = OSError(
+            "Please reduce your request rate.."
+        )
+        mock_get_metadata.return_value = [mock.MagicMock()]
+        cbwp = CapturedBlockWritePaths()
+        cbwp._write_paths = ["s3_write_path"]
+        cbwp._block_refs = [mock.MagicMock()]
+        mock_captured_block_write_paths.return_value = cbwp
+        with pytest.raises(RetryError):
+            s3u.upload_sliced_table(
+                mock.MagicMock(),
+                "s3-prefix",
+                mock.MagicMock(),
+                mock.MagicMock(),
+                mock.MagicMock(),
+                mock.MagicMock(),
+            )
+
+    @patch("deltacat.aws.s3u.UPLOAD_DOWNLOAD_RETRY_STOP_AFTER_DELAY", 1)
     @patch("deltacat.aws.s3u.s3_client_cache")
     def test_upload_transient_error_retry(self, mock_s3_client_cache):
         uri = f"s3://{self.TEST_S3_BUCKET_NAME}/{self.TEST_S3_KEY}"
@@ -98,11 +134,8 @@ class TestDownloadUpload(unittest.TestCase):
         mock_s3_client_cache.return_value = mock_s3 = mock.MagicMock()
 
         while transient_errors:
-            err = transient_errors.pop()
-            if err == ReadTimeoutError:
-                err_obj = err(endpoint_url="127.0.0.1")
-            else:
-                err_obj = err()
+            err_cls = transient_errors.pop()
+            err_obj = self._populate_error_by_type(err_cls)
             mock_s3.put_object.side_effect = err_obj
             with pytest.raises(RetryError):
                 s3u.upload(uri, body)
@@ -122,7 +155,7 @@ class TestDownloadUpload(unittest.TestCase):
         assert file is None
         assert mock_s3.put_object.call_count == 1
 
-    @patch("deltacat.aws.s3u.RETRY_STOP_AFTER_DELAY", 1)
+    @patch("deltacat.aws.s3u.UPLOAD_DOWNLOAD_RETRY_STOP_AFTER_DELAY", 1)
     @patch("deltacat.aws.s3u.s3_client_cache")
     def test_download_throttled(self, mock_s3_client_cache):
         uri = f"s3://{self.TEST_S3_BUCKET_NAME}/{self.TEST_S3_KEY}"
@@ -145,7 +178,7 @@ class TestDownloadUpload(unittest.TestCase):
         file = s3u.download(uri, fail_if_not_found=False)
         assert file is None
 
-    @patch("deltacat.aws.s3u.RETRY_STOP_AFTER_DELAY", 1)
+    @patch("deltacat.aws.s3u.UPLOAD_DOWNLOAD_RETRY_STOP_AFTER_DELAY", 1)
     @patch("deltacat.aws.s3u.s3_client_cache")
     def test_download_transient_error_retry(self, mock_s3_client_cache):
         uri = f"s3://{self.TEST_S3_BUCKET_NAME}/{self.TEST_S3_KEY}"
@@ -153,13 +186,20 @@ class TestDownloadUpload(unittest.TestCase):
         mock_s3_client_cache.return_value = mock_s3 = mock.MagicMock()
 
         while transient_errors:
-            err = transient_errors.pop()
-            if err == ReadTimeoutError:
-                err_obj = err(endpoint_url="127.0.0.1")
-            else:
-                err_obj = err()
+            err_cls = transient_errors.pop()
+            err_obj = self._populate_error_by_type(err_cls)
             mock_s3.get_object.side_effect = err_obj
             with pytest.raises(RetryError):
                 s3u.download(uri)
 
         assert mock_s3.get_object.call_count > len(RETRYABLE_TRANSIENT_ERRORS)
+
+    @staticmethod
+    def _populate_error_by_type(err_cls):
+        if err_cls in (ReadTimeoutError, ConnectTimeoutError):
+            err_obj = err_cls(endpoint_url="127.0.0.1")
+        elif err_cls in (HTTPClientError, botocore.exceptions.ConnectionError):
+            err_obj = err_cls(endpoint_url="127.0.0.1", error=Exception)
+        else:
+            err_obj = err_cls()
+        return err_obj


### PR DESCRIPTION
New transient exceptions (e.g. SSL handshake errors) were discovered from stress tests, which were incorrectly classified as non-retryable errors.