### PR TITLE
Add support for JSON and CSV data formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ pyvenv.cfg
 # Generated Files
 **/.riv-meta-*
 **/*.parquet
-**/*.csv
 **/*.feather
 **/*.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ pyvenv.cfg
 # Generated Files
 **/.riv-meta-*
 **/*.parquet
+**/*.csv
+**/*.feather
+**/*.json
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/deltacat/aws/s3u.py
+++ b/deltacat/aws/s3u.py
@@ -14,7 +14,7 @@ from deltacat.aws.constants import (
     DOWNLOAD_MANIFEST_ENTRY_RETRY_STOP_AFTER_DELAY,
 )
 
-import pyarrow as pa
+import pyarrow.fs
 import ray
 import s3fs
 from boto3.resources.base import ServiceResource
@@ -134,7 +134,7 @@ class UuidBlockWritePathProvider(FilenameProvider):
         self,
         base_path: str,
         *,
-        filesystem: Optional[pa.filesystem.FileSystem] = None,
+        filesystem: Optional[pyarrow.fs.FileSystem] = None,
         dataset_uuid: Optional[str] = None,
         block: Optional[ObjectRef[Block]] = None,
         block_index: Optional[int] = None,
@@ -150,7 +150,7 @@ class UuidBlockWritePathProvider(FilenameProvider):
         self,
         base_path: str,
         *,
-        filesystem: Optional[pa.filesystem.FileSystem] = None,
+        filesystem: Optional[pyarrow.fs.FileSystem] = None,
         dataset_uuid: Optional[str] = None,
         block: Optional[ObjectRef[Block]] = None,
         block_index: Optional[int] = None,

--- a/deltacat/examples/rivulet/data.csv
+++ b/deltacat/examples/rivulet/data.csv
@@ -1,0 +1,15 @@
+"group_id","group_name","msg_id","sender_ph","sender_name","message","reply_to","delay_ss"
+"xxx","xxx",100,904,"Alice","Hey Bob, did you reach out to ABC Consulting?"," ",1
+"xxx","xxx",101,903,"Bob","Not yet, I'll do that right away."," ",1
+"xxx","xxx",102,905,"Charlie","Bob, can you also send the proposal to XYZ Corp?"," ",1
+"xxx","xxx",103,903,"Bob","Sure thing, I'll have it ready by EOD."," ",1
+"xxx","xxx",104,906,"Olivia","whats happening with pepsico"," ",1
+"xxx","xxx",105,903,"Bob","I’m still waiting on their feedback. I’ll follow up with them today."," ",1
+"xxx","xxx",106,906,"Olivia","ok, lets create some marketing collateral and start reach outs @Charlie"," ",1
+"xxx","xxx",107,905,"Charlie","Sounds good, Olivia. What specific materials do you have in mind?"," ",1
+"xxx","xxx",108,906,"Olivia","a deck and some social media posts to start with"," ",1
+"xxx","xxx",109,905,"Charlie","Great! I can draft the deck. How many slides are you thinking?"," ",1
+"xxx","xxx",110,906,"Olivia","you decide"," ",1
+"xxx","xxx",111,905,"Charlie","How about a 10-slide deck? That should cover the key points without overwhelming them."," ",1
+"xxx","xxx",112,906,"Olivia","ok"," ",1
+"xxx","xxx",113,903,"Bob","Once the deck is ready, I can help with the social media posts. Do you have any specific platforms in mind?"," ",1

--- a/deltacat/examples/rivulet/pytorch_demo.ipynb
+++ b/deltacat/examples/rivulet/pytorch_demo.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# PyTorch Demo: Sentiment Analysis and Question Detection with Rivulet Dataset\n",
+    "\n",
+    "This demo showcases how to process a dataset of messages to perform **sentiment analysis** and **question detection** using pre-trained transformer models from Hugging Face. Leveraging the `transformers` library and **DeltaCat** for efficient dataset management.\n",
+    "\n",
+    "**Data Handling with DeltaCat:**\n",
+    "- **Importing Data:** Easily imports data from CSV files into a DeltaCat `Dataset`.\n",
+    "- **Pytorch Integration:** Easily allows passing of data between pytorch models and transformers.\n",
+    "- **Non-Destructive Transformation:** Transforms the data (e.g., adding sentiment and question classification) without modifying the original dataset.\n",
+    "- **Exporting Data:** Exports the modified dataset to supported formats such as Parquet and JSON for further analysis."
+   ],
+   "id": "2fb18b4d46a9548"
+  },
+  {
+   "metadata": {
+    "collapsed": true
+   },
+   "cell_type": "code",
+   "source": [
+    "import torch\n",
+    "from typing import List\n",
+    "from transformers import AutoTokenizer, AutoModelForSequenceClassification\n",
+    "import deltacat as dc\n",
+    "import pathlib\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.csv as csv"
+   ],
+   "id": "initial_id",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# Load tokenizer and model for sentiment analysis\n",
+    "sentiment_tokenizer = AutoTokenizer.from_pretrained(\"distilbert-base-uncased-finetuned-sst-2-english\")\n",
+    "sentiment_model = AutoModelForSequenceClassification.from_pretrained(\"distilbert-base-uncased-finetuned-sst-2-english\")\n",
+    "sentiment_model.eval()\n",
+    "\n",
+    "question_tokenizer = AutoTokenizer.from_pretrained(\"shahrukhx01/question-vs-statement-classifier\")\n",
+    "question_model = AutoModelForSequenceClassification.from_pretrained(\"shahrukhx01/question-vs-statement-classifier\")\n",
+    "question_model.eval()"
+   ],
+   "id": "51a2ddaed83da5f3",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "def compute_sentiments(batch: pa.RecordBatch) -> List[float]:\n",
+    "    messages = batch.column(\"message\").to_pylist()\n",
+    "\n",
+    "    def predict_sentiment(texts: List[str]) -> List[float]:\n",
+    "        inputs = sentiment_tokenizer(texts, return_tensors=\"pt\", padding=True, truncation=True)\n",
+    "        with torch.no_grad():\n",
+    "            outputs = sentiment_model(**inputs)\n",
+    "        probs = torch.softmax(outputs.logits, dim=1)\n",
+    "        return probs[:, 1].tolist()\n",
+    "\n",
+    "    return predict_sentiment(messages)"
+   ],
+   "id": "5b10e54bf945e8b4",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "def compute_is_questions(batch: pa.RecordBatch) -> List[float]:\n",
+    "    messages = batch.column(\"message\").to_pylist()\n",
+    "\n",
+    "    def predict_is_question(texts: List[str]) -> List[float]:\n",
+    "        inputs = question_tokenizer(texts, return_tensors=\"pt\", padding=True, truncation=True)\n",
+    "        with torch.no_grad():\n",
+    "            outputs = question_model(**inputs)\n",
+    "        probs = torch.softmax(outputs.logits, dim=1)\n",
+    "        return probs[:, 1].tolist()\n",
+    "\n",
+    "    return predict_is_question(messages)"
+   ],
+   "id": "182efb4e811a0280",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# Create a rivulet dataset using the CSV file\n",
+    "cwd = pathlib.Path.cwd()\n",
+    "csv_file_path = cwd / \"data.csv\"\n",
+    "ds = dc.Dataset.from_csv(\n",
+    "    name=\"chat\",\n",
+    "    file_uri=csv_file_path,\n",
+    "    metadata_uri=cwd.as_uri(),\n",
+    "    merge_keys=\"msg_id\"\n",
+    ")\n",
+    "ds.print(num_records=10)"
+   ],
+   "id": "b74792a57b9b28c1",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# define a new schema with fields for pytorch classification\n",
+    "ds.add_fields([\n",
+    "    (\"msg_id\", dc.Datatype.int64()),\n",
+    "    (\"sentiment\", dc.Datatype.float()),\n",
+    "    (\"is_question\", dc.Datatype.float())\n",
+    "], schema_name=\"message_classifier\", merge_keys=[\"msg_id\"])"
+   ],
+   "id": "1b90411fd69378e9",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "dataset_writer = ds.writer(schema_name=\"message_classifier\")\n",
+    "for batch in ds.scan().to_arrow():\n",
+    "    messages = batch.column(\"msg_id\").to_pylist()\n",
+    "\n",
+    "    # compute message data statistics\n",
+    "    sentiments = compute_sentiments(batch)\n",
+    "    is_questions = compute_is_questions(batch)\n",
+    "\n",
+    "    # construct columns for new fields using merge_key\n",
+    "    new_columns_existing_rows = []\n",
+    "    for idx, msg in enumerate(messages):\n",
+    "        new_columns_existing_rows.append({\n",
+    "            \"msg_id\": msg,\n",
+    "            \"sentiment\": sentiments[idx],\n",
+    "            \"is_question\": is_questions[idx]\n",
+    "        })\n",
+    "    dataset_writer.write(new_columns_existing_rows)\n",
+    "\n",
+    "dataset_writer.flush()\n",
+    "print(\"Sentiment and is_question values have been computed and updated in the dataset.\")"
+   ],
+   "id": "587f17e09e5d306a",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# export to a supported format (JSON, PARQUET, FEATHER)\n",
+    "ds.export(file_uri=\"./output.json\", format=\"json\")"
+   ],
+   "id": "8ef2dd2a1bc4e66a",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/deltacat/utils/export.py
+++ b/deltacat/utils/export.py
@@ -1,0 +1,49 @@
+import json
+import pyarrow as pa
+import pyarrow.parquet
+import pyarrow.feather
+from typing import Callable, Dict
+
+from deltacat.storage.rivulet.reader.query_expression import QueryExpression
+
+def export_parquet(dataset, file_uri: str, query: QueryExpression=QueryExpression()):
+    records = dataset.scan(query).to_arrow()
+    table = pa.Table.from_batches(records)
+    pyarrow.parquet.write_table(table, file_uri)
+
+def export_feather(dataset, file_uri: str, query: QueryExpression=QueryExpression()):
+    records = dataset.scan(query).to_arrow()
+    table = pa.Table.from_batches(records)
+    pyarrow.feather.write_feather(table, file_uri)
+
+def export_json(dataset, file_uri: str, query: QueryExpression=QueryExpression()):
+    with open(file_uri, "w") as f:
+        for batch in dataset.scan(query).to_pydict():
+            json.dump(batch, f, indent=2)
+            f.write("\n")
+
+def export_dataset(dataset, file_uri: str, format: str = "parquet", query=None):
+    """
+    Export the dataset to a file.
+
+    TODO: Make this pluggable for custom formats.
+
+    Args:
+        dataset: The dataset to export.
+        file_uri: The URI to write the dataset to.
+        format: The format to write the dataset in. Options are [parquet, feather, json].
+        query: QueryExpression to filter the dataset before exporting.
+    """
+    # Supported format handlers
+    export_handlers: Dict[str, Callable] = {
+        "parquet": export_parquet,
+        "feather": export_feather,
+        "json": export_json,
+    }
+
+    if format not in export_handlers:
+        raise ValueError(f"Unsupported format: {format}. Supported formats are {list(export_handlers.keys())}")
+
+    export_handlers[format](dataset, file_uri, query or QueryExpression())
+
+    print(f"Dataset exported to {file_uri} in {format} format.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,10 @@ intervaltree == 3.1.0
 msgpack ~= 1.0.7
 numpy == 1.22.4
 pandas == 1.3.5
-pyarrow == 12.0.1
-
+# upgrade to pyarrow 18.0.0 causes test
+# TestCompactionSession::test_compact_partition_when_incremental_then_rcf_stats_accurate to fail
+# due to input_inflation exceeding 1e-5
+pyarrow == 17.0.0
 
 # setup.py extras_require
 # any changes here should also be reflected in setup.py "extras_require"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,10 @@ setuptools.setup(
         "intervaltree == 3.1.0",
         "numpy == 1.21.5",
         "pandas == 1.3.5",
-        "pyarrow == 12.0.1",
+        # upgrade to pyarrow 18.0.0 causes test
+        # TestCompactionSession::test_compact_partition_when_incremental_then_rcf_stats_accurate to fail
+        # due to input_inflation exceeding 1e-5
+        "pyarrow == 17.0.0",
         "pydantic == 1.10.4",
         "pymemcache == 4.0.0",
         "ray >= 2.20.0",


### PR DESCRIPTION
## Changes

- **`dataset.from_json`**
  - **Purpose:** Create a Rivulet dataset from a JSON file.
  - **Functionality:** Similar to `from_parquet`.
  - **Limitations:** Supports only single JSON files at present, as PyArrow does not natively handle directories for JSON datasets.

- **`dataset.from_csv`**
  - **Purpose:** Create a Rivulet dataset from a CSV file.
  - **Functionality:** Similar to `from_parquet`.
  - **Limitations:** Supports only single CSV files at present, as PyArrow does not natively handle directories for CSV datasets.

**Future Enhancement:** Extend both `from_json` and `from_csv` to support directory imports.

- **`dataset.export`**
  - **Purpose:** Export Rivulet datasets into multiple formats.
  - **Supported Formats:** Parquet, JSON, and Feather.
  - **Functionality:** Provides a unified method for exporting datasets.

- **`dataset.print`**
  - **Purpose:** Make it easier for users to quickly print records.
  - **Functionality:** Prints x number of records from the dataset (in sorted order).

### PyTorch Rivulet Demo

- **Overview:** A notebook that uses a rivulet dataset to transform data using pytorch.
- **Features:**
  - **Data Ingestion:** Demonstrates importing JSON and CSV files using `from_json` and `from_csv`.
  - **Data Export:** Illustrates exporting datasets to JSON using the `export` method.
  - **End-to-End Workflow:** Showcases an end to end workflow for a user hoping to use rivulet with pytorch.

## Testing

ran unit tests using `make test`

## Checklist

- [ ] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

