### PR TITLE
Adding back __init__.py in stats.models

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.20"
+__version__ = "1.1.21"
 
 
 __all__ = [


### PR DESCRIPTION
A ModuleNotFoundError occurs when __init__.py is absent. This PR adds the init file to prevent the error when an external package imports the module. 