### PR TITLE
fix block group generation when min key matches global min key

### DIFF
--- a/deltacat/storage/rivulet/metastore/sst_interval_tree.py
+++ b/deltacat/storage/rivulet/metastore/sst_interval_tree.py
@@ -207,8 +207,8 @@ class BlockIntervalTree:
                 f"min_key {min_key} cannot be greater than max_key {max_key}"
             )
 
-        min_key_idx = bisect_left(key_boundaries, min_key) - 1 if min_key else None
-        max_key_idx = bisect_right(key_boundaries, max_key) + 1 if max_key else None
+        min_key_idx = max(0, bisect_left(key_boundaries, min_key) - 1) if min_key is not None else None
+        max_key_idx = bisect_right(key_boundaries, max_key) + 1 if max_key is not None else None
         boundary_table = key_boundaries[min_key_idx:max_key_idx]
 
         for lower_bound, upper_bound in pairwise(boundary_table):

--- a/deltacat/tests/storage/rivulet/test_sst_interval_tree.py
+++ b/deltacat/tests/storage/rivulet/test_sst_interval_tree.py
@@ -169,6 +169,27 @@ def test_build_sst_with_bounds(
     expected = _build_ordered_block_groups(expected_block_groups[0:3])
     assert expected == block_groups_filtered
 
+    block_groups_filtered = t.get_sorted_block_groups(0, 0)
+    expected = _build_ordered_block_groups(expected_block_groups[0:1])
+    assert expected == block_groups_filtered
+
+def test_build_sst_with_non_zero_min_key_matching_global_min_key(
+        manifest_context1
+):
+    # Using a non-0 value since 0 evaluates to False
+    min_key = 1
+    max_key = 95
+
+    sst_row = SSTableRow(min_key, max_key, "row-with-non-zero-min-key", 0, 1)
+    t = BlockIntervalTree()
+    t.add_sst_table(SSTable([sst_row], min_key, max_key), manifest_context1)
+
+    block_groups_filtered = t.get_sorted_block_groups(min_key, min_key + 1)
+    expected = _build_ordered_block_groups([
+        BlockGroup(min_key, max_key, {manifest_context1.schema: frozenset([Block(sst_row, manifest_context1)])})
+    ])
+    assert expected == block_groups_filtered
+
 
 def test_build_sst_invalid_bounds(
     sst1, sst2, schema1, schema2, sst_row_list, expected_block_groups


### PR DESCRIPTION
## Summary

Fixes an issue when scanning a rivulet dataset with a query expression where the min key matches the global min key would always return no records.

## Rationale

During testing, @anshumankomawar found that scans involving a query expression where the min key matches the global min key would incorrectly return no records (unless the min key happened to be 0).

## Changes

* Fixed guard conditions that incorrectly handled numeric key values of `0` as "Falsy" values.
* Pinned min key index to 0 when bisecting the interval tree (whereas before it would potentially use an index of `-1`).

## Impact

This should allow rivulet to return expected records even when min key matches the global min key.

## Testing

Added a new functional unit test that fails without the corresponding bugfix

`make test` to ensure no regressions.

## Regression Risk

Low. Existing functional tests passed and changes are backward compatible.

## Checklist

- [x] Unit tests covering the changes have been added
  - [x] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed
