### PR TITLE
Fliver/2.0

### DIFF
--- a/deltacat/storage/rivulet/dataset.py
+++ b/deltacat/storage/rivulet/dataset.py
@@ -54,7 +54,7 @@ class Dataset:
         return cls(base_uri, field_groups=[PydictFieldGroup(data, riv_schema)])
 
     @classmethod
-    def from_parquet(cls, base_uri: str, primary_key: str, schema_mode: str = 'union'):
+    def from_parquet(cls, base_uri: str, primary_key: str, schema_mode: str = "union"):
         """
         Create a Dataset from parquet files.
 
@@ -70,7 +70,7 @@ class Dataset:
         """
         dataset = pa.dataset.dataset(base_uri)
 
-        if schema_mode == 'intersect':
+        if schema_mode == "intersect":
             schemas = [pa.parquet.read_schema(f) for f in dataset.files]
             # Find common columns across all schemas
             common_columns = set(schemas[0].names)

--- a/deltacat/storage/rivulet/dataset.py
+++ b/deltacat/storage/rivulet/dataset.py
@@ -55,7 +55,6 @@ class Dataset:
         riv_schema = Schema.from_pyarrow_schema(table.schema, primary_key)
         return cls(base_uri, field_groups=[PydictFieldGroup(data, riv_schema)])
 
-    # TODO: Just realized that base_uri is where the manifests are stored, storage_uri should be where the files are at.
     @classmethod
     def from_parquet(
         cls,

--- a/deltacat/storage/rivulet/field_group.py
+++ b/deltacat/storage/rivulet/field_group.py
@@ -31,7 +31,9 @@ class FieldGroup(Protocol):
 # Field group whose data is backed by a glob path
 class GlobPathFieldGroup(FieldGroup):
     def __init__(self, glob_path: str | GlobPath, schema: Schema):
-        self._glob_path = GlobPath(glob_path) if isinstance(glob_path, str) else glob_path
+        self._glob_path = (
+            GlobPath(glob_path) if isinstance(glob_path, str) else glob_path
+        )
         self._schema = schema
 
     @property

--- a/deltacat/storage/rivulet/field_group.py
+++ b/deltacat/storage/rivulet/field_group.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Protocol, Dict, Any, List, runtime_checkable
 from deltacat.storage.rivulet.glob_path import GlobPath
 from deltacat.storage.rivulet import Schema
@@ -28,8 +30,8 @@ class FieldGroup(Protocol):
 
 # Field group whose data is backed by a glob path
 class GlobPathFieldGroup(FieldGroup):
-    def __init__(self, glob_path: GlobPath, schema: Schema):
-        self._glob_path = glob_path
+    def __init__(self, glob_path: str | GlobPath, schema: Schema):
+        self._glob_path = GlobPath(glob_path) if isinstance(glob_path, str) else glob_path
         self._schema = schema
 
     @property
@@ -37,7 +39,7 @@ class GlobPathFieldGroup(FieldGroup):
         return self._schema
 
     def __str__(self) -> str:
-        return f"GlobPathFieldGroup(glob_path={self._glob_path}, schema={self._schema})"
+        return f"GlobPathFieldGroup(glob_path={self._glob_path.path}, schema={self._schema})"
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/deltacat/storage/rivulet/glob_path.py
+++ b/deltacat/storage/rivulet/glob_path.py
@@ -1,7 +1,7 @@
 # Defines a glob path, allowing for files in the path to include variables
 #       This is useful if external data contains keys within file path
 class GlobPath:
-    def __init__(self, path):
+    def __init__(self, path: str):
         """
         GlobPath allows for a mix of literal path components and variable placeholders.
         Variable placeholders are denoted by ${variable_name}
@@ -18,18 +18,18 @@ class GlobPath:
         :param path: A string representing a glob path with variable placeholders.
         """
         self.path = path
-        self.vars = self.parse_path()
+        self.elements = self.parse_path()
 
     def parse_path(self):
         # Split the path into elements.
-        vars = []
+        elements = []
         path_parts = self.path.split("/")
         for part in path_parts:
             if part.startswith("${") and part.endswith("}"):
                 # Variable element (e.g., ${date})
                 # Append just the column name (e.g. "date")
-                vars.append(part[2:-1])
-        return vars
+                elements.append(part[2:-1])
+        return elements
 
     def __str__(self):
         return f"GlobPath: {self.path}\nElements: {self.elements}"

--- a/deltacat/tests/storage/rivulet/test_dataset.py
+++ b/deltacat/tests/storage/rivulet/test_dataset.py
@@ -1,7 +1,12 @@
+from typing import Dict
+
 import pytest
+
+import pyarrow as pa
 
 from deltacat.storage.rivulet import Schema
 from deltacat.storage.rivulet.dataset import Dataset
+from deltacat.storage.rivulet.field_group import GlobPathFieldGroup
 from deltacat.storage.rivulet.schema.datatype import Datatype
 from deltacat.storage.rivulet.glob_path import GlobPath
 from deltacat.storage.rivulet.reader.query_expression import QueryExpression
@@ -14,10 +19,23 @@ def sample_schema():
         primary_key="id",
     )
 
