### PR TITLE
Revert "Clear object store after every round"

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.21"
+__version__ = "1.1.22"
 
 
 __all__ = [

--- a/deltacat/compute/compactor_v2/private/compaction_utils.py
+++ b/deltacat/compute/compactor_v2/private/compaction_utils.py
@@ -365,7 +365,6 @@ def _run_hash_and_merge(
     mutable_compaction_audit.set_telemetry_time_in_seconds(
         telemetry_this_round + previous_telemetry
     )
-    params.object_store.clear()
 
     return merge_results
 


### PR DESCRIPTION
This PR reverts the code change (https://github.com/ray-project/deltacat/pull/357/files) performed to clear object store after every round. Clearing entire object store will also prevent any partitions that are running in parallel to complete. Hence, a dedicated task will be taken up to address this use-case. 