### PR TITLE
Upgrade daft and adding two more tests for schema evolution usecase

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.11"
+__version__ = "1.1.12"
 
 
 __all__ = [

--- a/deltacat/tests/utils/test_daft.py
+++ b/deltacat/tests/utils/test_daft.py
@@ -104,6 +104,44 @@ class TestDaftS3FileToTable(unittest.TestCase):
         self.assertEqual(table.schema.field("MISSING").type, pa.string())
         self.assertEqual(table.num_rows, 100)
 
+    def test_read_from_s3_single_column_with_schema_extra_cols_column_names(self):
+        schema = pa.schema([("a", pa.int8()), ("MISSING", pa.string())])
+        pa_read_func_kwargs_provider = ReadKwargsProviderPyArrowSchemaOverride(
+            schema=schema
+        )
+        table = daft_s3_file_to_table(
+            self.MVP_PATH,
+            content_encoding=ContentEncoding.IDENTITY.value,
+            content_type=ContentType.PARQUET.value,
+            column_names=["a", "MISSING"],
+            pa_read_func_kwargs_provider=pa_read_func_kwargs_provider,
+        )
+        self.assertEqual(
+            table.schema.names, ["a", "MISSING"]
+        )  # NOTE: "MISSING" is padded as a null array
+        self.assertEqual(table.schema.field("a").type, pa.int8())
+        self.assertEqual(table.schema.field("MISSING").type, pa.string())
+        self.assertEqual(table.num_rows, 100)
+
+    def test_read_from_s3_single_column_with_schema_only_missing_col(self):
+        schema = pa.schema([("a", pa.int8()), ("MISSING", pa.string())])
+        pa_read_func_kwargs_provider = ReadKwargsProviderPyArrowSchemaOverride(
+            schema=schema
+        )
+        table = daft_s3_file_to_table(
+            self.MVP_PATH,
+            content_encoding=ContentEncoding.IDENTITY.value,
+            content_type=ContentType.PARQUET.value,
+            include_columns=["MISSING"],
+            column_names=["a", "MISSING"],
+            pa_read_func_kwargs_provider=pa_read_func_kwargs_provider,
+        )
+        self.assertEqual(
+            table.schema.names, ["MISSING"]
+        )  # NOTE: "MISSING" is padded as a null array
+        self.assertEqual(table.schema.field("MISSING").type, pa.string())
+        self.assertEqual(table.num_rows, 0)
+
     def test_read_from_s3_single_column_with_row_groups(self):
 
         metadata = pq.read_metadata(self.MVP_PATH)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,4 +8,5 @@ pre-commit == 2.20.0
 pytest == 7.2.0
 pytest-cov == 4.0.0
 pytest-mock == 3.14.0
+ray[default] >= 2.20.0
 requests-mock == 1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # any changes here should also be reflected in setup.py "install_requires"
 aws-embedded-metrics == 3.2.0
 boto3 ~= 1.34
-getdaft==0.2.29
+getdaft==0.2.31
 numpy == 1.21.5
 pandas == 1.3.5
 pyarrow == 12.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pandas == 1.3.5
 pyarrow == 12.0.1
 pydantic == 1.10.4
 pymemcache == 4.0.0
-ray[default] >= 2.20.0
+ray >= 2.20.0
 redis == 4.6.0
 s3fs == 2024.5.0
 schedule == 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         "typing-extensions == 4.4.0",
         "pymemcache == 4.0.0",
         "redis == 4.6.0",
-        "getdaft == 0.2.29",
+        "getdaft == 0.2.31",
         "schedule == 1.2.0",
     ],
     setup_requires=["wheel"],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
         "pandas == 1.3.5",
         "pyarrow == 12.0.1",
         "pydantic == 1.10.4",
-        "ray[default] >= 2.20.0",
+        "ray >= 2.20.0",
         "s3fs == 2024.5.0",
         "tenacity == 8.1.0",
         "typing-extensions == 4.4.0",


### PR DESCRIPTION
- Added couple of tests.
- Upgraded daft version
- This fixes an issue when column name not in parquet schema is passed. 