### PR TITLE
Now waiting for 10 mins instead of 5 to fetch credentials from STS

### DIFF
--- a/deltacat/aws/clients.py
+++ b/deltacat/aws/clients.py
@@ -42,7 +42,7 @@ RETRYABLE_HTTP_STATUS_CODES = [
 
 boto_retry_wrapper = Retrying(
     wait=wait_random_exponential(multiplier=1, max=10),
-    stop=stop_after_delay(60 * 5),
+    stop=stop_after_delay(60 * 10),
     # CredentialRetrievalError can still be thrown due to throttling, even if IMDS health checks succeed.
     retry=retry_if_exception_type(CredentialRetrievalError),
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pandas == 1.3.5
 pyarrow == 12.0.1
 pydantic == 1.10.4
 pymemcache == 4.0.0
-ray >= 2.20.0,<2.34.0
+ray >= 2.20.0,<2.31.0
 redis == 4.6.0
 s3fs == 2024.5.0
 schedule == 1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pandas == 1.3.5
 pyarrow == 12.0.1
 pydantic == 1.10.4
 pymemcache == 4.0.0
-ray >= 2.20.0
+ray >= 2.20.0,<2.34.0
 redis == 4.6.0
 s3fs == 2024.5.0
 schedule == 1.2.0


### PR DESCRIPTION
- STS throttle when the new instance is spin up causing `CredentialRetrievalError`. 
- As a symptomatic fix, we are now waiting 10 mins instead of 5 mins earlier. 