### PR TITLE
Modify in-place compacted check to include rebase source partition locator

### DIFF
--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -666,6 +666,12 @@ def _execute_compaction(
         f"compacted at: {params.last_stream_position_to_compact},"
     )
     is_inplace_compacted: bool = (
+        params.rebase_source_partition_locator
+        and params.rebase_source_partition_locator.partition_values
+        == params.destination_partition_locator.partition_values
+        and params.rebase_source_partition_locator.stream_id
+        == params.destination_partition_locator.stream_id
+    ) or (
         params.source_partition_locator.partition_values
         == params.destination_partition_locator.partition_values
         and params.source_partition_locator.stream_id

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -123,12 +123,12 @@ def compact_partition(params: CompactPartitionParams, **kwargs) -> Optional[str]
                 f"Committing compacted partition to: {execute_compaction_result.new_compacted_partition.locator} "
                 f"using previous partition: {previous_partition.locator if previous_partition else None}"
             )
-            commited_partition: Partition = params.deltacat_storage.commit_partition(
+            committed_partition: Partition = params.deltacat_storage.commit_partition(
                 execute_compaction_result.new_compacted_partition,
                 previous_partition,
                 **params.deltacat_storage_kwargs,
             )
-            logger.info(f"Committed compacted partition: {commited_partition}")
+            logger.info(f"Committed compacted partition: {committed_partition}")
             round_completion_file_s3_url = rcf.write_round_completion_file(
                 params.compaction_artifact_s3_bucket,
                 execute_compaction_result.new_round_completion_file_partition_locator,

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -662,19 +662,16 @@ def _execute_compaction(
     )
 
     logger.info(
-        f"partition-{params.source_partition_locator.partition_values},"
+        f"Partition-{params.source_partition_locator.partition_values},"
         f"compacted at: {params.last_stream_position_to_compact},"
     )
+    logger.info(
+        f"Checking if partition {rcf_source_partition_locator} is inplace compacted against {params.destination_partition_locator}..."
+    )
     is_inplace_compacted: bool = (
-        params.rebase_source_partition_locator
-        and params.rebase_source_partition_locator.partition_values
+        rcf_source_partition_locator.partition_values
         == params.destination_partition_locator.partition_values
-        and params.rebase_source_partition_locator.stream_id
-        == params.destination_partition_locator.stream_id
-    ) or (
-        params.source_partition_locator.partition_values
-        == params.destination_partition_locator.partition_values
-        and params.source_partition_locator.stream_id
+        and rcf_source_partition_locator.stream_id
         == params.destination_partition_locator.stream_id
     )
     if is_inplace_compacted:

--- a/deltacat/tests/compute/compact_partition_rebase_test_cases.py
+++ b/deltacat/tests/compute/compact_partition_rebase_test_cases.py
@@ -31,7 +31,6 @@ class RebaseCompactionTestCaseParams(BaseCompactorTestCase):
 
     Args:
         * (inherited from CompactorTestCase): see CompactorTestCase docstring for details
-        is_inplace: bool - argument to indicate whether to try compacting an in-place compacted table (the source table is the destination table). Also needed to control whether the destination table is created
         rebase_expected_compact_partition_result: pa.Table - expected table after rebase compaction runs. An output that is asserted on in Rebase then Incremental unit tests
     """
 

--- a/deltacat/tests/compute/compact_partition_rebase_test_cases.py
+++ b/deltacat/tests/compute/compact_partition_rebase_test_cases.py
@@ -27,11 +27,11 @@ from deltacat.tests.compute.compact_partition_test_cases import (
 @dataclass(frozen=True)
 class RebaseCompactionTestCaseParams(BaseCompactorTestCase):
     """
-    A pytest parameterized test case for the `compact_partition` function with rebase and incremental compaction.
+    A pytest parameterized test case for the `compact_partition` function with rebase compaction.
 
     Args:
         * (inherited from CompactorTestCase): see CompactorTestCase docstring for details
-        rebase_expected_compact_partition_result: pa.Table - expected table after rebase compaction runs. An output that is asserted on in Rebase then Incremental unit tests
+        rebase_expected_compact_partition_result: pa.Table - expected table after rebase compaction runs. An output that is asserted on in Rebase unit tests
     """
 
     rebase_expected_compact_partition_result: pa.Table

--- a/deltacat/tests/compute/compact_partition_rebase_test_cases.py
+++ b/deltacat/tests/compute/compact_partition_rebase_test_cases.py
@@ -1,0 +1,89 @@
+import pyarrow as pa
+from deltacat.tests.compute.test_util_common import (
+    PartitionKey,
+    PartitionKeyType,
+)
+from deltacat.tests.compute.test_util_constant import (
+    DEFAULT_MAX_RECORDS_PER_FILE,
+    DEFAULT_HASH_BUCKET_COUNT,
+)
+from dataclasses import dataclass
+
+
+from deltacat.storage import (
+    DeltaType,
+)
+
+from deltacat.compute.compactor.model.compactor_version import CompactorVersion
+
+from deltacat.storage.model.sort_key import SortKey
+
+from deltacat.tests.compute.compact_partition_test_cases import (
+    BaseCompactorTestCase,
+    with_compactor_version_func_test_param,
+)
+
+
+@dataclass(frozen=True)
+class RebaseCompactionTestCaseParams(BaseCompactorTestCase):
+    """
+    A pytest parameterized test case for the `compact_partition` function with rebase and incremental compaction.
+
+    Args:
+        * (inherited from CompactorTestCase): see CompactorTestCase docstring for details
+        is_inplace: bool - argument to indicate whether to try compacting an in-place compacted table (the source table is the destination table). Also needed to control whether the destination table is created
+        rebase_expected_compact_partition_result: pa.Table - expected table after rebase compaction runs. An output that is asserted on in Rebase then Incremental unit tests
+    """
+
+    rebase_expected_compact_partition_result: pa.Table
+
+
+REBASE_TEST_CASES = {
+    "1-rebase-sanity": RebaseCompactionTestCaseParams(
+        primary_keys={"pk_col_1"},
+        sort_keys=[
+            SortKey.of(key_name="sk_col_1"),
+            SortKey.of(key_name="sk_col_2"),
+        ],
+        partition_keys=[PartitionKey.of("region_id", PartitionKeyType.INT)],
+        partition_values=["1"],
+        input_deltas=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(0, 10)]),
+                pa.array(["foo"] * 10),
+                pa.array([i / 10 for i in range(10, 20)]),
+            ],
+            names=["pk_col_1", "sk_col_1", "sk_col_2", "col_1"],
+        ),
+        input_deltas_delta_type=DeltaType.UPSERT,
+        rebase_expected_compact_partition_result=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(0, 10)]),
+                pa.array(["foo"] * 10),
+                pa.array([i / 10 for i in range(10, 20)]),
+            ],
+            names=["pk_col_1", "sk_col_1", "sk_col_2", "col_1"],
+        ),
+        expected_terminal_compact_partition_result=pa.Table.from_arrays(
+            [
+                pa.array([str(i) for i in range(10)]),
+                pa.array([i for i in range(20, 30)]),
+                pa.array(["foo"] * 10),
+                pa.array([i / 10 for i in range(40, 50)]),
+            ],
+            names=["pk_col_1", "sk_col_1", "sk_col_2", "col_1"],
+        ),
+        expected_terminal_exception=None,
+        expected_terminal_exception_message=None,
+        do_create_placement_group=False,
+        records_per_compacted_file=DEFAULT_MAX_RECORDS_PER_FILE,
+        hash_bucket_count=DEFAULT_HASH_BUCKET_COUNT,
+        read_kwargs_provider=None,
+        drop_duplicates=True,
+        skip_enabled_compact_partition_drivers=[CompactorVersion.V1],
+    ),
+}
+
+REBASE_TEST_CASES = with_compactor_version_func_test_param(REBASE_TEST_CASES)

--- a/deltacat/tests/compute/compactor_v2/test_compaction_session.py
+++ b/deltacat/tests/compute/compactor_v2/test_compaction_session.py
@@ -5,7 +5,10 @@ import os
 from unittest.mock import patch
 import deltacat.tests.local_deltacat_storage as ds
 from deltacat.types.media import ContentType
-from deltacat.compute.compactor_v2.compaction_session import compact_partition, _execute_compaction
+from deltacat.compute.compactor_v2.compaction_session import (
+    compact_partition,
+    _execute_compaction,
+)
 from deltacat.compute.compactor.model.compact_partition_params import (
     CompactPartitionParams,
 )

--- a/deltacat/tests/compute/compactor_v2/test_compaction_session.py
+++ b/deltacat/tests/compute/compactor_v2/test_compaction_session.py
@@ -134,7 +134,7 @@ class TestCompactionSession(unittest.TestCase):
                     "rebase_source_partition_high_watermark": None,
                     "records_per_compacted_file": 4000,
                     "s3_client_kwargs": {},
-                    "source_partition_locator": None,
+                    "source_partition_locator": source_partition.locator,
                 }
             )
         )

--- a/deltacat/tests/compute/compactor_v2/test_compaction_session.py
+++ b/deltacat/tests/compute/compactor_v2/test_compaction_session.py
@@ -5,9 +5,12 @@ import os
 from unittest.mock import patch
 import deltacat.tests.local_deltacat_storage as ds
 from deltacat.types.media import ContentType
-from deltacat.compute.compactor_v2.compaction_session import compact_partition
+from deltacat.compute.compactor_v2.compaction_session import compact_partition, _execute_compaction
 from deltacat.compute.compactor.model.compact_partition_params import (
     CompactPartitionParams,
+)
+from deltacat.compute.compactor_v2.model.compaction_session import (
+    ExecutionCompactionResult,
 )
 from deltacat.utils.common import current_time_ms
 from deltacat.tests.test_utils.pyarrow import stage_partition_from_file_paths
@@ -86,3 +89,52 @@ class TestCompactionSession(unittest.TestCase):
 
         # verify that no RCF is written
         self.assertIsNone(rcf_url)
+
+    @patch("deltacat.compute.compactor_v2.compaction_session.rcf")
+    @patch("deltacat.compute.compactor_v2.compaction_session.s3_utils")
+    def test_compact_partition_rebase_no_source_partition(self, s3_utils, rcf_url):
+        # setup
+        rcf_url.read_round_completion_file.return_value = None
+        staged_source = stage_partition_from_file_paths(
+            self.NAMESPACE, ["test"], **self.deltacat_storage_kwargs
+        )
+        source_partition = ds.commit_partition(
+            staged_source, **self.deltacat_storage_kwargs
+        )
+
+        staged_dest = stage_partition_from_file_paths(
+            self.NAMESPACE, ["destination"], **self.deltacat_storage_kwargs
+        )
+        dest_partition = ds.commit_partition(
+            staged_dest, **self.deltacat_storage_kwargs
+        )
+
+        # action
+        execute_compaction_result: ExecutionCompactionResult = _execute_compaction(
+            CompactPartitionParams.of(
+                {
+                    "compaction_artifact_s3_bucket": "test_bucket",
+                    "compacted_file_content_type": ContentType.PARQUET,
+                    "dd_max_parallelism_ratio": 1.0,
+                    "deltacat_storage": ds,
+                    "deltacat_storage_kwargs": self.deltacat_storage_kwargs,
+                    "destination_partition_locator": dest_partition.locator,
+                    "drop_duplicates": True,
+                    "hash_bucket_count": 1,
+                    "last_stream_position_to_compact": source_partition.stream_position,
+                    "list_deltas_kwargs": {
+                        **self.deltacat_storage_kwargs,
+                        **{"equivalent_table_types": []},
+                    },
+                    "primary_keys": [],
+                    "rebase_source_partition_locator": source_partition.locator,
+                    "rebase_source_partition_high_watermark": None,
+                    "records_per_compacted_file": 4000,
+                    "s3_client_kwargs": {},
+                    "source_partition_locator": None,
+                }
+            )
+        )
+
+        # verify that the job was NOT marked as in-place compacted
+        self.assertFalse(execute_compaction_result.is_inplace_compacted)

--- a/deltacat/tests/compute/test_compact_partition_rebase.py
+++ b/deltacat/tests/compute/test_compact_partition_rebase.py
@@ -1,0 +1,276 @@
+import ray
+import os
+from moto import mock_s3
+import pytest
+import boto3
+from boto3.resources.base import ServiceResource
+import pyarrow as pa
+from deltacat.io.ray_plasma_object_store import RayPlasmaObjectStore
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from deltacat.tests.compute.test_util_constant import (
+    TEST_S3_RCF_BUCKET_NAME,
+    DEFAULT_NUM_WORKERS,
+    DEFAULT_WORKER_INSTANCE_CPUS,
+)
+from deltacat.compute.compactor.model.compactor_version import CompactorVersion
+from deltacat.tests.compute.test_util_common import (
+    get_compacted_delta_locator_from_rcf,
+)
+from deltacat.tests.compute.test_util_create_table_deltas_repo import (
+    create_src_w_deltas_destination_rebase_w_deltas_strategy,
+)
+from deltacat.tests.compute.compact_partition_rebase_test_cases import (
+    REBASE_TEST_CASES,
+)
+from typing import Any, Callable, Dict, List, Optional, Set
+from deltacat.types.media import StorageType
+from deltacat.storage import (
+    DeltaLocator,
+    Partition,
+)
+from deltacat.types.media import ContentType
+from deltacat.compute.compactor.model.compact_partition_params import (
+    CompactPartitionParams,
+)
+from deltacat.utils.placement import (
+    PlacementGroupManager,
+)
+
+DATABASE_FILE_PATH_KEY, DATABASE_FILE_PATH_VALUE = (
+    "db_file_path",
+    "deltacat/tests/local_deltacat_storage/db_test.sqlite",
+)
+
+
+"""
+MODULE scoped fixtures
+"""
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup_ray_cluster():
+    ray.init(local_mode=True, ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+
+@pytest.fixture(autouse=True, scope="module")
+def mock_aws_credential():
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_ID"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    yield
+
+
+@pytest.fixture(autouse=True, scope="module")
+def cleanup_the_database_file_after_all_compaction_session_package_tests_complete():
+    # make sure the database file is deleted after all the compactor package tests are completed
+    if os.path.exists(DATABASE_FILE_PATH_VALUE):
+        os.remove(DATABASE_FILE_PATH_VALUE)
+
+
+@pytest.fixture(scope="module")
+def s3_resource(mock_aws_credential):
+    with mock_s3():
+        yield boto3.resource("s3")
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup_compaction_artifacts_s3_bucket(s3_resource: ServiceResource):
+    s3_resource.create_bucket(
+        ACL="authenticated-read",
+        Bucket=TEST_S3_RCF_BUCKET_NAME,
+    )
+    yield
+
+
+"""
+FUNCTION scoped fixtures
+"""
+
+
+@pytest.fixture(scope="function")
+def local_deltacat_storage_kwargs(request: pytest.FixtureRequest):
+    # see deltacat/tests/local_deltacat_storage/README.md for documentation
+    kwargs_for_local_deltacat_storage: Dict[str, Any] = {
+        DATABASE_FILE_PATH_KEY: DATABASE_FILE_PATH_VALUE,
+    }
+    yield kwargs_for_local_deltacat_storage
+    if os.path.exists(DATABASE_FILE_PATH_VALUE):
+        os.remove(DATABASE_FILE_PATH_VALUE)
+
+
+@pytest.mark.parametrize(
+    [
+        "test_name",
+        "primary_keys",
+        "sort_keys",
+        "partition_keys_param",
+        "partition_values_param",
+        "input_deltas_param",
+        "input_deltas_delta_type",
+        "expected_terminal_compact_partition_result",
+        "expected_terminal_exception",
+        "expected_terminal_exception_message",
+        "create_placement_group_param",
+        "records_per_compacted_file_param",
+        "hash_bucket_count_param",
+        "read_kwargs_provider_param",
+        "drop_duplicates_param",
+        "skip_enabled_compact_partition_drivers",
+        "rebase_expected_compact_partition_result",
+        "compact_partition_func",
+    ],
+    [
+        (
+            test_name,
+            primary_keys,
+            sort_keys,
+            partition_keys_param,
+            partition_values_param,
+            input_deltas,
+            input_deltas_delta_type,
+            expected_terminal_compact_partition_result,
+            expected_terminal_exception,
+            expected_terminal_exception_message,
+            create_placement_group_param,
+            records_per_compacted_file_param,
+            hash_bucket_count_param,
+            drop_duplicates_param,
+            read_kwargs_provider,
+            skip_enabled_compact_partition_drivers,
+            rebase_expected_compact_partition_result,
+            compact_partition_func,
+        )
+        for test_name, (
+            primary_keys,
+            sort_keys,
+            partition_keys_param,
+            partition_values_param,
+            input_deltas,
+            input_deltas_delta_type,
+            expected_terminal_compact_partition_result,
+            expected_terminal_exception,
+            expected_terminal_exception_message,
+            create_placement_group_param,
+            records_per_compacted_file_param,
+            hash_bucket_count_param,
+            drop_duplicates_param,
+            read_kwargs_provider,
+            skip_enabled_compact_partition_drivers,
+            rebase_expected_compact_partition_result,
+            compact_partition_func,
+        ) in REBASE_TEST_CASES.items()
+    ],
+    ids=[test_name for test_name in REBASE_TEST_CASES],
+)
+def test_compact_partition_rebase_same_source_and_destination(
+    s3_resource: ServiceResource,
+    local_deltacat_storage_kwargs: Dict[str, Any],
+    test_name: str,
+    primary_keys: Set[str],
+    sort_keys: List[Optional[Any]],
+    partition_keys_param: Optional[List[Any]],
+    partition_values_param: List[Optional[str]],
+    input_deltas_param: List[pa.Array],
+    input_deltas_delta_type: str,
+    expected_terminal_compact_partition_result: pa.Table,
+    expected_terminal_exception: BaseException,
+    expected_terminal_exception_message: Optional[str],
+    create_placement_group_param: bool,
+    records_per_compacted_file_param: int,
+    hash_bucket_count_param: int,
+    drop_duplicates_param: bool,
+    read_kwargs_provider_param: Any,
+    rebase_expected_compact_partition_result: pa.Table,
+    skip_enabled_compact_partition_drivers: List[CompactorVersion],
+    compact_partition_func: Callable,
+    benchmark: BenchmarkFixture,
+):
+    import deltacat.tests.local_deltacat_storage as ds
+
+    ds_mock_kwargs = local_deltacat_storage_kwargs
+    """
+    This test tests the scenario where source partition locator == destination partition locator,
+    but rebase source partition locator is different.
+    This scenario could occur when hash bucket count changes.
+    """
+    partition_keys = partition_keys_param
+    (
+        source_table_stream,
+        _,
+        rebased_table_stream,
+    ) = create_src_w_deltas_destination_rebase_w_deltas_strategy(
+        primary_keys,
+        sort_keys,
+        partition_keys,
+        input_deltas_param,
+        input_deltas_delta_type,
+        partition_values_param,
+        ds_mock_kwargs,
+    )
+    source_partition: Partition = ds.get_partition(
+        source_table_stream.locator,
+        partition_values_param,
+        **ds_mock_kwargs,
+    )
+    rebased_partition: Partition = ds.get_partition(
+        rebased_table_stream.locator,
+        partition_values_param,
+        **ds_mock_kwargs,
+    )
+    num_workers, worker_instance_cpu = DEFAULT_NUM_WORKERS, DEFAULT_WORKER_INSTANCE_CPUS
+    total_cpus = num_workers * worker_instance_cpu
+    pgm = None
+    create_placement_group_param = False
+    if create_placement_group_param:
+        pgm = PlacementGroupManager(
+            1, total_cpus, worker_instance_cpu, memory_per_bundle=4000000
+        ).pgs[0]
+    compact_partition_params = CompactPartitionParams.of(
+        {
+            "compaction_artifact_s3_bucket": TEST_S3_RCF_BUCKET_NAME,
+            "compacted_file_content_type": ContentType.PARQUET,
+            "dd_max_parallelism_ratio": 1.0,
+            "deltacat_storage": ds,
+            "deltacat_storage_kwargs": ds_mock_kwargs,
+            "destination_partition_locator": rebased_partition.locator,
+            "hash_bucket_count": hash_bucket_count_param,
+            "last_stream_position_to_compact": source_partition.stream_position,
+            "list_deltas_kwargs": {**ds_mock_kwargs, **{"equivalent_table_types": []}},
+            "object_store": RayPlasmaObjectStore(),
+            "pg_config": pgm,
+            "primary_keys": primary_keys,
+            "read_kwargs_provider": read_kwargs_provider_param,
+            "rebase_source_partition_locator": source_partition.locator,
+            "records_per_compacted_file": records_per_compacted_file_param,
+            "s3_client_kwargs": {},
+            "source_partition_locator": rebased_partition.locator,
+            "sort_keys": sort_keys if sort_keys else None,
+        }
+    )
+    # execute
+    rcf_file_s3_uri = compact_partition_func(compact_partition_params)
+    compacted_delta_locator: DeltaLocator = get_compacted_delta_locator_from_rcf(
+        s3_resource, rcf_file_s3_uri
+    )
+    tables = ds.download_delta(
+        compacted_delta_locator, storage_type=StorageType.LOCAL, **ds_mock_kwargs
+    )
+    actual_rebase_compacted_table = pa.concat_tables(tables)
+    # if no primary key is specified then sort by sort_key for consistent assertion
+    sorting_cols: List[Any] = (
+        [(val, "ascending") for val in primary_keys] if primary_keys else sort_keys
+    )
+    rebase_expected_compact_partition_result = (
+        rebase_expected_compact_partition_result.combine_chunks().sort_by(sorting_cols)
+    )
+    actual_rebase_compacted_table = (
+        actual_rebase_compacted_table.combine_chunks().sort_by(sorting_cols)
+    )
+    assert actual_rebase_compacted_table.equals(
+        rebase_expected_compact_partition_result
+    ), f"{actual_rebase_compacted_table} does not match {rebase_expected_compact_partition_result}"

--- a/deltacat/tests/compute/test_util_create_table_deltas_repo.py
+++ b/deltacat/tests/compute/test_util_create_table_deltas_repo.py
@@ -251,6 +251,7 @@ def create_src_w_deltas_destination_rebase_w_deltas_strategy(
     ds.commit_partition(staged_partition, **ds_mock_kwargs)
 
     # get streams
+    # TODO: Add deltas to destination stream
     destination_table_stream: Stream = ds.get_stream(
         namespace=destination_table_namespace,
         table_name=destination_table_name,

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,4 +7,5 @@ moto==4.1.12
 pre-commit == 2.20.0
 pytest == 7.2.0
 pytest-cov == 4.0.0
+pytest-mock == 3.14.0
 requests-mock == 1.11.0


### PR DESCRIPTION
This change adds a check for the rebase source partition locator. This is to prevent erroneously marking tables as in-place compacted during rebase jobs.

Tested by running a rebase job in personal stack.