### PR TITLE
`commit_partition` storage interface method signature now has `previous_partition` as an optional parameter. Additional support for in-place compaction

### DIFF
--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -129,5 +129,6 @@ class RoundCompletionInfo(dict):
     def input_average_record_size_bytes(self) -> Optional[float]:
         return self.get("inputAverageRecordSizeBytes")
 
+    @staticmethod
     def get_audit_bucket_name_and_key(compaction_audit_url: str) -> Tuple[str, str]:
         return compaction_audit_url.replace("s3://", "").split("/", 1)

--- a/deltacat/compute/compactor/model/round_completion_info.py
+++ b/deltacat/compute/compactor/model/round_completion_info.py
@@ -128,3 +128,6 @@ class RoundCompletionInfo(dict):
     @property
     def input_average_record_size_bytes(self) -> Optional[float]:
         return self.get("inputAverageRecordSizeBytes")
+
+    def get_audit_bucket_name_and_key(compaction_audit_url: str) -> Tuple[str, str]:
+        return compaction_audit_url.replace("s3://", "").split("/", 1)

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -24,7 +24,9 @@ from deltacat.compute.compactor import (
 )
 from deltacat.compute.compactor_v2.model.merge_result import MergeResult
 from deltacat.compute.compactor_v2.model.hash_bucket_result import HashBucketResult
-from deltacat.compute.compactor_v2.model.compaction_session import ExecutionCompactionResult
+from deltacat.compute.compactor_v2.model.compaction_session import (
+    ExecutionCompactionResult,
+)
 from deltacat.compute.compactor.model.materialize_result import MaterializeResult
 from deltacat.compute.compactor_v2.utils.merge import (
     generate_local_merge_input,
@@ -58,7 +60,7 @@ from deltacat.compute.compactor_v2.utils import io
 from deltacat.compute.compactor.utils import round_completion_file as rcf
 from deltacat.utils.metrics import metrics
 
-from typing import List, Optional, Tuple
+from typing import List, Optional
 from collections import defaultdict
 from deltacat.compute.compactor.model.compaction_session_audit_info import (
     CompactionSessionAuditInfo,
@@ -114,9 +116,16 @@ def compact_partition(params: CompactPartitionParams, **kwargs) -> Optional[str]
                 if is_inplace_compacted
                 else None
             )
-            logger.info(f"Committing compacted partition to: {new_partition.locator} using previous partition: {previous_partition.locator if previous_partition else None}")
-            if previous_partition and previous_partition.stream_position > new_partition.stream_position:
-                logger.warning(f"New partition: {new_partition.locator} has a lower stream position {new_partition.stream_position} than the previous partition: {previous_partition.locator if previous_partition else None}")
+            logger.info(
+                f"Committing compacted partition to: {new_partition.locator} using previous partition: {previous_partition.locator if previous_partition else None}"
+            )
+            if (
+                previous_partition
+                and previous_partition.stream_position > new_partition.stream_position
+            ):
+                logger.warning(
+                    f"New partition: {new_partition.locator} has a lower stream position {new_partition.stream_position} than the previous partition: {previous_partition.locator if previous_partition else None}"
+                )
             partition: Partition = params.deltacat_storage.commit_partition(
                 new_partition, previous_partition, **params.deltacat_storage_kwargs
             )

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -46,7 +46,6 @@ from deltacat.storage import (
     DeltaLocator,
     Manifest,
     Partition,
-    Stream,
 )
 from deltacat.compute.compactor.model.compact_partition_params import (
     CompactPartitionParams,
@@ -108,19 +107,12 @@ def compact_partition(params: CompactPartitionParams, **kwargs) -> Optional[str]
         )
         round_completion_file_s3_url: Optional[str] = None
         if new_partition:
-            source_table_stream: Optional[Stream] = None
             previous_partition: Optional[Partition] = None
             if is_inplace_compacted:
-                source_table_stream = params.deltacat_storage.get_stream(
-                    params.source_partition_locator.namespace,
-                    params.source_partition_locator.table_name,
-                    params.source_partition_locator.table_version,
-                    **params.deltacat_storage_kwargs,
-                )
                 previous_partition: Optional[
                     Partition
                 ] = params.deltacat_storage.get_partition(
-                    source_table_stream.locator,
+                    params.source_partition_locator.stream_locator,
                     params.source_partition_locator.partition_values,
                     **params.deltacat_storage_kwargs,
                 )

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -117,7 +117,8 @@ def compact_partition(params: CompactPartitionParams, **kwargs) -> Optional[str]
                     **params.deltacat_storage_kwargs,
                 )
             logger.info(
-                f"Committing compacted partition to: {new_partition.locator} at {new_partition.stream_position} using previous partition: {previous_partition.locator if previous_partition else None} at stream position: {previous_partition.stream_position if previous_partition else None}"
+                f"Committing compacted partition to: {new_partition.locator} at {new_partition.stream_position} "
+                f"using previous partition: {previous_partition.locator if previous_partition else None}"
             )
             partition: Partition = params.deltacat_storage.commit_partition(
                 new_partition, previous_partition, **params.deltacat_storage_kwargs

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -128,9 +128,7 @@ def compact_partition(params: CompactPartitionParams, **kwargs) -> Optional[str]
                 previous_partition,
                 **params.deltacat_storage_kwargs,
             )