-
 @pytest.fixture
 def sample_pydict():
     return {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}
+
+@pytest.fixture
+def sample_extra_records_pydict():
+    return {"id": [4, 5, 6], "name": ["Alice", "Bob", "McKenzie"], "age": [19, 30, 54]}
+
+@pytest.fixture
+def sample_schema_overlap_pydict():
+    return {"id": [7, 8, 9], "name": ["Rahul", "Priya", "Matthew"], "zip": [48072, 91048, 49320]}
+
+def write_parquet_file_from_dict(path: str, data: Dict):
+    # Helper function to create temporary parquet files from dictionaries
+    table = pa.Table.from_pydict(data)
+    pa.parquet.write_table(table, path)
+
 
 
 def test_dataset_creation(tmp_path):
@@ -133,3 +151,82 @@ def test_dataset_from_glob_path(tmp_path, sample_schema):
 
     assert dataset.schema == sample_schema
     assert len(dataset.field_groups) == 1
+
+
+def test_from_parquet_single_file(tmp_path, sample_pydict):
+    """Test creating Dataset from parquet file"""
+    # First create a sample parquet file
+    table = pa.Table.from_pydict(sample_pydict)
+
+    # Write sample data to parquet
+    parquet_file_path = tmp_path / "test.parquet"
+    pa.parquet.write_table(table, str(parquet_file_path))
+
+    # Test creating dataset from parquet
+    dataset = Dataset.from_parquet(str(parquet_file_path), primary_key='id')
+
+    # Verify the dataset
+    assert len(dataset.field_groups) == 1
+    assert isinstance(dataset.field_groups[0], GlobPathFieldGroup)
+    assert dataset.schema.primary_key.name == 'id'
+    assert len(dataset.schema) == 3
+    # Note: we're auto-inferring the schema using pyarrow, not using the fixture's int32 schema, so it ends up as int64
+    assert dataset.schema['id'].datatype == Datatype('int64')
+    assert dataset.schema['name'].datatype == Datatype('string')
+    assert dataset.schema['age'].datatype == Datatype('int64')
+
+    # Test file not found
+    with pytest.raises(FileNotFoundError):
+        Dataset.from_parquet(str(tmp_path / "nonexistent.parquet"), primary_key='id')
+
+def test_from_parquet_glob_path(tmp_path, sample_pydict, sample_extra_records_pydict):
+    """Test creating Dataset from multiple parquet files"""
+    # First create sample parquet files
+    sample_pydict_path = tmp_path / "sample_pydict.parquet"
+    sample_extra_records_pydict_path = tmp_path / "sample_extra_records_pydict.parquet"
+    write_parquet_file_from_dict(sample_pydict_path, sample_pydict)
+    write_parquet_file_from_dict(sample_extra_records_pydict_path, sample_extra_records_pydict)
+
+
+    # Test creating dataset from parquet base path containing both files
+    dataset = Dataset.from_parquet(str(tmp_path), primary_key='id')
+
+    # Verify the dataset, both source files have the same schema, so we should just have one field_group
+    assert len(dataset.field_groups) == 1
+    assert isinstance(dataset.field_groups[0], GlobPathFieldGroup)
+    assert dataset.schema.primary_key.name == 'id'
+    assert len(dataset.schema) == 3
+    # Note: we're auto-inferring the schema using pyarrow, not using the fixture's int32 schema, so it ends up as int64
+    assert dataset.schema['id'].datatype == Datatype('int64')
+    assert dataset.schema['name'].datatype == Datatype('string')
+    assert dataset.schema['age'].datatype == Datatype('int64')
+
+def test_from_parquet_glob_path_schema_modes(tmp_path, sample_pydict, sample_schema_overlap_pydict):
+    """Test creating Dataset from multiple parquet files with different schema modes"""
+    # First create sample parquet files
+    sample_pydict_path = tmp_path / "sample_pydict.parquet"
+    sample_schema_overlap_pydict_path = tmp_path / "sample_schema_overlap_pydict.parquet"
+    write_parquet_file_from_dict(sample_pydict_path, sample_pydict)
+    write_parquet_file_from_dict(sample_schema_overlap_pydict_path, sample_schema_overlap_pydict)
+
+    # Test intersect schema mode (default)
+    dataset_intersect = Dataset.from_parquet(str(tmp_path), primary_key='id', schema_mode='intersect')
+    assert len(dataset_intersect.field_groups) == 1
+    assert isinstance(dataset_intersect.field_groups[0], GlobPathFieldGroup)
+    assert dataset_intersect.schema.primary_key.name == 'id'
+    assert len(dataset_intersect.schema) == 2  # Only common columns: 'id' and 'name'
+    assert 'id' in dataset_intersect.schema
+    assert 'name' in dataset_intersect.schema
+    assert 'age' not in dataset_intersect.schema
+    assert 'zip' not in dataset_intersect.schema
+
+    # Test union schema mode
+    dataset_union = Dataset.from_parquet(str(tmp_path), primary_key='id', schema_mode='union')
+    assert len(dataset_union.field_groups) == 1
+    assert isinstance(dataset_union.field_groups[0], GlobPathFieldGroup)
+    assert dataset_union.schema.primary_key.name == 'id'
+    assert len(dataset_union.schema) == 4  # All columns: 'id', 'name', 'age', 'zip'
+    assert dataset_union.schema['id'].datatype == Datatype('int64')
+    assert dataset_union.schema['name'].datatype == Datatype('string')
+    assert dataset_union.schema['age'].datatype == Datatype('int64')
+    assert dataset_union.schema['zip'].datatype == Datatype('int64')

