### PR TITLE
Hotfix for memcached noreply flag + bump version

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.23"
+__version__ = "1.1.24"
 
 
 __all__ = [

--- a/deltacat/io/memcached_object_store.py
+++ b/deltacat/io/memcached_object_store.py
@@ -200,9 +200,9 @@ class MemcachedObjectStore(IObjectStore):
             total_refs += len(current_refs)
             try:
                 # always returns true
-                client.delete_many(current_refs, no_reply=self.noreply)
+                client.delete_many(current_refs, noreply=self.noreply)
                 fully_deleted_refs += len(current_refs)
-            except Exception:
+            except BaseException:
                 # if an exception is raised then all, some, or none of the keys may have been deleted
                 logger.warning(
                     f"Failed to fully delete refs: {current_refs}", exc_info=True

--- a/deltacat/io/s3_object_store.py
+++ b/deltacat/io/s3_object_store.py
@@ -50,7 +50,7 @@ class S3ObjectStore(IObjectStore):
             try:
                 s3_utils.delete_files_by_prefix(self.bucket, str(ref))
                 num_deleted += 1
-            except Exception:
+            except BaseException:
                 logger.warning(f"Failed to delete ref {ref}!", exc_info=True)
         end = time.monotonic()
 


### PR DESCRIPTION
Here is the relevant documentation showing `noreply` is correct (rather than `no_reply`): https://pymemcache.readthedocs.io/en/latest/apidoc/pymemcache.client.base.html#pymemcache.client.base.Client.delete_many