### PR TITLE
Resolve ArrowCapacityError when processing >2GB

### DIFF
--- a/deltacat/compute/compactor_v2/constants.py
+++ b/deltacat/compute/compactor_v2/constants.py
@@ -88,7 +88,7 @@ DEFAULT_NUM_ROUNDS = 1
 # required for bucketing where it's not mandatory
 # when dropping duplicates. Setting this to True
 # will disable sha1 hashing in cases where it isn't
-# mandatory. This flag is enabled by default.
+# mandatory. This flag is False by default.
 SHA1_HASHING_FOR_MEMORY_OPTIMIZATION_DISABLED = env_bool(
     "SHA1_HASHING_FOR_MEMORY_OPTIMIZATION_DISABLED", False
 )

--- a/deltacat/compute/compactor_v2/constants.py
+++ b/deltacat/compute/compactor_v2/constants.py
@@ -1,3 +1,5 @@
+from deltacat.utils.common import env_bool, env_integer
+
 TOTAL_BYTES_IN_SHA1_HASH = 20
 
 PK_DELIMITER = "L6kl7u5f"
@@ -31,7 +33,9 @@ TOTAL_MEMORY_BUFFER_PERCENTAGE = 30
 # The total size of records that will be hash bucketed at once
 # Since, sorting is nlogn, we ensure that is not performed
 # on a very large dataset for best performance.
-MAX_SIZE_OF_RECORD_BATCH_IN_GIB = 2 * 1024 * 1024 * 1024
+MAX_SIZE_OF_RECORD_BATCH_IN_GIB = env_integer(
+    "MAX_SIZE_OF_RECORD_BATCH_IN_GIB", 2 * 1024 * 1024 * 1024
+)
 
 # Whether to drop duplicates during merge.
 DROP_DUPLICATES = True
@@ -78,3 +82,13 @@ COMPACT_PARTITION_METRIC_PREFIX = "compact_partition"
 # Number of rounds to run hash/merge for a single
 # partition. (For large table support)
 DEFAULT_NUM_ROUNDS = 1
+
+# Whether to perform sha1 hashing when required to
+# optimize memory. For example, hashing is always
+# required for bucketing where it's not mandatory
+# when dropping duplicates. Setting this to True
+# will disable sha1 hashing in cases where it isn't
+# mandatory. This flag is enabled by default.
+SHA1_HASHING_FOR_MEMORY_OPTIMIZATION_DISABLED = env_bool(
+    "SHA1_HASHING_FOR_MEMORY_OPTIMIZATION_DISABLED", False
+)

--- a/deltacat/compute/compactor_v2/steps/merge.py
+++ b/deltacat/compute/compactor_v2/steps/merge.py
@@ -162,7 +162,7 @@ def _merge_tables(
         ):
             logger.info("Casting compacted and incremental pk hash to large_string...")
             # is_in requires the first arg to not exceed 2GB in size