-            logger.info(
-                f"Committed compacted partition: {commited_partition} with stream position: {commited_partition.stream_position} and previous stream position: {commited_partition.previous_stream_position}"
-            )
+            logger.info(f"Committed compacted partition: {commited_partition}")
             round_completion_file_s3_url = rcf.write_round_completion_file(
                 params.compaction_artifact_s3_bucket,
                 execute_compaction_result.new_round_completion_file_partition_locator,

--- a/deltacat/compute/compactor_v2/model/compaction_session.py
+++ b/deltacat/compute/compactor_v2/model/compaction_session.py
@@ -12,9 +12,9 @@ from typing import Optional
 
 @dataclass(frozen=True)
 class ExecutionCompactionResult:
-    compacted_partition: Optional[Partition]
-    round_completion_info: Optional[RoundCompletionInfo]
-    round_completion_file_partition_locator: Optional[PartitionLocator]
+    new_compacted_partition: Optional[Partition]
+    new_round_completion_info: Optional[RoundCompletionInfo]
+    new_round_completion_file_partition_locator: Optional[PartitionLocator]
     is_inplace_compacted: bool
 
     def __iter__(self):

--- a/deltacat/compute/compactor_v2/model/compaction_session.py
+++ b/deltacat/compute/compactor_v2/model/compaction_session.py
@@ -1,17 +1,13 @@
 from dataclasses import dataclass, fields
 
 from deltacat.storage import (
-    Delta,
-    DeltaLocator,
-    Manifest,
     Partition,
 )
 from deltacat.compute.compactor import (
-    HighWatermark,
-    PyArrowWriteResult,
     RoundCompletionInfo,
 )
 from typing import Optional
+
 
 @dataclass(frozen=True)
 class ExecutionCompactionResult:

--- a/deltacat/compute/compactor_v2/model/compaction_session.py
+++ b/deltacat/compute/compactor_v2/model/compaction_session.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, fields
 
 from deltacat.storage import (
     Partition,
+    PartitionLocator,
 )
 from deltacat.compute.compactor import (
     RoundCompletionInfo,
@@ -13,7 +14,7 @@ from typing import Optional
 class ExecutionCompactionResult:
     compacted_partition: Optional[Partition]
     round_completion_info: Optional[RoundCompletionInfo]
-    round_completion_file_partition_locator: Optional[str]
+    round_completion_file_partition_locator: Optional[PartitionLocator]
     is_inplace_compacted: bool
 
     def __iter__(self):

--- a/deltacat/compute/compactor_v2/model/compaction_session.py
+++ b/deltacat/compute/compactor_v2/model/compaction_session.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, fields
+
+from deltacat.storage import (
+    Delta,
+    DeltaLocator,
+    Manifest,
+    Partition,
+)
+from deltacat.compute.compactor import (
+    HighWatermark,
+    PyArrowWriteResult,
+    RoundCompletionInfo,
+)
+from typing import Optional
+
+@dataclass(frozen=True)
+class ExecutionCompactionResult:
+    compacted_partition: Optional[Partition]
+    round_completion_info: Optional[RoundCompletionInfo]
+    round_completion_file_partition_locator: Optional[str]
+    is_inplace_compacted: bool
+
+    def __iter__(self):
+        return (getattr(self, field.name) for field in fields(self))

--- a/deltacat/storage/interface.py
+++ b/deltacat/storage/interface.py
@@ -414,11 +414,14 @@ def stage_partition(
     raise NotImplementedError("stage_partition not implemented")
 
 
-def commit_partition(partition: Partition, *args, **kwargs) -> Partition:
+def commit_partition(partition: Partition, previous_partition: Optional[Partition] = None, *args, **kwargs) -> Partition:
     """
     Commits the given partition to its associated table version stream,
-    replacing any previous partition registered for the same stream and
-    partition values. Returns the registered partition. If the partition's
+    replacing any previous partition (i.e., "partition being replaced") registered for the same stream and
+    partition values. 
+    If the previous_partition is specified explicitly, 
+    the specified previous_partition will be the partition being replaced, otherwise it will be retrieved.
+    Returns the registered partition. If the partition's
     previous delta stream position is specified, then the commit will
     be rejected if it does not match the actual previous stream position of
     the partition being replaced. If the partition's previous partition ID is

--- a/deltacat/storage/interface.py
+++ b/deltacat/storage/interface.py
@@ -424,8 +424,7 @@ def commit_partition(
     Commits the given partition to its associated table version stream,
     replacing any previous partition (i.e., "partition being replaced") registered for the same stream and
     partition values.
-    If the previous_partition is specified explicitly,
-    the specified previous_partition will be the partition being replaced, otherwise it will be retrieved.
+    If the previous_partition is passed as an argument, the specified previous_partition will be the partition being replaced, otherwise it will be retrieved.
     Returns the registered partition. If the partition's
     previous delta stream position is specified, then the commit will
     be rejected if it does not match the actual previous stream position of

--- a/deltacat/storage/interface.py
+++ b/deltacat/storage/interface.py
@@ -414,12 +414,17 @@ def stage_partition(
     raise NotImplementedError("stage_partition not implemented")
 
 
-def commit_partition(partition: Partition, previous_partition: Optional[Partition] = None, *args, **kwargs) -> Partition:
+def commit_partition(
+    partition: Partition,
+    previous_partition: Optional[Partition] = None,
+    *args,
+    **kwargs
+) -> Partition:
     """
     Commits the given partition to its associated table version stream,
     replacing any previous partition (i.e., "partition being replaced") registered for the same stream and
-    partition values. 
-    If the previous_partition is specified explicitly, 
+    partition values.
+    If the previous_partition is specified explicitly,
     the specified previous_partition will be the partition being replaced, otherwise it will be retrieved.
     Returns the registered partition. If the partition's
     previous delta stream position is specified, then the commit will

--- a/deltacat/tests/catalog/test_default_catalog_impl.py
+++ b/deltacat/tests/catalog/test_default_catalog_impl.py
@@ -36,6 +36,8 @@ class TestReadTable(unittest.TestCase):
     @classmethod
     def doClassCleanups(cls) -> None:
         os.remove(cls.DB_FILE_PATH)
+        ray.shutdown()
+        super().tearDownClass()
 
     def test_daft_distributed_read_sanity(self):
         # setup

--- a/deltacat/tests/compute/compact_partition_test_cases.py
+++ b/deltacat/tests/compute/compact_partition_test_cases.py
@@ -94,7 +94,9 @@ class IncrementalCompactionTestCaseParams(BaseCompactorTestCase):
     """
 
     is_inplace: bool
-    add_late_deltas: Optional[List[Tuple[pa.Table, DeltaType, Optional[DeleteParameters]]]]
+    add_late_deltas: Optional[
+        List[Tuple[pa.Table, DeltaType, Optional[DeleteParameters]]]
+    ]
 
 
 @dataclass(frozen=True)
@@ -536,11 +538,11 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         add_late_deltas=[
             (
                 pa.Table.from_arrays(
-                     [
+                    [
                         pa.array([str(i) for i in range(20)]),
                         pa.array([i for i in range(20)]),
                     ],
-                names=["pk_col_1", "sk_col_1"],
+                    names=["pk_col_1", "sk_col_1"],
                 ),
                 DeltaType.UPSERT,
                 None,

--- a/deltacat/tests/compute/compact_partition_test_cases.py
+++ b/deltacat/tests/compute/compact_partition_test_cases.py
@@ -22,6 +22,7 @@ from deltacat.storage import (
 from deltacat.compute.compactor_v2.compaction_session import (
     compact_partition as compact_partition_v2,
 )
+from deltacat.storage import DeleteParameters
 
 from deltacat.compute.compactor.model.compactor_version import CompactorVersion
 
@@ -89,9 +90,11 @@ class IncrementalCompactionTestCaseParams(BaseCompactorTestCase):
     """
     Args:
         is_inplace: bool - argument to indicate whether to try compacting an in-place compacted table (the source table is the destination table). Also needed to control whether the destination table is created
+        add_late_deltas: List[Tuple[pa.Table, DeltaType]] - argument to indicate whether to add deltas to the source_partition after we've triggered compaction
     """
 
     is_inplace: bool
+    add_late_deltas: Optional[List[Tuple[pa.Table, DeltaType, Optional[DeleteParameters]]]]
 
 
 @dataclass(frozen=True)
@@ -148,6 +151,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "2-incremental-pkstr-skstr-norcf": IncrementalCompactionTestCaseParams(
@@ -175,6 +179,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "3-incremental-pkstr-multiskstr-norcf": IncrementalCompactionTestCaseParams(
@@ -211,6 +216,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "4-incremental-duplicate-pk": IncrementalCompactionTestCaseParams(
@@ -246,6 +252,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "5-incremental-decimal-pk-simple": IncrementalCompactionTestCaseParams(
@@ -276,6 +283,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "6-incremental-integer-pk-simple": IncrementalCompactionTestCaseParams(
@@ -306,6 +314,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "7-incremental-timestamp-pk-simple": IncrementalCompactionTestCaseParams(
@@ -336,6 +345,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "8-incremental-decimal-timestamp-pk-multi": IncrementalCompactionTestCaseParams(
@@ -368,6 +378,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "9-incremental-decimal-pk-multi-dup": IncrementalCompactionTestCaseParams(
@@ -398,6 +409,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "10-incremental-decimal-pk-partitionless": IncrementalCompactionTestCaseParams(
@@ -428,6 +440,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "11-incremental-decimal-hash-bucket-single": IncrementalCompactionTestCaseParams(
@@ -458,6 +471,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "12-incremental-decimal-single-hash-bucket": IncrementalCompactionTestCaseParams(
@@ -488,6 +502,7 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=False,
+        add_late_deltas=None,
         skip_enabled_compact_partition_drivers=None,
     ),
     "13-incremental-pkstr-skexists-isinplacecompacted": IncrementalCompactionTestCaseParams(
@@ -518,6 +533,19 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         read_kwargs_provider=None,
         drop_duplicates=True,
         is_inplace=True,
+        add_late_deltas=[
+            (
+                pa.Table.from_arrays(
+                     [
+                        pa.array([str(i) for i in range(20)]),
+                        pa.array([i for i in range(20)]),
+                    ],
+                names=["pk_col_1", "sk_col_1"],
+                ),
+                DeltaType.UPSERT,
+                None,
+            )
+        ],
         skip_enabled_compact_partition_drivers=[CompactorVersion.V1],
     ),
 }

--- a/deltacat/tests/compute/compact_partition_test_cases.py
+++ b/deltacat/tests/compute/compact_partition_test_cases.py
@@ -550,6 +550,37 @@ INCREMENTAL_TEST_CASES: Dict[str, IncrementalCompactionTestCaseParams] = {
         ],
         skip_enabled_compact_partition_drivers=[CompactorVersion.V1],
     ),
+    "14-incremental-pkstr-skexists-unhappy-hash-bucket-count-not-present": IncrementalCompactionTestCaseParams(
+        primary_keys={"pk_col_1"},
+        sort_keys=[SortKey.of(key_name="sk_col_1")],
+        partition_keys=[PartitionKey.of("region_id", PartitionKeyType.INT)],
+        partition_values=["1"],
+        input_deltas=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(10)]),
+            ],
+            names=["pk_col_1", "sk_col_1"],
+        ),
+        input_deltas_delta_type=DeltaType.UPSERT,
+        expected_terminal_compact_partition_result=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(10)]),
+            ],
+            names=["pk_col_1", "sk_col_1"],
+        ),
+        expected_terminal_exception=AssertionError,
+        expected_terminal_exception_message="hash_bucket_count is a required arg for compactor v2",
+        do_create_placement_group=False,
+        records_per_compacted_file=DEFAULT_MAX_RECORDS_PER_FILE,
+        hash_bucket_count=None,
+        read_kwargs_provider=None,
+        drop_duplicates=True,
+        is_inplace=False,
+        add_late_deltas=False,
+        skip_enabled_compact_partition_drivers=[CompactorVersion.V1],
+    ),
 }
 
 INCREMENTAL_TEST_CASES = with_compactor_version_func_test_param(INCREMENTAL_TEST_CASES)

--- a/deltacat/tests/compute/compactor_v2/deletes/test_delete_strategy_equality_delete.py
+++ b/deltacat/tests/compute/compactor_v2/deletes/test_delete_strategy_equality_delete.py
@@ -319,7 +319,6 @@ class TestEqualityDeleteStrategy:
         from deltacat.io.ray_plasma_object_store import RayPlasmaObjectStore
 
         delete_strategy: DeleteStrategy = EqualityDeleteStrategy()
-        ray.init(local_mode=True, ignore_reinit_error=True)
         table = pa.Table.from_arrays(
             [
                 pa.array([0, 1, 2, 3]),

--- a/deltacat/tests/compute/compactor_v2/deletes/test_delete_strategy_equality_delete.py
+++ b/deltacat/tests/compute/compactor_v2/deletes/test_delete_strategy_equality_delete.py
@@ -30,7 +30,7 @@ class ApplyAllDeletesTestCaseParams:
 
 
 @pytest.fixture(scope="module", autouse=True)
-def cleanup():
+def setup_ray_cluster():
     ray.init(local_mode=True, ignore_reinit_error=True)
     yield
     ray.shutdown()

--- a/deltacat/tests/compute/compactor_v2/deletes/test_delete_strategy_equality_delete.py
+++ b/deltacat/tests/compute/compactor_v2/deletes/test_delete_strategy_equality_delete.py
@@ -29,6 +29,13 @@ class ApplyAllDeletesTestCaseParams:
         return (getattr(self, field.name) for field in fields(self))
 
 
+@pytest.fixture(scope="module", autouse=True)
+def cleanup():
+    ray.init(local_mode=True, ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+
 TEST_CASES_APPLY_MANY_DELETES = {
     "1-test-delete-successful": ApplyAllDeletesTestCaseParams(
         table=pa.Table.from_arrays(
@@ -277,8 +284,6 @@ class TestEqualityDeleteStrategy:
         )
 
         delete_strategy: DeleteStrategy = EqualityDeleteStrategy()
-        ray.shutdown()
-        ray.init(local_mode=True, ignore_reinit_error=True)
         delete_file_envelopes = [
             DeleteFileEnvelope.of(**params) for params in delete_file_envelopes_params
         ]
@@ -314,8 +319,7 @@ class TestEqualityDeleteStrategy:
         from deltacat.io.ray_plasma_object_store import RayPlasmaObjectStore
 
         delete_strategy: DeleteStrategy = EqualityDeleteStrategy()
-        ray.shutdown()
-        ray.init()
+        ray.init(local_mode=True, ignore_reinit_error=True)
         table = pa.Table.from_arrays(
             [
                 pa.array([0, 1, 2, 3]),

--- a/deltacat/tests/compute/compactor_v2/deletes/test_delete_utils.py
+++ b/deltacat/tests/compute/compactor_v2/deletes/test_delete_utils.py
@@ -52,6 +52,13 @@ class PrepareDeleteTestCaseParams:
         return (getattr(self, field.name) for field in fields(self))
 
 
+@pytest.fixture(scope="module", autouse=True)
+def cleanup():
+    ray.init(local_mode=True, ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+
 @pytest.fixture(scope="function")
 def local_deltacat_storage_kwargs(request: pytest.FixtureRequest):
     # see deltacat/tests/local_deltacat_storage/README.md for documentation
@@ -499,7 +506,6 @@ class TestPrepareDeletes:
             prepare_deletes,
         )
 
-        ray.shutdown()
         ray.init(local_mode=True, ignore_reinit_error=True)
         source_namespace, source_table_name, source_table_version = create_src_table(
             set(self.TEST_PRIMARY_KEYS),

--- a/deltacat/tests/compute/compactor_v2/deletes/test_delete_utils.py
+++ b/deltacat/tests/compute/compactor_v2/deletes/test_delete_utils.py
@@ -53,7 +53,7 @@ class PrepareDeleteTestCaseParams:
 
 
 @pytest.fixture(scope="module", autouse=True)
-def cleanup():
+def setup_ray_cluster():
     ray.init(local_mode=True, ignore_reinit_error=True)
     yield
     ray.shutdown()

--- a/deltacat/tests/compute/compactor_v2/deletes/test_delete_utils.py
+++ b/deltacat/tests/compute/compactor_v2/deletes/test_delete_utils.py
@@ -506,7 +506,6 @@ class TestPrepareDeletes:
             prepare_deletes,
         )
 
-        ray.init(local_mode=True, ignore_reinit_error=True)
         source_namespace, source_table_name, source_table_version = create_src_table(
             set(self.TEST_PRIMARY_KEYS),
             None,

--- a/deltacat/tests/compute/compactor_v2/steps/test_hash_bucket.py
+++ b/deltacat/tests/compute/compactor_v2/steps/test_hash_bucket.py
@@ -41,6 +41,8 @@ class TestHashBucket(unittest.TestCase):
     @classmethod
     def doClassCleanups(cls) -> None:
         os.remove(cls.DB_FILE_PATH)
+        ray.shutdown()
+        super().tearDownClass()
 
     def test_single_string_pk_correctly_hashes(self):
         # setup

--- a/deltacat/tests/compute/compactor_v2/steps/test_merge.py
+++ b/deltacat/tests/compute/compactor_v2/steps/test_merge.py
@@ -64,6 +64,7 @@ class TestMerge(unittest.TestCase):
     @classmethod
     def tearDown(cls):
         os.remove(cls.DB_FILE_PATH)
+        ray.shutdown()
 
     def test_merge_multiple_hash_group_string_pk(self):
         number_of_hash_group = 2

--- a/deltacat/tests/compute/compactor_v2/steps/test_merge.py
+++ b/deltacat/tests/compute/compactor_v2/steps/test_merge.py
@@ -65,6 +65,7 @@ class TestMerge(unittest.TestCase):
     def tearDown(cls):
         os.remove(cls.DB_FILE_PATH)
         ray.shutdown()
+        super().tearDownClass()
 
     def test_merge_multiple_hash_group_string_pk(self):
         number_of_hash_group = 2

--- a/deltacat/tests/compute/compactor_v2/test_compaction_session.py
+++ b/deltacat/tests/compute/compactor_v2/test_compaction_session.py
@@ -35,6 +35,7 @@ class TestCompactionSession(unittest.TestCase):
     @classmethod
     def doClassCleanups(cls) -> None:
         os.remove(cls.DB_FILE_PATH)
+        ray.shutdown()
 
     @patch("deltacat.compute.compactor_v2.compaction_session.rcf")
     @patch("deltacat.compute.compactor_v2.compaction_session.s3_utils")

--- a/deltacat/tests/compute/compactor_v2/test_compaction_session.py
+++ b/deltacat/tests/compute/compactor_v2/test_compaction_session.py
@@ -36,6 +36,7 @@ class TestCompactionSession(unittest.TestCase):
     def doClassCleanups(cls) -> None:
         os.remove(cls.DB_FILE_PATH)
         ray.shutdown()
+        super().tearDownClass()
 
     @patch("deltacat.compute.compactor_v2.compaction_session.rcf")
     @patch("deltacat.compute.compactor_v2.compaction_session.s3_utils")

--- a/deltacat/tests/compute/test_compact_partition_incremental.py
+++ b/deltacat/tests/compute/test_compact_partition_incremental.py
@@ -29,7 +29,7 @@ from deltacat.tests.compute.test_util_constant import (
 from deltacat.compute.compactor import (
     RoundCompletionInfo,
 )
-from deltacat.storage import(
+from deltacat.storage import (
     DeltaType,
 )
 from deltacat import logs
@@ -199,7 +199,6 @@ def test_compact_partition_incremental(
         DeltaLocator,
         Partition,
         PartitionLocator,
-        Stream,
     )
     from deltacat.compute.compactor.model.compaction_session_audit_info import (
         CompactionSessionAuditInfo,
@@ -286,7 +285,9 @@ def test_compact_partition_incremental(
         return (compact_partition_params,), {}
 
     if add_late_deltas:
-        late_delta, incremental_length = add_late_deltas_to_partition(add_late_deltas, source_partition, ds_mock_kwargs)
+        late_delta, incremental_length = add_late_deltas_to_partition(
+            add_late_deltas, source_partition, ds_mock_kwargs
+        )
     rcf_file_s3_uri = benchmark.pedantic(
         compact_partition_func, setup=_incremental_compaction_setup
     )

--- a/deltacat/tests/compute/test_compact_partition_incremental.py
+++ b/deltacat/tests/compute/test_compact_partition_incremental.py
@@ -288,7 +288,8 @@ def test_compact_partition_incremental(
         return (compact_partition_params,), {}
 
     if add_late_deltas:
-        # NOTE: In the case of in-place compaction it is plausible that new deltas may be added to the source partition during compaction (so that the source_partitition.stream_position > last_stream_position_to_compact).
+        # NOTE: In the case of in-place compaction it is plausible that new deltas may be added to the source partition during compaction
+        # (so that the source_partitition.stream_position > last_stream_position_to_compact).
         # This parameter helps simulate the case to check that no late deltas are dropped even when the compacted partition is created.
         latest_delta, _ = add_late_deltas_to_partition(
             add_late_deltas, source_partition, ds_mock_kwargs

--- a/deltacat/tests/compute/test_compact_partition_incremental.py
+++ b/deltacat/tests/compute/test_compact_partition_incremental.py
@@ -352,11 +352,9 @@ def test_compact_partition_incremental(
             )
             compacted_partition_deltas: List[Delta] = ds.list_partition_deltas(
                 partition_like=compacted_table_partition,
-                ascending_order=True,
+                ascending_order=False,
                 **ds_mock_kwargs,
             ).all_items()
-            for i, delta in enumerate(compacted_partition_deltas):
-                logger.info(f"PDEBUG::{i=}, {delta.stream_position=}")
             assert (
                 len(compacted_partition_deltas) == len(add_late_deltas) + 1
             ), f"Expected the number of deltas within the newly promoted partition to equal 1 (the compacted delta) + the # of late deltas: {len(add_late_deltas)}"

--- a/deltacat/tests/compute/test_compact_partition_rebase_then_incremental.py
+++ b/deltacat/tests/compute/test_compact_partition_rebase_then_incremental.py
@@ -37,6 +37,19 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 from deltacat.types.media import StorageType
 from deltacat.storage import (
     DeltaType,
+    DeltaLocator,
+    Partition,
+    PartitionLocator,
+)
+from deltacat.types.media import ContentType
+from deltacat.compute.compactor.model.compact_partition_params import (
+    CompactPartitionParams,
+)
+from deltacat.utils.placement import (
+    PlacementGroupManager,
+)
+from deltacat.compute.compactor.model.compaction_session_audit_info import (
+    CompactionSessionAuditInfo,
 )
 
 DATABASE_FILE_PATH_KEY, DATABASE_FILE_PATH_VALUE = (
@@ -75,14 +88,14 @@ def cleanup_the_database_file_after_all_compaction_session_package_tests_complet
 
 
 @pytest.fixture(scope="module")
-def setup_s3_resource(mock_aws_credential):
+def s3_resource(mock_aws_credential):
     with mock_s3():
         yield boto3.resource("s3")
 
 
 @pytest.fixture(autouse=True, scope="module")
-def setup_compaction_artifacts_s3_bucket(setup_s3_resource: ServiceResource):
-    setup_s3_resource.create_bucket(
+def setup_compaction_artifacts_s3_bucket(s3_resource: ServiceResource):
+    s3_resource.create_bucket(
         ACL="authenticated-read",
         Bucket=TEST_S3_RCF_BUCKET_NAME,
     )
@@ -173,7 +186,7 @@ def local_deltacat_storage_kwargs(request: pytest.FixtureRequest):
     ids=[test_name for test_name in REBASE_THEN_INCREMENTAL_TEST_CASES],
 )
 def test_compact_partition_rebase_then_incremental(
-    setup_s3_resource: ServiceResource,
+    s3_resource: ServiceResource,
     local_deltacat_storage_kwargs: Dict[str, Any],
     test_name: str,
     primary_keys: Set[str],
@@ -197,24 +210,8 @@ def test_compact_partition_rebase_then_incremental(
     benchmark: BenchmarkFixture,
 ):
     import deltacat.tests.local_deltacat_storage as ds
-    from deltacat.types.media import ContentType
-    from deltacat.storage import (
-        DeltaLocator,
-        Partition,
-        PartitionLocator,
-    )
-    from deltacat.compute.compactor.model.compact_partition_params import (
-        CompactPartitionParams,
-    )
-    from deltacat.utils.placement import (
-        PlacementGroupManager,
-    )
-    from deltacat.compute.compactor.model.compaction_session_audit_info import (
-        CompactionSessionAuditInfo,
-    )
 
     ds_mock_kwargs = local_deltacat_storage_kwargs
-    ray.init(local_mode=True, ignore_reinit_error=True)
     """
     REBASE
     """
@@ -280,7 +277,7 @@ def test_compact_partition_rebase_then_incremental(
     # execute
     rcf_file_s3_uri = benchmark(compact_partition_func, compact_partition_params)
     compacted_delta_locator: DeltaLocator = get_compacted_delta_locator_from_rcf(
-        setup_s3_resource, rcf_file_s3_uri
+        s3_resource, rcf_file_s3_uri
     )
     tables = ds.download_delta(
         compacted_delta_locator, storage_type=StorageType.LOCAL, **ds_mock_kwargs
@@ -346,16 +343,14 @@ def test_compact_partition_rebase_then_incremental(
         assert expected_terminal_exception_message in str(exc_info.value)
         return
     rcf_file_s3_uri = compact_partition_func(compact_partition_params)
-    round_completion_info = get_rcf(setup_s3_resource, rcf_file_s3_uri)
+    round_completion_info = get_rcf(s3_resource, rcf_file_s3_uri)
     compacted_delta_locator_incremental: DeltaLocator = (
         round_completion_info.compacted_delta_locator
     )
     audit_bucket, audit_key = round_completion_info.compaction_audit_url.replace(
         "s3://", ""
     ).split("/", 1)
-    compaction_audit_obj: dict = read_s3_contents(
-        setup_s3_resource, audit_bucket, audit_key
-    )
+    compaction_audit_obj: dict = read_s3_contents(s3_resource, audit_bucket, audit_key)
     compaction_audit: CompactionSessionAuditInfo = CompactionSessionAuditInfo(
         **compaction_audit_obj
     )

--- a/deltacat/tests/compute/test_compact_partition_rebase_then_incremental.py
+++ b/deltacat/tests/compute/test_compact_partition_rebase_then_incremental.py
@@ -54,6 +54,7 @@ MODULE scoped fixtures
 def setup_ray_cluster():
     ray.init(local_mode=True, ignore_reinit_error=True)
     yield
+    ray.shutdown()
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -213,7 +214,6 @@ def test_compact_partition_rebase_then_incremental(
     )
 
     ds_mock_kwargs = local_deltacat_storage_kwargs
-    ray.shutdown()
     ray.init(local_mode=True, ignore_reinit_error=True)
     """
     REBASE

--- a/deltacat/tests/compute/test_util_create_table_deltas_repo.py
+++ b/deltacat/tests/compute/test_util_create_table_deltas_repo.py
@@ -24,20 +24,22 @@ from deltacat import logs
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
+
 def _add_deltas_to_partition(
-                    deltas_ingredients: List[Tuple[pa.Table, DeltaType, Optional[Dict[str, str]]]],
-                    partition: Optional[Partition], 
-                    ds_mock_kwargs: Optional[Dict[str, Any]],
-                    ) -> List[Optional[Delta], int]:
+    deltas_ingredients: List[Tuple[pa.Table, DeltaType, Optional[Dict[str, str]]]],
+    partition: Optional[Partition],
+    ds_mock_kwargs: Optional[Dict[str, Any]],
+) -> List[Optional[Delta], int]:
     import deltacat.tests.local_deltacat_storage as ds
+
     all_deltas_length = 0
     for (delta_data, delta_type, delete_parameters) in deltas_ingredients:
         staged_delta: Delta = ds.stage_delta(
-                delta_data,
-                partition,
-                delta_type,
-                delete_parameters=delete_parameters,
-                **ds_mock_kwargs,
+            delta_data,
+            partition,
+            delta_type,
+            delete_parameters=delete_parameters,
+            **ds_mock_kwargs,
         )
         incremental_delta = ds.commit_delta(
             staged_delta,
@@ -47,12 +49,13 @@ def _add_deltas_to_partition(
     return incremental_delta, all_deltas_length
 
 
-
 def add_late_deltas_to_partition(
-            late_deltas: List[Tuple[pa.Table, DeltaType, Optional[Dict[str, str]]]],
-            source_partition: Optional[Partition], 
-            ds_mock_kwargs: Optional[Dict[str, Any]]) -> List[Optional[Delta], int]:
+    late_deltas: List[Tuple[pa.Table, DeltaType, Optional[Dict[str, str]]]],
+    source_partition: Optional[Partition],
+    ds_mock_kwargs: Optional[Dict[str, Any]],
+) -> List[Optional[Delta], int]:
     return _add_deltas_to_partition(late_deltas, source_partition, ds_mock_kwargs)
+
 
 def create_incremental_deltas_on_source_table(
     source_namespace: str,
@@ -170,7 +173,14 @@ def create_src_w_deltas_destination_plus_destination(
         table_version=destination_table_version,
         **ds_mock_kwargs,
     )
-    return source_table_stream_after_committed, destination_table_stream, None, source_namespace, source_table_name, source_table_version
+    return (
+        source_table_stream_after_committed,
+        destination_table_stream,
+        None,
+        source_namespace,
+        source_table_name,
+        source_table_version,
+    )
 
 
 def create_src_w_deltas_destination_rebase_w_deltas_strategy(

--- a/deltacat/tests/local_deltacat_storage/__init__.py
+++ b/deltacat/tests/local_deltacat_storage/__init__.py
@@ -821,8 +821,6 @@ def commit_partition(
     partition_deltas: Optional[List[Delta]] = list_partition_deltas(
         partition, ascending_order=False, *args, **kwargs
     ).all_items()
-    # previous_partition_deltas.sort(reverse=True, key=lambda x: x.stream_position)
-    # partition_deltas.sort(reverse=True, key=lambda x: x.stream_position)
     previous_partition_deltas_spos_gt: List[Delta] = [
         delta
         for delta in previous_partition_deltas

--- a/deltacat/tests/local_deltacat_storage/__init__.py
+++ b/deltacat/tests/local_deltacat_storage/__init__.py
@@ -271,9 +271,7 @@ def list_partition_deltas(
         if not include_manifest:
             current_delta.manifest = None
 
-    result.sort(
-        reverse=True if not ascending_order else False, key=lambda d: d.stream_position
-    )
+    result.sort(reverse=(not ascending_order), key=lambda d: d.stream_position)
     return ListResult.of(result, None, None)
 
 
@@ -823,10 +821,12 @@ def commit_partition(
     partition_deltas: Optional[List[Delta]] = list_partition_deltas(
         partition, ascending_order=True, *args, **kwargs
     ).all_items()
+    previous_partition_deltas.sort(reverse=True, key=lambda x: x.stream_position)
+    partition_deltas.sort(reverse=True, key=lambda x: x.stream_position)
     previous_partition_deltas_spos_gt: List[Delta] = [
         delta
         for delta in previous_partition_deltas
-        if delta and delta.stream_position > partition_deltas[0].stream_position
+        if delta.stream_position > partition_deltas[0].stream_position
     ]
     # handle the case if the previous partition deltas have a greater stream position than the partition_delta
     partition_deltas = previous_partition_deltas_spos_gt + partition_deltas

--- a/deltacat/tests/local_deltacat_storage/__init__.py
+++ b/deltacat/tests/local_deltacat_storage/__init__.py
@@ -816,13 +816,13 @@ def commit_partition(
         cur.execute("UPDATE partitions SET value = ? WHERE locator = ?", params)
 
     previous_partition_deltas: Optional[List[Delta]] = list_partition_deltas(
-        previous_partition, ascending_order=True, *args, **kwargs
+        previous_partition, ascending_order=False, *args, **kwargs
     ).all_items()
     partition_deltas: Optional[List[Delta]] = list_partition_deltas(
-        partition, ascending_order=True, *args, **kwargs
+        partition, ascending_order=False, *args, **kwargs
     ).all_items()
-    previous_partition_deltas.sort(reverse=True, key=lambda x: x.stream_position)
-    partition_deltas.sort(reverse=True, key=lambda x: x.stream_position)
+    # previous_partition_deltas.sort(reverse=True, key=lambda x: x.stream_position)
+    # partition_deltas.sort(reverse=True, key=lambda x: x.stream_position)
     previous_partition_deltas_spos_gt: List[Delta] = [
         delta
         for delta in previous_partition_deltas

--- a/deltacat/tests/local_deltacat_storage/__init__.py
+++ b/deltacat/tests/local_deltacat_storage/__init__.py
@@ -1,7 +1,5 @@
 from typing import Any, Callable, Dict, List, Optional, Set, Union, Tuple
 
-from collections import deque
-
 import pyarrow as pa
 import daft
 import json
@@ -800,7 +798,12 @@ def stage_partition(
     return partition
 
 
-def commit_partition(partition: Partition, previous_partition: Optional[Partition] = None, *args, **kwargs) -> Partition:
+def commit_partition(
+    partition: Partition,
+    previous_partition: Optional[Partition] = None,
+    *args,
+    **kwargs,
+) -> Partition:
     cur, con = _get_sqlite3_cursor_con(kwargs)
     pv_partition: Optional[Partition] = previous_partition or get_partition(
         partition.stream_locator,
@@ -814,20 +817,29 @@ def commit_partition(partition: Partition, previous_partition: Optional[Partitio
         params = (json.dumps(pv_partition), pv_partition.locator.canonical_string())
         cur.execute("UPDATE partitions SET value = ? WHERE locator = ?", params)
 
-    previous_partition_deltas: Optional[List[Delta]] = list_partition_deltas(partition, *args, **kwargs).all_items()
-    partition_deltas: Optional[List[Delta]] = list_partition_deltas(partition, *args, **kwargs).all_items()
+    previous_partition_deltas: Optional[List[Delta]] = list_partition_deltas(
+        partition, *args, **kwargs
+    ).all_items()
+    partition_deltas: Optional[List[Delta]] = list_partition_deltas(
+        partition, *args, **kwargs
+    ).all_items()
     # handle the case if the previous partition deltas have a greater stream position than the partition_delta
     if partition_deltas and previous_partition_deltas:
         partition_deltas.extend(
             [
-                previous_partition_delta 
-                for previous_partition_delta in previous_partition_deltas 
-                if previous_partition_delta.stream_position > partition_deltas[-1].stream_position 
+                previous_partition_delta
+                for previous_partition_delta in previous_partition_deltas
+                if previous_partition_delta.stream_position
+                > partition_deltas[-1].stream_position
             ]
         )
     partition_deltas.sort(reverse=True, key=lambda x: x.stream_position)
 
-    stream_position = partition_deltas[0].stream_position if partition_deltas else partition.stream_position 
+    stream_position = (
+        partition_deltas[0].stream_position
+        if partition_deltas
+        else partition.stream_position
+    )
 
     partition.state = CommitState.COMMITTED
     partition.stream_position = stream_position

--- a/deltacat/tests/local_deltacat_storage/__init__.py
+++ b/deltacat/tests/local_deltacat_storage/__init__.py
@@ -814,13 +814,18 @@ def commit_partition(
         pv_partition.state = CommitState.DEPRECATED
         params = (json.dumps(pv_partition), pv_partition.locator.canonical_string())
         cur.execute("UPDATE partitions SET value = ? WHERE locator = ?", params)
-
-    previous_partition_deltas: Optional[List[Delta]] = list_partition_deltas(
-        previous_partition, ascending_order=False, *args, **kwargs
-    ).all_items()
-    partition_deltas: Optional[List[Delta]] = list_partition_deltas(
-        partition, ascending_order=False, *args, **kwargs
-    ).all_items()
+    previous_partition_deltas = (
+        list_partition_deltas(
+            pv_partition, ascending_order=False, *args, **kwargs
+        ).all_items()
+        or []
+    )
+    partition_deltas: Optional[List[Delta]] = (
+        list_partition_deltas(
+            partition, ascending_order=False, *args, **kwargs
+        ).all_items()
+        or []
+    )
     previous_partition_deltas_spos_gt: List[Delta] = [
         delta
         for delta in previous_partition_deltas


### PR DESCRIPTION
## Notes
- `commit_partition` signature updated to include optional argument`previous_partition`. It is primarily used for the in-place compaction (the source == destination) case
- LocalDeltacatStorage fake signature and implementation updated. It now handles the case that the previous partition has deltas with a greater stream position than the partition to commit
- Added `add_late_deltas` test parameter and non-existants hash-bucket count test case to incremental compact_partition test class
- Lightweight `ExecutionCompactionResult` dataclass created to contain result of `_execute_compaction`
- Refactoring: More type-hinting added

## Impact
- Refactored unit tests to reduce overall time taken to run all units tests. They now run in ~5 minutes and used to take around ~8 minutes 30 seconds (~35% speed-up)
- Late deltas (> last_stream_position_to_compact) to the source_partition will now be merged in to the the promoted compacted partition for the in-place compaction case