### PR TITLE
Clear object store after every round

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.19"
+__version__ = "1.1.20"
 
 
 __all__ = [

--- a/deltacat/compute/compactor_v2/private/compaction_utils.py
+++ b/deltacat/compute/compactor_v2/private/compaction_utils.py
@@ -365,6 +365,8 @@ def _run_hash_and_merge(
     mutable_compaction_audit.set_telemetry_time_in_seconds(
         telemetry_this_round + previous_telemetry
     )
+    params.object_store.clear()
+
     return merge_results
 
 


### PR DESCRIPTION
This PR clears object store store after every round. This change was missed in the previous PR and was discovered after running a test run. 