### PR TITLE
fix: respect schema fields in file reader

### DIFF
--- a/deltacat/storage/rivulet/feather/file_reader.py
+++ b/deltacat/storage/rivulet/feather/file_reader.py
@@ -13,6 +13,7 @@ from deltacat.storage.rivulet.reader.data_reader import (
     FILE_FORMAT,
 )
 from deltacat.storage.rivulet.reader.pyarrow_data_reader import RecordBatchRowIndex
+from deltacat.storage.rivulet.schema.schema import Schema
 
 
 class FeatherFileReader(FileReader[RecordBatchRowIndex]):
@@ -23,12 +24,14 @@ class FeatherFileReader(FileReader[RecordBatchRowIndex]):
     TODO can consider abstracting code between this and ParquetFileReader
     """
 
-    def __init__(self, sst_row: SSTableRow, file_store: FileStore, primary_key: str):
+    def __init__(self, sst_row: SSTableRow, file_store: FileStore, primary_key: str, schema: Schema):
         self.sst_row = sst_row
         self.input = file_store.new_input_file(self.sst_row.uri)
 
         self.key = primary_key
         self.feather_file = sst_row.uri
+
+        self.schema = schema
 
         # Iterator from pyarrow iter_batches API call. Pyarrow manages state of traversal within parquet row groups
 
@@ -115,5 +118,9 @@ class FeatherFileReader(FileReader[RecordBatchRowIndex]):
             self._curr_batch_index += 1
             self._curr_row_offset = 0
             self._pk_col = self._curr_batch[self.key]
+            # Filter the batch to only include fields in the schema
+            # Pyarrow select will throw a ValueError if the field is not in the schema
+            fields = [field for field in self.schema.keys() if field in self._curr_batch.schema.names]
+            self._curr_batch = self._curr_batch.select(fields)
         except ValueError:
             raise StopIteration(f"Ended iteration at batch {self._curr_batch_index}")

--- a/deltacat/storage/rivulet/reader/block_scanner.py
+++ b/deltacat/storage/rivulet/reader/block_scanner.py
@@ -294,6 +294,7 @@ class ZipperBlockScanExecutor(Generic[MEMORY_FORMAT]):
                     sst_row,
                     self.metastore.file_store,
                     self.result_schema.get_merge_key(),
+                    self.result_schema,
                     self.file_readers,
                 )
                 file_reader.__enter__()
@@ -338,6 +339,7 @@ class BlockScanner:
                 block,
                 self.metastore.file_store,
                 schema.get_merge_key(),
+                schema,
                 self.file_readers,
             )
             with file_reader:

--- a/deltacat/storage/rivulet/reader/data_reader.py
+++ b/deltacat/storage/rivulet/reader/data_reader.py
@@ -15,6 +15,7 @@ from typing import (
 
 from deltacat.storage.rivulet.fs.file_store import FileStore
 from deltacat.storage.rivulet.metastore.sst import SSTableRow
+from deltacat.storage.rivulet.schema.schema import Schema
 
 FILE_FORMAT = TypeVar("FILE_FORMAT")
 MEMORY_FORMAT = TypeVar("MEMORY_FORMAT")
@@ -48,7 +49,7 @@ class FileReader(
 
     @abstractmethod
     def __init__(
-        self, sst_row: SSTableRow, file_store: FileStore, primary_key: str
+        self, sst_row: SSTableRow, file_store: FileStore, primary_key: str, schema: Schema
     ) -> None:
         """
         Required constructor (see: FileReaderRegistrar)

--- a/deltacat/storage/rivulet/reader/reader_type_registrar.py
+++ b/deltacat/storage/rivulet/reader/reader_type_registrar.py
@@ -3,6 +3,8 @@ from deltacat.storage.rivulet.metastore.sst import SSTableRow
 from deltacat.storage.rivulet.reader.data_reader import FileReader
 from typing import Type, Dict
 
+from deltacat.storage.rivulet.schema.schema import Schema
+
 
 class FileReaderRegistrar:
     """
@@ -58,6 +60,7 @@ class FileReaderRegistrar:
         sst_row: SSTableRow,
         file_store: FileStore,
         primary_key: str,
+        schema: Schema,
         reader_cache: Dict[str, FileReader] = None,
     ) -> FileReader:
         """
@@ -73,7 +76,7 @@ class FileReaderRegistrar:
             return reader_cache[extension]
 
         reader_class = FileReaderRegistrar.get_reader_class(sst_row.uri)