-            # The cast must here be zero-copy in most cases
+            # The cast here should be zero-copy in most cases
             compacted_pk_hash_str = pc.cast(compacted_pk_hash_str, pa.large_string())
             incremental_pk_hash_str = pc.cast(
                 incremental_pk_hash_str, pa.large_string()

--- a/deltacat/compute/compactor_v2/steps/merge.py
+++ b/deltacat/compute/compactor_v2/steps/merge.py
@@ -161,8 +161,10 @@ def _merge_tables(
             or incremental_table[sc._PK_HASH_STRING_COLUMN_NAME].nbytes >= MAX_INT_BYTES
         ):
             logger.info("Casting compacted and incremental pk hash to large_string...")
-            # is_in requires the first arg to not exceed 2GB in size
-            # The cast here should be zero-copy in most cases
+            # is_in combines the chunks of the chunked array passed which can cause
+            # ArrowCapacityError if the total size of string array is over 2GB.
+            # Using a large_string would resolve this issue.
+            # The cast here should be zero-copy in most cases.
             compacted_pk_hash_str = pc.cast(compacted_pk_hash_str, pa.large_string())
             incremental_pk_hash_str = pc.cast(
                 incremental_pk_hash_str, pa.large_string()

--- a/deltacat/compute/compactor_v2/steps/merge.py
+++ b/deltacat/compute/compactor_v2/steps/merge.py
@@ -161,7 +161,7 @@ def _merge_tables(
             or incremental_table[sc._PK_HASH_STRING_COLUMN_NAME].nbytes >= MAX_INT_BYTES
         ):
             logger.info("Casting compacted and incremental pk hash to large_string...")
-            # is_in required the first arg to not exceed 2GB in size
+            # is_in requires the first arg to not exceed 2GB in size
             # The cast must here be zero-copy in most cases
             compacted_pk_hash_str = pc.cast(compacted_pk_hash_str, pa.large_string())
             incremental_pk_hash_str = pc.cast(

--- a/deltacat/compute/compactor_v2/steps/merge.py
+++ b/deltacat/compute/compactor_v2/steps/merge.py
@@ -151,10 +151,16 @@ def _merge_tables(
         compacted_pk_hash_str = compacted_table[sc._PK_HASH_STRING_COLUMN_NAME]
         incremental_pk_hash_str = incremental_table[sc._PK_HASH_STRING_COLUMN_NAME]
 
+        logger.info(
+            f"Size of compacted pk hash={compacted_pk_hash_str.nbytes} "
+            f"and incremental pk hash={incremental_pk_hash_str.nbytes}."
+        )
+
         if (
             compacted_table[sc._PK_HASH_STRING_COLUMN_NAME].nbytes >= MAX_INT_BYTES
             or incremental_table[sc._PK_HASH_STRING_COLUMN_NAME].nbytes >= MAX_INT_BYTES
         ):
+            logger.info("Casting compacted and incremental pk hash to large_string...")
             # is_in required the first arg to not exceed 2GB in size
             # The cast must here be zero-copy in most cases
             compacted_pk_hash_str = pc.cast(compacted_pk_hash_str, pa.large_string())

--- a/deltacat/compute/compactor_v2/utils/primary_key_index.py
+++ b/deltacat/compute/compactor_v2/utils/primary_key_index.py
@@ -10,6 +10,7 @@ from deltacat.compute.compactor_v2.constants import (
     TOTAL_BYTES_IN_SHA1_HASH,
     PK_DELIMITER,
     MAX_SIZE_OF_RECORD_BATCH_IN_GIB,
+    SHA1_HASHING_FOR_MEMORY_OPTIMIZATION_DISABLED,
 )
 import time
 from deltacat.compute.compactor.model.delta_file_envelope import DeltaFileEnvelope
@@ -47,6 +48,13 @@ def _is_sha1_desired(hash_columns: List[pa.Array]) -> bool:
     logger.info(
         f"Found total length of hash column={total_len} and total_size={total_size}"
     )
+
+    if SHA1_HASHING_FOR_MEMORY_OPTIMIZATION_DISABLED:
+        logger.info(
+            f"SHA1_HASHING_FOR_MEMORY_OPTIMIZATION_DISABLED is True. "
+            f"Returning False for is_sha1_desired"
+        )
+        return False
 
     return total_size > TOTAL_BYTES_IN_SHA1_HASH * total_len
 

--- a/deltacat/tests/compute/compactor_v2/test_compaction_session.py
+++ b/deltacat/tests/compute/compactor_v2/test_compaction_session.py
@@ -573,8 +573,8 @@ class TestCompactionSession:
         self, s3_resource, local_deltacat_storage_kwargs, disable_sha1
     ):
         """
-        A test case which ensures the compaction succeeds even if the previously
-        compacted arrow table size is over 2GB. It is added to prevent ArrowCapacityError
+        A test case which ensures the compaction succeeds even if the incremental
+        arrow table size is over 2GB. It is added to prevent ArrowCapacityError
         when running is_in operation during merge.
 
         Note that we set SHA1_HASHING_FOR_MEMORY_OPTIMIZATION_DISABLED to bypass sha1 hashing

--- a/deltacat/tests/compute/compactor_v2/test_compaction_session.py
+++ b/deltacat/tests/compute/compactor_v2/test_compaction_session.py
@@ -637,8 +637,7 @@ class TestCompactionSession:
         # Run incremental with a small delta on source
         chunked_pk_array = pa.chunked_array(
             [
-                ["13bytesstring" * 95_000_000],
-                ["11bytstring" * 95_000_000, "small_string"],
+                ["11bytstring", "small_string"],
             ]
         )  # 2.3GB
         table = pa.table([chunked_pk_array], names=["pk"])


### PR DESCRIPTION
## Summary

This change addresses cases where the previous hash bucket size is over 2GB.

## Rationale

is_in op in arrow doesn't allow the first arg to be over 2GB in size. 

## Changes

To overcome the arrow limitation, we cast the first arg to large_string. 

## Impact

No impact to existing tables. Only the tables that were failing before will now run through this codepath. 

## Testing

A functional test is added. 
Note: reduced the memory used by functional test to be able to run it on standard github hosted runners.

## Regression Risk

Very low. 

## Checklist

- [x] Unit tests covering the changes have been added
  - [x] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