--- a/deltacat/tests/storage/rivulet/test_dataset.py
+++ b/deltacat/tests/storage/rivulet/test_dataset.py
@@ -250,3 +250,24 @@ def test_from_parquet_glob_path_schema_modes(
     assert dataset_union.schema["name"].datatype == Datatype("string")
     assert dataset_union.schema["age"].datatype == Datatype("int64")
     assert dataset_union.schema["zip"].datatype == Datatype("int64")
+
+
+def test_from_parquet_separate_uris(
+    tmp_path, sample_pydict, sample_schema_overlap_pydict
+):
+    """Test that file_uri and base_uri are handled separately"""
+    # Create sample parquet files
+    sample_pydict_path = tmp_path / "sample_pydict.parquet"
+    write_parquet_file_from_dict(sample_pydict_path, sample_pydict)
+
+    # Different paths for file_uri and base_uri
+    file_uri = str(tmp_path)
+    base_uri = str(tmp_path / "some-other-metadata-path")
+
+    # Create dataset with separate uris
+    dataset = Dataset.from_parquet(
+        primary_key="id", file_uri=file_uri, base_uri=base_uri
+    )
+
+    assert dataset.base_uri == base_uri
+    assert len(dataset.schema) == 3  # Verify schema still works

--- a/deltacat/tests/storage/rivulet/test_dataset.py
+++ b/deltacat/tests/storage/rivulet/test_dataset.py
@@ -19,23 +19,30 @@ def sample_schema():
         primary_key="id",
     )
 
+
 @pytest.fixture
 def sample_pydict():
     return {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}
+
 
 @pytest.fixture
 def sample_extra_records_pydict():
     return {"id": [4, 5, 6], "name": ["Alice", "Bob", "McKenzie"], "age": [19, 30, 54]}
 
+
 @pytest.fixture
 def sample_schema_overlap_pydict():
-    return {"id": [7, 8, 9], "name": ["Rahul", "Priya", "Matthew"], "zip": [48072, 91048, 49320]}
+    return {
+        "id": [7, 8, 9],
+        "name": ["Rahul", "Priya", "Matthew"],
+        "zip": [48072, 91048, 49320],
+    }
+
 
 def write_parquet_file_from_dict(path: str, data: Dict):
     # Helper function to create temporary parquet files from dictionaries
     table = pa.Table.from_pydict(data)
     pa.parquet.write_table(table, path)
-
 
 
 def test_dataset_creation(tmp_path):
@@ -163,21 +170,22 @@ def test_from_parquet_single_file(tmp_path, sample_pydict):
     pa.parquet.write_table(table, str(parquet_file_path))
 
     # Test creating dataset from parquet
-    dataset = Dataset.from_parquet(str(parquet_file_path), primary_key='id')
+    dataset = Dataset.from_parquet(str(parquet_file_path), primary_key="id")
 
     # Verify the dataset
     assert len(dataset.field_groups) == 1
     assert isinstance(dataset.field_groups[0], GlobPathFieldGroup)
-    assert dataset.schema.primary_key.name == 'id'
+    assert dataset.schema.primary_key.name == "id"
     assert len(dataset.schema) == 3
     # Note: we're auto-inferring the schema using pyarrow, not using the fixture's int32 schema, so it ends up as int64
-    assert dataset.schema['id'].datatype == Datatype('int64')
-    assert dataset.schema['name'].datatype == Datatype('string')
-    assert dataset.schema['age'].datatype == Datatype('int64')
+    assert dataset.schema["id"].datatype == Datatype("int64")
+    assert dataset.schema["name"].datatype == Datatype("string")
+    assert dataset.schema["age"].datatype == Datatype("int64")
 
     # Test file not found
     with pytest.raises(FileNotFoundError):
-        Dataset.from_parquet(str(tmp_path / "nonexistent.parquet"), primary_key='id')
+        Dataset.from_parquet(str(tmp_path / "nonexistent.parquet"), primary_key="id")
+
 
 def test_from_parquet_glob_path(tmp_path, sample_pydict, sample_extra_records_pydict):
     """Test creating Dataset from multiple parquet files"""
@@ -185,48 +193,60 @@ def test_from_parquet_glob_path(tmp_path, sample_pydict, sample_extra_records_py
     sample_pydict_path = tmp_path / "sample_pydict.parquet"
     sample_extra_records_pydict_path = tmp_path / "sample_extra_records_pydict.parquet"
     write_parquet_file_from_dict(sample_pydict_path, sample_pydict)
-    write_parquet_file_from_dict(sample_extra_records_pydict_path, sample_extra_records_pydict)
-
+    write_parquet_file_from_dict(
+        sample_extra_records_pydict_path, sample_extra_records_pydict
+    )
 
     # Test creating dataset from parquet base path containing both files
-    dataset = Dataset.from_parquet(str(tmp_path), primary_key='id')
+    dataset = Dataset.from_parquet(str(tmp_path), primary_key="id")
 
     # Verify the dataset, both source files have the same schema, so we should just have one field_group
     assert len(dataset.field_groups) == 1
     assert isinstance(dataset.field_groups[0], GlobPathFieldGroup)
-    assert dataset.schema.primary_key.name == 'id'
+    assert dataset.schema.primary_key.name == "id"
     assert len(dataset.schema) == 3
     # Note: we're auto-inferring the schema using pyarrow, not using the fixture's int32 schema, so it ends up as int64
-    assert dataset.schema['id'].datatype == Datatype('int64')
-    assert dataset.schema['name'].datatype == Datatype('string')
-    assert dataset.schema['age'].datatype == Datatype('int64')
+    assert dataset.schema["id"].datatype == Datatype("int64")
+    assert dataset.schema["name"].datatype == Datatype("string")
+    assert dataset.schema["age"].datatype == Datatype("int64")
 
-def test_from_parquet_glob_path_schema_modes(tmp_path, sample_pydict, sample_schema_overlap_pydict):
+
+def test_from_parquet_glob_path_schema_modes(
+    tmp_path, sample_pydict, sample_schema_overlap_pydict
+):
     """Test creating Dataset from multiple parquet files with different schema modes"""
     # First create sample parquet files
     sample_pydict_path = tmp_path / "sample_pydict.parquet"
-    sample_schema_overlap_pydict_path = tmp_path / "sample_schema_overlap_pydict.parquet"
+    sample_schema_overlap_pydict_path = (
+        tmp_path / "sample_schema_overlap_pydict.parquet"
+    )
     write_parquet_file_from_dict(sample_pydict_path, sample_pydict)
-    write_parquet_file_from_dict(sample_schema_overlap_pydict_path, sample_schema_overlap_pydict)
+    write_parquet_file_from_dict(
+        sample_schema_overlap_pydict_path, sample_schema_overlap_pydict
+    )
 
     # Test intersect schema mode (default)
-    dataset_intersect = Dataset.from_parquet(str(tmp_path), primary_key='id', schema_mode='intersect')
+    dataset_intersect = Dataset.from_parquet(
+        str(tmp_path), primary_key="id", schema_mode="intersect"
+    )
     assert len(dataset_intersect.field_groups) == 1
     assert isinstance(dataset_intersect.field_groups[0], GlobPathFieldGroup)
-    assert dataset_intersect.schema.primary_key.name == 'id'
+    assert dataset_intersect.schema.primary_key.name == "id"
     assert len(dataset_intersect.schema) == 2  # Only common columns: 'id' and 'name'
-    assert 'id' in dataset_intersect.schema
-    assert 'name' in dataset_intersect.schema
-    assert 'age' not in dataset_intersect.schema
-    assert 'zip' not in dataset_intersect.schema
+    assert "id" in dataset_intersect.schema
+    assert "name" in dataset_intersect.schema
+    assert "age" not in dataset_intersect.schema
+    assert "zip" not in dataset_intersect.schema
 
     # Test union schema mode
-    dataset_union = Dataset.from_parquet(str(tmp_path), primary_key='id', schema_mode='union')
+    dataset_union = Dataset.from_parquet(
+        str(tmp_path), primary_key="id", schema_mode="union"
+    )
     assert len(dataset_union.field_groups) == 1
     assert isinstance(dataset_union.field_groups[0], GlobPathFieldGroup)
-    assert dataset_union.schema.primary_key.name == 'id'
+    assert dataset_union.schema.primary_key.name == "id"
     assert len(dataset_union.schema) == 4  # All columns: 'id', 'name', 'age', 'zip'
-    assert dataset_union.schema['id'].datatype == Datatype('int64')
-    assert dataset_union.schema['name'].datatype == Datatype('string')
-    assert dataset_union.schema['age'].datatype == Datatype('int64')
-    assert dataset_union.schema['zip'].datatype == Datatype('int64')
+    assert dataset_union.schema["id"].datatype == Datatype("int64")
+    assert dataset_union.schema["name"].datatype == Datatype("string")
+    assert dataset_union.schema["age"].datatype == Datatype("int64")
+    assert dataset_union.schema["zip"].datatype == Datatype("int64")

--- a/deltacat/tests/storage/rivulet/test_field_group.py
+++ b/deltacat/tests/storage/rivulet/test_field_group.py
@@ -1,0 +1,114 @@
+import pytest
+from typing import Dict, List, Any
+import pyarrow as pa
+
+from deltacat.storage.rivulet import Schema
+from deltacat.storage.rivulet.schema.datatype import Datatype
+from deltacat.storage.rivulet.glob_path import GlobPath
+from deltacat.storage.rivulet.field_group import (
+    FieldGroup,
+    GlobPathFieldGroup,
+    PydictFieldGroup,
+    FileSystemFieldGroup
+)
+
+
+@pytest.fixture
+def sample_schema():
+    return Schema({
+        'id': Datatype('int32'),
+        'name': Datatype('string'),
+        'age': Datatype('int32')
+    }, primary_key='id')
+
+
+@pytest.fixture
+def sample_data():
+    return {
+        'id': [1, 2, 3],
+        'name': ['Alice', 'Bob', 'Charlie'],
+        'age': [25, 30, 35]
+    }
+
+
+def test_glob_path_field_group(sample_schema):
+    """Test GlobPathFieldGroup initialization and properties"""
+    # Test with string path
+    str_path = "/path/to/data/*.parquet"
+    fg1 = GlobPathFieldGroup(str_path, sample_schema)
+    assert isinstance(fg1._glob_path, GlobPath)
+    assert str(fg1._glob_path.path) == str_path
+    assert fg1.schema == sample_schema
+
+    # Test with GlobPath
+    glob_path = GlobPath("/path/to/other/*.parquet")
+    fg2 = GlobPathFieldGroup(glob_path, sample_schema)
+    assert isinstance(fg2._glob_path, GlobPath)
+    assert fg2._glob_path == glob_path
+    assert fg2.schema == sample_schema
+
+    # Test string representation
+    assert str(fg1) == f"GlobPathFieldGroup(glob_path={str_path}, schema={sample_schema})"
+
+
+def test_pydict_field_group(sample_schema, sample_data):
+    """Test PydictFieldGroup initialization and properties"""
+    fg = PydictFieldGroup(sample_data, sample_schema)
+
+    # Test schema property
+    assert fg.schema == sample_schema
+
+    # Test row data construction
+    assert len(fg._row_data) == 3
+    assert fg._row_data[1] == {'id': 1, 'name': 'Alice', 'age': 25}
+    assert fg._row_data[2] == {'id': 2, 'name': 'Bob', 'age': 30}
+    assert fg._row_data[3] == {'id': 3, 'name': 'Charlie', 'age': 35}
+
+    # Test empty data
+    empty_fg = PydictFieldGroup({}, sample_schema)
+    assert len(empty_fg._row_data) == 0
+
+    # Test string representation
+    assert str(fg) == f"DictFieldGroup(data={sample_data}, schema={sample_schema})"
+
+
+def test_filesystem_field_group(sample_schema):
+    """Test FileSystemFieldGroup initialization and properties"""
+    fg1 = FileSystemFieldGroup(sample_schema)
+    fg2 = FileSystemFieldGroup(sample_schema)
+
+    # Test schema property
+    assert fg1.schema == sample_schema
+
+    # Test equality
+    assert fg1 == fg2
+    assert fg1 != "not a field group"
+
+    # Test with different schema
+    different_schema = Schema({
+        'id': Datatype('int32'),
+        'email': Datatype('string')
+    }, primary_key='id')
+    fg3 = FileSystemFieldGroup(different_schema)
+    assert fg1 != fg3
+
+    # Test string representation
+    assert str(fg1) == f"FileSystemFieldGroup(schema={sample_schema})"
+
+
+def test_field_group_protocol():
+    """Test that all field group classes implement the FieldGroup protocol"""
+    # Create instances to test
+    sample_schema = Schema({
+        'id': Datatype('int32'),
+        'name': Datatype('string')
+    }, primary_key='id')
+
+    glob_fg = GlobPathFieldGroup("/test/*.parquet", sample_schema)
+    pydict_fg = PydictFieldGroup({}, sample_schema)
+    fs_fg = FileSystemFieldGroup(sample_schema)
+
+    # Test instances instead of classes
+    assert isinstance(glob_fg, FieldGroup)
+    assert isinstance(pydict_fg, FieldGroup)
+    assert isinstance(fs_fg, FieldGroup)

--- a/deltacat/tests/storage/rivulet/test_field_group.py
+++ b/deltacat/tests/storage/rivulet/test_field_group.py
@@ -1,6 +1,4 @@
 import pytest
-from typing import Dict, List, Any
-import pyarrow as pa
 
 from deltacat.storage.rivulet import Schema
 from deltacat.storage.rivulet.schema.datatype import Datatype
@@ -9,26 +7,21 @@ from deltacat.storage.rivulet.field_group import (
     FieldGroup,
     GlobPathFieldGroup,
     PydictFieldGroup,
-    FileSystemFieldGroup
+    FileSystemFieldGroup,
 )
 
 
 @pytest.fixture
 def sample_schema():
-    return Schema({
-        'id': Datatype('int32'),
-        'name': Datatype('string'),
-        'age': Datatype('int32')
-    }, primary_key='id')
+    return Schema(
+        {"id": Datatype("int32"), "name": Datatype("string"), "age": Datatype("int32")},
+        primary_key="id",
+    )
 
 
 @pytest.fixture
 def sample_data():
-    return {
-        'id': [1, 2, 3],
-        'name': ['Alice', 'Bob', 'Charlie'],
-        'age': [25, 30, 35]
-    }
+    return {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}
 
 
 def test_glob_path_field_group(sample_schema):
@@ -48,7 +41,9 @@ def test_glob_path_field_group(sample_schema):
     assert fg2.schema == sample_schema
 
     # Test string representation
-    assert str(fg1) == f"GlobPathFieldGroup(glob_path={str_path}, schema={sample_schema})"
+    assert (
+        str(fg1) == f"GlobPathFieldGroup(glob_path={str_path}, schema={sample_schema})"
+    )
 
 
 def test_pydict_field_group(sample_schema, sample_data):
@@ -60,9 +55,9 @@ def test_pydict_field_group(sample_schema, sample_data):
 
     # Test row data construction
     assert len(fg._row_data) == 3
-    assert fg._row_data[1] == {'id': 1, 'name': 'Alice', 'age': 25}
-    assert fg._row_data[2] == {'id': 2, 'name': 'Bob', 'age': 30}
-    assert fg._row_data[3] == {'id': 3, 'name': 'Charlie', 'age': 35}
+    assert fg._row_data[1] == {"id": 1, "name": "Alice", "age": 25}
+    assert fg._row_data[2] == {"id": 2, "name": "Bob", "age": 30}
+    assert fg._row_data[3] == {"id": 3, "name": "Charlie", "age": 35}
 
     # Test empty data
     empty_fg = PydictFieldGroup({}, sample_schema)
@@ -85,10 +80,9 @@ def test_filesystem_field_group(sample_schema):
     assert fg1 != "not a field group"
 
     # Test with different schema
-    different_schema = Schema({
-        'id': Datatype('int32'),
-        'email': Datatype('string')
-    }, primary_key='id')
+    different_schema = Schema(
+        {"id": Datatype("int32"), "email": Datatype("string")}, primary_key="id"
+    )
     fg3 = FileSystemFieldGroup(different_schema)
     assert fg1 != fg3
 
@@ -99,10 +93,9 @@ def test_filesystem_field_group(sample_schema):
 def test_field_group_protocol():
     """Test that all field group classes implement the FieldGroup protocol"""
     # Create instances to test
-    sample_schema = Schema({
-        'id': Datatype('int32'),
-        'name': Datatype('string')
-    }, primary_key='id')
+    sample_schema = Schema(
+        {"id": Datatype("int32"), "name": Datatype("string")}, primary_key="id"
+    )
 
     glob_fg = GlobPathFieldGroup("/test/*.parquet", sample_schema)
     pydict_fg = PydictFieldGroup({}, sample_schema)


### PR DESCRIPTION
## Summary

Introduce a new Dataset.from_parquet() that does schema inference using pyarrow. It provides both union and intersect schema inferencing, and adds a bunch of tests to the underlying glob_path and field_group classes to help validate intentions.

## Rationale

It's now super easy to create a rivulet dataset w/ schema from a parquet dataset (or set of parquet files) in one line.

## Changes

new Dataset.from_parquet() and supporting changes.

## Impact

No impact.

## Testing

make test && make lint w/ new tests that validate that single file, union, and intersect schema inference all work properly.

## Regression Risk

N/A

## Checklist

- [X] Unit tests covering the changes have been added

## Additional Notes

I haven't tried doing some of the other constructor types pyarrow provides, like parquet metadata files. It's also possible in the future there might be a better way of wrapping pyarrow datasets (there are alot of constructors for pyarrow datasets), or just take a pyarrow dataset.
