### PR TITLE
Adding metric prefix to get the right method name

### DIFF
--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -78,6 +78,7 @@ from deltacat.compute.compactor_v2.utils.task_options import (
 )
 from deltacat.compute.compactor.model.compactor_version import CompactorVersion
 from deltacat.exceptions import categorize_errors
+from deltacat.compute.compactor_v2.constants import COMPACT_PARTITION_METRIC_PREFIX
 
 if importlib.util.find_spec("memray"):
     import memray
@@ -86,7 +87,7 @@ if importlib.util.find_spec("memray"):
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
-@metrics
+@metrics(prefix=COMPACT_PARTITION_METRIC_PREFIX)
 @categorize_errors
 def compact_partition(params: CompactPartitionParams, **kwargs) -> Optional[str]:
     assert (

--- a/deltacat/compute/compactor_v2/constants.py
+++ b/deltacat/compute/compactor_v2/constants.py
@@ -68,3 +68,6 @@ DISCOVER_DELTAS_METRIC_PREFIX = "discover_deltas"
 
 # Metric prefix for prepare deletes
 PREPARE_DELETES_METRIC_PREFIX = "prepare_deletes"
+
+# Metric prefix for compact partition method
+COMPACT_PARTITION_METRIC_PREFIX = "compact_partition"


### PR DESCRIPTION
The @metrics annotation uses a method name on which it is annotated. In this case, it annotated over a decorator and hence `categorize_errors` will be used to emit metrics. This PR hardcodes prefix so that we don't have to change dashboards when additional annotations are added.