### PR TITLE
Extend deltacat interface to support Iceberg bucketing

### DIFF
--- a/deltacat/storage/__init__.py
+++ b/deltacat/storage/__init__.py
@@ -14,6 +14,20 @@ from deltacat.storage.model.stream import Stream, StreamLocator
 from deltacat.storage.model.table import Table, TableLocator
 from deltacat.storage.model.table_version import TableVersion, TableVersionLocator
 from deltacat.storage.model.delete_parameters import DeleteParameters
+from deltacat.storage.model.partition_spec import (
+    PartitionFilter,
+    PartitionValues,
+    DeltaPartitionSpec,
+    StreamPartitionSpec,
+)
+from deltacat.storage.model.transform import (
+    Transform,
+    TransformName,
+    TransformParameters,
+    BucketingStrategy,
+    BucketTransformParameters,
+    IdentityTransformParameters,
+)
 
 from deltacat.storage.model.types import (
     CommitState,
@@ -56,4 +70,14 @@ __all__ = [
     "TableVersionLocator",
     "SortKey",
     "SortOrder",
+    "PartitionFilter",
+    "PartitionValues",
+    "DeltaPartitionSpec",
+    "StreamPartitionSpec",
+    "Transform",
+    "TransformName",
+    "TransformParameters",
+    "BucketingStrategy",
+    "BucketTransformParameters",
+    "IdentityTransformParameters",
 ]

--- a/deltacat/storage/model/partition.py
+++ b/deltacat/storage/model/partition.py
@@ -1,10 +1,9 @@
 # Allow classes to use self-referencing Type hints in Python 3.7.
 from __future__ import annotations
-
 from typing import Any, Dict, List, Optional, Union
 
 import pyarrow as pa
-
+from deltacat.storage.model.partition_spec import PartitionValues
 from deltacat.storage.model.locator import Locator
 from deltacat.storage.model.namespace import NamespaceLocator
 from deltacat.storage.model.stream import StreamLocator
@@ -127,7 +126,7 @@ class Partition(dict):
         return None
 
     @property
-    def partition_values(self) -> Optional[List[Any]]:
+    def partition_values(self) -> Optional[PartitionValues]:
         partition_locator = self.locator
         if partition_locator:
             return partition_locator.partition_values
@@ -199,7 +198,7 @@ class PartitionLocator(Locator, dict):
     @staticmethod
     def of(
         stream_locator: Optional[StreamLocator],
-        partition_values: Optional[List[Any]],
+        partition_values: Optional[PartitionValues],
         partition_id: Optional[str],
     ) -> PartitionLocator:
         """
@@ -225,7 +224,7 @@ class PartitionLocator(Locator, dict):
         table_version: Optional[str],
         stream_id: Optional[str],
         storage_type: Optional[str],
-        partition_values: Optional[List[Any]],
+        partition_values: Optional[PartitionValues],
         partition_id: Optional[str],
     ) -> PartitionLocator:
         stream_locator = StreamLocator.at(
@@ -253,11 +252,11 @@ class PartitionLocator(Locator, dict):
         self["streamLocator"] = stream_locator
 
     @property
-    def partition_values(self) -> Optional[List[Any]]:
+    def partition_values(self) -> Optional[PartitionValues]:
         return self.get("partitionValues")
 
     @partition_values.setter
-    def partition_values(self, partition_values: Optional[List[Any]]) -> None:
+    def partition_values(self, partition_values: Optional[PartitionValues]) -> None:
         self["partitionValues"] = partition_values
 
     @property

--- a/deltacat/storage/model/partition_spec.py
+++ b/deltacat/storage/model/partition_spec.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+from typing import List, Optional, Any
+from deltacat.storage.model.transform import Transform
+
+"""
+An ordered list of partition values determining the values of
+ordered transforms specified in the partition spec.
+"""
+PartitionValues = List[Any]
+
+
+class PartitionFilter(dict):
+    """
+    This class represents a filter for partitions.
+    It is used to filter partitions based on certain criteria.
+    """
+
+    @staticmethod
+    def of(
+        partition_values: Optional[PartitionValues] = None,
+    ) -> PartitionFilter:
+        """
+        Creates a new PartitionFilter instance with the specified partition key and value.
+        """
+        partition_filter = PartitionFilter()
+        partition_filter["partitionValues"] = partition_values
+        return partition_filter
+
+    @property
+    def partition_values(self) -> Optional[PartitionValues]:
+        return self.get("partitionValues")
+
+
+class PartitionSpec(dict):
+    """
+    This class determines how the underlying entities in the
+    hierarchy are partitioned. Stream partitions deltas and
+    delta partitions files.
+    """
+
+    @staticmethod
+    def of(ordered_transforms: List[Transform] = None) -> PartitionSpec:
+        partition_spec = PartitionSpec()
+        partition_spec.ordered_transforms = ordered_transforms
+        return partition_spec
+
+    @property
+    def ordered_transforms(self) -> List[Transform]:
+        return self.get("orderedTransforms")
+
+    @ordered_transforms.setter
+    def ordered_transforms(self, value: List[Transform]) -> None:
+        self["orderedTransforms"] = value
+
+
+class StreamPartitionSpec(PartitionSpec):
+    """
+    A class representing a stream partition specification.
+    A stream partitions deltas into multiple different Partition
+    """
+
+    pass
+
+
+class DeltaPartitionSpec(PartitionSpec):
+    """
+    A class representing delta partition specification.
+    The manifest entries in delta are partitioned based on this spec.
+    """
+
+    pass

--- a/deltacat/storage/model/transform.py
+++ b/deltacat/storage/model/transform.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+from typing import List
+from enum import Enum
+
+
+class TransformName(str, Enum):
+    IDENTITY = "identity"
+    BUCKET = "bucket"
+
+
+class TransformParameters(dict):
+    """
+    This is a parent class that contains properties
+    to be passed to the corresponding transform
+    """
+
+    pass
+
+
+class IdentityTransformParameters(TransformParameters):
+    """
+    This class is used to pass parameters to the identity transform
+    """
+
+    @staticmethod
+    def of(column_name: str) -> IdentityTransformParameters:
+        identify_transform_parameters = IdentityTransformParameters()
+        identify_transform_parameters["columnName"] = column_name
+        return identify_transform_parameters
+
+    @property
+    def column_name(self) -> str:
+        """
+        The name of the column to use for identity transform
+        """
+        return self["columnName"]
+
+    @column_name.setter
+    def column_name(self, value: str) -> None:
+        self["columnName"] = value
+
+
+class BucketingStrategy(str, Enum):
+    """
+    A bucketing strategy for the transform
+    """
+
+    # Uses default deltacat bucketing strategy.
+    # This strategy supports hashing on composite keys
+    # and uses SHA1 hashing for determining the bucket.
+    # If no columns passed, it will use a random UUID
+    # for determining the bucket.
+    DEFAULT = "default"
+
+    # Uses iceberg compliant bucketing strategy.
+    # As indicated in the iceberg spec, it does not support
+    # composite keys and uses murmur3 hash for determining
+    # the bucket.
+    # See https://iceberg.apache.org/spec/#partitioning
+    ICEBERG = "iceberg"
+
+
+class BucketTransformParameters(TransformParameters):
+    """
+    Encapsulates parameters for the bucket transform.
+    """
+
+    def of(
+        self,
+        num_buckets: int,
+        column_names: List[str],
+        bucketing_strategy: BucketingStrategy,
+    ) -> BucketTransformParameters:
+        bucket_transform_parameters = BucketTransformParameters()
+        bucket_transform_parameters["numBuckets"] = num_buckets
+        bucket_transform_parameters["columnNames"] = column_names
+        bucket_transform_parameters["bucketingStrategy"] = bucketing_strategy
+
+        return bucket_transform_parameters
+
+    @property
+    def num_buckets(self) -> int:
+        """
+        The total number of buckets to create for values of the column
+        """
+        return self["numBuckets"]
+
+    @property
+    def column_names(self) -> List[str]:
+        """
+        An ordered list of unique column names from the table schema
+        to use for bucketings.
+        """
+        return self["columnNames"]
+
+    @property
+    def bucketing_strategy(self) -> BucketingStrategy:
+        """
+        The bucketing strategy to used.
+        """
+        return self["bucketingStrategy"]
+
+
+class Transform(dict):
+    """
+    A transform is represents how a particular column value can be
+    transformed into a new value. This is mostly used in the context
+    of partitioning the data files in a table.
+    """
+
+    @staticmethod
+    def of(
+        name: TransformName,
+        parameters: TransformParameters,
+    ) -> Transform:
+        partition_transform = Transform()
+        partition_transform["name"] = name
+        partition_transform["parameters"] = parameters
+        return partition_transform
+
+    @property
+    def name(self) -> TransformName:
+        return self["name"]
+
+    @property
+    def parameters(self) -> TransformParameters:
+        return self["parameters"]


### PR DESCRIPTION
This PR contains interface changes and local deltacat support to read/writer delta partition spec. The motivation for this change is explained in a different document. However, to summarize we have a use where Delta must encapsulate Iceberg Manifest but there is no way to represent iceberg partition in DeltaCAT today. This PR adds partition spec model which allows us to specify identity and bucketing partition strategies where latter is what we will also be using with Iceberg. The interface changes are backward compatible. 