### PR TITLE
Update boto3 and s3fs dependencies, drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
               uses: actions/checkout@v3
               with:
                   fetch-depth: 0
-            - name: Set up Python ${{ matrix.python-version }} (minimum supported python version for deltaCAT is 3.7)
+            - name: Set up Python ${{ matrix.python-version }} (minimum supported python version for deltaCAT is 3.8)
               uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
         steps:
             - name: checkout
               uses: actions/checkout@v3
-            - name: Set up Python 3.7
+            - name: Set up Python 3.8
               uses: actions/setup-python@v1
               with:
-                  python-version: 3.7
+                  python-version: 3.8
             - name: Linting
               run: |
                   python -m pip install --upgrade pip
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.7", "3.8", "3.9", "3.10"]
+                python-version: ["3.8", "3.9", "3.10"]
         timeout-minutes: 20
         steps:
             - name: "checkout repository"

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,10 +11,10 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 0
-      - name: Set up Python 3.7 (minimum supported python version for deltaCAT)
+      - name: Set up Python 3.8 (minimum supported python version for deltaCAT)
         uses: actions/setup-python@v3
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Install pypa/build
         run: >-
           python -m

--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.8"
+__version__ = "1.1.7"
 
 
 __all__ = [

--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.6"
+__version__ = "1.1.8"
 
 
 __all__ = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # any changes here should also be reflected in setup.py "install_requires"
 aws-embedded-metrics == 3.2.0
 boto3 ~= 1.34
-getdaft==0.2.23
+getdaft==0.2.25
 numpy == 1.21.5
 pandas == 1.3.5
 pyarrow == 12.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pydantic == 1.10.4
 pymemcache == 4.0.0
 ray[default] ~= 2.0
 redis == 4.6.0
-s3fs == 2024.5.0
+s3fs == 2022.2.0
 schedule == 1.2.0
 tenacity == 8.1.0
 typing-extensions == 4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pydantic == 1.10.4
 pymemcache == 4.0.0
 ray[default] ~= 2.0
 redis == 4.6.0
-s3fs == 2022.2.0
+s3fs == 2024.5.0
 schedule == 1.2.0
 tenacity == 8.1.0
 typing-extensions == 4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # any changes here should also be reflected in setup.py "install_requires"
 aws-embedded-metrics == 3.2.0
 boto3 ~= 1.34
-getdaft==0.2.25
+getdaft==0.2.23
 numpy == 1.21.5
 pandas == 1.3.5
 pyarrow == 12.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # setup.py install_requires
 # any changes here should also be reflected in setup.py "install_requires"
 aws-embedded-metrics == 3.2.0
-boto3 ~= 1.20
+boto3 ~= 1.34
 getdaft==0.2.23
 numpy == 1.21.5
 pandas == 1.3.5
@@ -10,7 +10,7 @@ pydantic == 1.10.4
 pymemcache == 4.0.0
 ray[default] ~= 2.0
 redis == 4.6.0
-s3fs == 2022.2.0
+s3fs == 2024.5.0
 schedule == 1.2.0
 tenacity == 8.1.0
 typing-extensions == 4.4.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         "typing-extensions == 4.4.0",
         "pymemcache == 4.0.0",
         "redis == 4.6.0",
-        "getdaft == 0.2.25",
+        "getdaft == 0.2.23",
         "schedule == 1.2.0",
     ],
     setup_requires=["wheel"],

--- a/setup.py
+++ b/setup.py
@@ -58,10 +58,9 @@ setuptools.setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/setup.py
+++ b/setup.py
@@ -36,13 +36,13 @@ setuptools.setup(
     install_requires=[
         # any changes here should also be reflected in requirements.txt
         "aws-embedded-metrics == 3.2.0",
-        "boto3 ~= 1.20",
+        "boto3 ~= 1.34",
         "numpy == 1.21.5",
         "pandas == 1.3.5",
         "pyarrow == 12.0.1",
         "pydantic == 1.10.4",
         "ray[default] ~= 2.0",
-        "s3fs == 2022.2.0",
+        "s3fs == 2024.5.0",
         "tenacity == 8.1.0",
         "typing-extensions == 4.4.0",
         "pymemcache == 4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
         "pyarrow == 12.0.1",
         "pydantic == 1.10.4",
         "ray[default] ~= 2.0",
-        "s3fs == 2022.2.0",
+        "s3fs == 2024.5.0",
         "tenacity == 8.1.0",
         "typing-extensions == 4.4.0",
         "pymemcache == 4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         "typing-extensions == 4.4.0",
         "pymemcache == 4.0.0",
         "redis == 4.6.0",
-        "getdaft == 0.2.23",
+        "getdaft == 0.2.25",
         "schedule == 1.2.0",
     ],
     setup_requires=["wheel"],

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
         "pyarrow == 12.0.1",
         "pydantic == 1.10.4",
         "ray[default] ~= 2.0",
-        "s3fs == 2024.5.0",
+        "s3fs == 2022.2.0",
         "tenacity == 8.1.0",
         "typing-extensions == 4.4.0",
         "pymemcache == 4.0.0",


### PR DESCRIPTION
This PR updates boto3 and s3fs versions to their latest versions. The current versions conflict with various AWS APIs.

It also drops support for Python 3.7, which is
- Almost a year past EOL
- Not compatible with the latest boto3 version

Also updates daft.

## Note on benchmarks

Updating S3Fs introduced a regression in some of the benchmarks -- the mechanism for this is unknown at the moment, and it's not clear if this would translate to an actual performance regression in production. We're proceeding with caution.