### PR TITLE
Fix divide by zero error when pyarrow table size comes out 0

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.26"
+__version__ = "1.1.27"
 
 
 __all__ = [

--- a/deltacat/compute/resource_estimation/delta.py
+++ b/deltacat/compute/resource_estimation/delta.py
@@ -188,7 +188,7 @@ def _estimate_resources_required_to_process_delta_using_file_sampling(
         sampled_on_disk_size += delta.manifest.entries[entry_index].meta.content_length
         sampled_num_rows += len(tbl)
 
-    if not sampled_on_disk_size:
+    if not sampled_on_disk_size or not sampled_in_memory_size:
         return EstimatedResources.of(
             memory_bytes=0,
             statistics=Statistics.of(


### PR DESCRIPTION
## Summary

This commit ensures the pyarrow table size 0 is handled appropriately. 

## Rationale

The size of the arrow table could be zero even if the file itself isn't 0.

## Changes

N/A

## Impact

Existing UTs pass. No impact,. 

## Testing

Added test cases to repro 0 arrow table size. 

## Regression Risk

None

## Checklist

- [x] Unit tests covering the changes have been added
  - [x ] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
