### PR TITLE
Set default disable copy by reference value to True

### DIFF
--- a/deltacat/compute/compactor_v2/constants.py
+++ b/deltacat/compute/compactor_v2/constants.py
@@ -41,7 +41,7 @@ DROP_DUPLICATES = True
 # size in metadata to pyarrow table size.
 PARQUET_TO_PYARROW_INFLATION = 4
 
-# By default, copy by reference is enabled
+# By default, copy by reference is disabled
 DEFAULT_DISABLE_COPY_BY_REFERENCE = True
 
 # Metric Names

--- a/deltacat/compute/compactor_v2/constants.py
+++ b/deltacat/compute/compactor_v2/constants.py
@@ -42,7 +42,7 @@ DROP_DUPLICATES = True
 PARQUET_TO_PYARROW_INFLATION = 4
 
 # By default, copy by reference is enabled
-DEFAULT_DISABLE_COPY_BY_REFERENCE = False
+DEFAULT_DISABLE_COPY_BY_REFERENCE = True
 
 # Metric Names
 # Time taken for a hash bucket task


### PR DESCRIPTION
### Notes
This change sets the default copy by reference behavior to "disabled".

### Testing
 - job succeeded on personal stack