-        reader_instance = reader_class(sst_row, file_store, primary_key)
+        reader_instance = reader_class(sst_row, file_store, primary_key, schema)
 
         if reader_cache:
             reader_cache[extension] = reader_instance

--- a/deltacat/tests/storage/rivulet/reader/test_data_scan.py
+++ b/deltacat/tests/storage/rivulet/reader/test_data_scan.py
@@ -1,0 +1,101 @@
+import pytest
+from deltacat.tests.storage.rivulet.test_utils import (
+    verify_pyarrow_scan
+)
+import pyarrow as pa
+from deltacat.storage.rivulet import Schema, Field, Datatype
+from deltacat.storage.rivulet.dataset import Dataset
+
+@pytest.fixture
+def combined_schema():
+    return Schema(
+        fields=[
+            Field("id", Datatype.int64(), is_merge_key=True),
+            Field("name", Datatype.string()),
+            Field("age", Datatype.int32()),
+            Field("height", Datatype.int64()),
+            Field("gender", Datatype.string()),
+        ]
+    )
+
+@pytest.fixture
+def initial_schema():
+    return Schema(
+        fields=[
+            Field("id", Datatype.int32(), is_merge_key=True),
+            Field("name", Datatype.string()),
+            Field("age", Datatype.int32()),
+        ]
+    )
+
+@pytest.fixture
+def extended_schema():
+    return Schema(
+        fields=[
+            Field("id", Datatype.int64(), is_merge_key=True),
+            Field("height", Datatype.int64()),
+            Field("gender", Datatype.string()),
+        ]
+    )
+
+@pytest.fixture
+def sample_data():
+    return {
+        "id": [1, 2, 3],
+        "name": ["Alice", "Bob", "Charlie"],
+        "age": [25, 30, 35],
+    }
+
+@pytest.fixture
+def extended_data():
+    return {
+        "id": [1, 2, 3],
+        "height": [150, 160, 159],
+        "gender": ["male", "female", "male"],
+    }
+
+@pytest.fixture
+def combined_data(sample_data, extended_data):
+    data = sample_data.copy()
+    data.update(extended_data)
+    return data
+
+@pytest.fixture
+def parquet_data(tmp_path, sample_data):
+    parquet_path = tmp_path / "test.parquet"
+    table = pa.Table.from_pydict(sample_data)
+    pa.parquet.write_table(table, parquet_path)
+    return parquet_path
+
+@pytest.fixture
+def sample_dataset(parquet_data, tmp_path):
+    return Dataset.from_parquet(
+        name="test_dataset",
+        file_uri=str(parquet_data),
+        metadata_uri=tmp_path,
+        merge_keys="id",
+    )
+
+
+def test_end_to_end_scan_with_multiple_schemas(
+        sample_dataset, initial_schema, extended_schema, combined_schema, sample_data, extended_data, combined_data
+):
+    # Verify initial scan.
+    verify_pyarrow_scan(sample_dataset.scan().to_arrow(), initial_schema, sample_data)
+
+    # Add a new schema to the dataset
+    sample_dataset.add_schema(schema=extended_schema, schema_name="schema2")
+    new_data = [
+        {"id": 1, "height": 150, "gender": "male"},
+        {"id": 2, "height": 160, "gender": "female"},
+        {"id": 3, "height": 159, "gender": "male"},
+    ]
+    writer = sample_dataset.writer(schema_name="schema2")
+    writer.write(new_data)
+    writer.flush()
+
+    # Verify scan with the extended schema retrieves only extended datfa
+    verify_pyarrow_scan(sample_dataset.scan(schema_name="schema2").to_arrow(), extended_schema, extended_data)
+
+    # Verify a combined scan retrieves data matching the combined schema
+    verify_pyarrow_scan(sample_dataset.scan().to_arrow(), combined_schema, combined_data)


### PR DESCRIPTION
## Summary

Found an issue with schema fields not being respected during dataset scan. If new schemas are created and explicitly mentioned in a DataScan the returned fields should be limited to that of the schema.

## Changes

Updated the `FileReader implementations to select columns during batch read. This functionality is already provided by pyarrow through methods like batch.select which have an optional column field.

## Testing

- `make test` to run existing tests. 
- verified changes with manual testing of DataScan ensured outputs are as expected
- added a end to end test for scan with multiple schemas to highlight the fix

## Checklist

- [x] Unit tests covering the changes have been added
  - [x] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed
