### PR TITLE
Bump version to 1.1.28

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,34 @@
 fail_fast: true
-minimum_pre_commit_version: '0'
+minimum_pre_commit_version: "0"
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: check-added-large-files
+      - id: check-added-large-files
         exclude: "deltacat/compute/compactor/TheFlashCompactorDesign.pdf"
-    -   id: check-case-conflict
-    -   id: check-json
-    -   id: check-yaml
-    -   id: check-executables-have-shebangs
-    -   id: end-of-file-fixer
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-yaml
+      - id: check-executables-have-shebangs
+      - id: end-of-file-fixer
         exclude_types: [pdf]
-    -   id: requirements-txt-fixer
-    -   id: check-merge-conflict
-    -   id: trailing-whitespace
--   repo: https://github.com/python-jsonschema/check-jsonschema
+      - id: requirements-txt-fixer
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+  - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.16.0
     hooks:
-    - id: check-github-actions
-    - id: check-github-workflows
--   repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.2
+      - id: check-github-actions
+      - id: check-github-workflows
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v2.5.0
     hooks:
-    -   id: pycln
--   repo: https://github.com/psf/black
+      - id: pycln
+  - repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:
       - id: black
--   repo: https://github.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 5.0.0
     hooks:
-    -   id: flake8
+      - id: flake8

--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.27"
+__version__ = "1.1.28"
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

version bump

## Rationale

Release new changes. 

## Changes

https://github.com/ray-project/deltacat/pull/439

## Impact

The changes are backward compatible. They fix several high severity tickets at our side. 

## Testing

See testing section: https://github.com/ray-project/deltacat/pull/439

## Regression Risk

The new changes only affect reads that were failing before. So, the risk is very low.  

## Checklist

- [x] Unit tests covering the changes have been added
  - [x] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
