### PR TITLE
Fix linter and run linter to apply reformatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,9 +21,10 @@ repos:
     - id: check-github-actions
     - id: check-github-workflows
 -   repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.2
+    rev: v2.5.0
     hooks:
     -   id: pycln
+        args: [--all]
 -   repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:

--- a/deltacat/storage/README.md
+++ b/deltacat/storage/README.md
@@ -71,9 +71,9 @@ a **Name Resolution Directory** to map the object's mutable name or alias back t
 
 **Name Mapping File**
 
-The format of the **Name Mapping File** file is: 
+The format of the **Name Mapping File** file is:
 `<revision_number_padded_20_digits>_<txn_operation_type>_<txn_id>.<object_id>`
-Where `object_id` is the name of the associated object's **Immutable ID** directory. 
+Where `object_id` is the name of the associated object's **Immutable ID** directory.
 Note that (except **Immutable ID**) this is the same format used by **Metadata Revision Files**, and the same process is employed to `create`, `update`, and `delete` name mappings.
 
 ### Transaction Log Directory

--- a/deltacat/storage/rivulet/dataset.py
+++ b/deltacat/storage/rivulet/dataset.py
@@ -233,7 +233,9 @@ class Dataset:
         dataset_schema = Schema.from_pyarrow(pyarrow_schema, merge_keys)
 
         # TODO the file URI never gets stored/saved, do we need to do so?
-        dataset = cls(dataset_name=name, metadata_uri=metadata_uri, schema=dataset_schema)
+        dataset = cls(
+            dataset_name=name, metadata_uri=metadata_uri, schema=dataset_schema
+        )
 
         # TODO: avoid write! associate fields with their source data.
         writer = dataset.writer()
@@ -246,12 +248,12 @@ class Dataset:
 
     @classmethod
     def from_json(
-            cls,
-            name: str,
-            file_uri: str,
-            merge_keys: str | Iterable[str],
-            metadata_uri: Optional[str] = None,
-            schema_mode: str = "union",
+        cls,
+        name: str,
+        file_uri: str,
+        merge_keys: str | Iterable[str],
+        metadata_uri: Optional[str] = None,
+        schema_mode: str = "union",
     ) -> "Dataset":
         """
         Create a Dataset from a single JSON file.
@@ -279,7 +281,9 @@ class Dataset:
         dataset_schema = Schema.from_pyarrow(pyarrow_schema, merge_keys)
 
         # Create the Dataset instance
-        dataset = cls(dataset_name=name, metadata_uri=metadata_uri, schema=dataset_schema)
+        dataset = cls(
+            dataset_name=name, metadata_uri=metadata_uri, schema=dataset_schema
+        )
 
         writer = dataset.writer()
         writer.write(pyarrow_table.to_batches())
@@ -289,12 +293,12 @@ class Dataset:
 
     @classmethod
     def from_csv(
-            cls,
-            name: str,
-            file_uri: str,
-            merge_keys: str | Iterable[str],
-            metadata_uri: Optional[str] = None,
-            schema_mode: str = "union",
+        cls,
+        name: str,
+        file_uri: str,
+        merge_keys: str | Iterable[str],
+        metadata_uri: Optional[str] = None,
+        schema_mode: str = "union",
     ) -> "Dataset":
         """
         Create a Dataset from a single JSON file.
@@ -322,7 +326,9 @@ class Dataset:
         dataset_schema = Schema.from_pyarrow(pyarrow_schema, merge_keys)
 
         # Create the Dataset instance
-        dataset = cls(dataset_name=name, metadata_uri=metadata_uri, schema=dataset_schema)
+        dataset = cls(
+            dataset_name=name, metadata_uri=metadata_uri, schema=dataset_schema
+        )
 
         writer = dataset.writer()
         writer.write(table.to_batches())
@@ -334,9 +340,14 @@ class Dataset:
         """Prints the first `num_records` records in the dataset."""
         records = self.scan().to_pydict()
         for record in itertools.islice(records, num_records):
-                print(record)
+            print(record)
 
-    def export(self, file_uri: str, format: str = "parquet", query: QueryExpression=QueryExpression()) -> None:
+    def export(
+        self,
+        file_uri: str,
+        format: str = "parquet",
+        query: QueryExpression = QueryExpression(),
+    ) -> None:
         """Export the dataset to a file.
 
         Args:

--- a/deltacat/storage/rivulet/feather/file_reader.py
+++ b/deltacat/storage/rivulet/feather/file_reader.py
@@ -24,7 +24,13 @@ class FeatherFileReader(FileReader[RecordBatchRowIndex]):
     TODO can consider abstracting code between this and ParquetFileReader
     """
 
-    def __init__(self, sst_row: SSTableRow, file_store: FileStore, primary_key: str, schema: Schema):
+    def __init__(
+        self,
+        sst_row: SSTableRow,
+        file_store: FileStore,
+        primary_key: str,
+        schema: Schema,
+    ):
         self.sst_row = sst_row
         self.input = file_store.new_input_file(self.sst_row.uri)
 
@@ -120,7 +126,11 @@ class FeatherFileReader(FileReader[RecordBatchRowIndex]):
             self._pk_col = self._curr_batch[self.key]
             # Filter the batch to only include fields in the schema
             # Pyarrow select will throw a ValueError if the field is not in the schema
-            fields = [field for field in self.schema.keys() if field in self._curr_batch.schema.names]
+            fields = [
+                field
+                for field in self.schema.keys()
+                if field in self._curr_batch.schema.names
+            ]
             self._curr_batch = self._curr_batch.select(fields)
         except ValueError:
             raise StopIteration(f"Ended iteration at batch {self._curr_batch_index}")

--- a/deltacat/storage/rivulet/metastore/sst_interval_tree.py
+++ b/deltacat/storage/rivulet/metastore/sst_interval_tree.py
@@ -207,8 +207,14 @@ class BlockIntervalTree:
                 f"min_key {min_key} cannot be greater than max_key {max_key}"
             )
 
-        min_key_idx = max(0, bisect_left(key_boundaries, min_key) - 1) if min_key is not None else None
-        max_key_idx = bisect_right(key_boundaries, max_key) + 1 if max_key is not None else None
+        min_key_idx = (
+            max(0, bisect_left(key_boundaries, min_key) - 1)
+            if min_key is not None
+            else None
+        )
+        max_key_idx = (
+            bisect_right(key_boundaries, max_key) + 1 if max_key is not None else None
+        )
         boundary_table = key_boundaries[min_key_idx:max_key_idx]
 
         for lower_bound, upper_bound in pairwise(boundary_table):

--- a/deltacat/storage/rivulet/reader/data_reader.py
+++ b/deltacat/storage/rivulet/reader/data_reader.py
@@ -49,7 +49,11 @@ class FileReader(
 
     @abstractmethod
     def __init__(
-        self, sst_row: SSTableRow, file_store: FileStore, primary_key: str, schema: Schema
+        self,
+        sst_row: SSTableRow,
+        file_store: FileStore,
+        primary_key: str,
+        schema: Schema,
     ) -> None:
         """
         Required constructor (see: FileReaderRegistrar)

--- a/deltacat/tests/storage/rivulet/reader/test_data_scan.py
+++ b/deltacat/tests/storage/rivulet/reader/test_data_scan.py
@@ -1,10 +1,9 @@
 import pytest
-from deltacat.tests.storage.rivulet.test_utils import (
-    verify_pyarrow_scan
-)
+from deltacat.tests.storage.rivulet.test_utils import verify_pyarrow_scan
 import pyarrow as pa
 from deltacat.storage.rivulet import Schema, Field, Datatype
 from deltacat.storage.rivulet.dataset import Dataset
+
 
 @pytest.fixture
 def combined_schema():
@@ -18,6 +17,7 @@ def combined_schema():
         ]
     )
 
+
 @pytest.fixture
 def initial_schema():
     return Schema(
@@ -27,6 +27,7 @@ def initial_schema():
             Field("age", Datatype.int32()),
         ]
     )
+
 
 @pytest.fixture
 def extended_schema():
@@ -38,6 +39,7 @@ def extended_schema():
         ]
     )
 
+
 @pytest.fixture
 def sample_data():
     return {
@@ -45,6 +47,7 @@ def sample_data():
         "name": ["Alice", "Bob", "Charlie"],
         "age": [25, 30, 35],
     }
+
 
 @pytest.fixture
 def extended_data():
@@ -54,11 +57,13 @@ def extended_data():
         "gender": ["male", "female", "male"],
     }
 
+
 @pytest.fixture
 def combined_data(sample_data, extended_data):
     data = sample_data.copy()
     data.update(extended_data)
     return data
+
 
 @pytest.fixture
 def parquet_data(tmp_path, sample_data):
@@ -66,6 +71,7 @@ def parquet_data(tmp_path, sample_data):
     table = pa.Table.from_pydict(sample_data)
     pa.parquet.write_table(table, parquet_path)
     return parquet_path
+
 
 @pytest.fixture
 def sample_dataset(parquet_data, tmp_path):
@@ -78,7 +84,13 @@ def sample_dataset(parquet_data, tmp_path):
 
 
 def test_end_to_end_scan_with_multiple_schemas(
-        sample_dataset, initial_schema, extended_schema, combined_schema, sample_data, extended_data, combined_data
+    sample_dataset,
+    initial_schema,
+    extended_schema,
+    combined_schema,
+    sample_data,
+    extended_data,
+    combined_data,
 ):
     # Verify initial scan.
     verify_pyarrow_scan(sample_dataset.scan().to_arrow(), initial_schema, sample_data)
@@ -95,7 +107,13 @@ def test_end_to_end_scan_with_multiple_schemas(
     writer.flush()
 
     # Verify scan with the extended schema retrieves only extended datfa
-    verify_pyarrow_scan(sample_dataset.scan(schema_name="schema2").to_arrow(), extended_schema, extended_data)
+    verify_pyarrow_scan(
+        sample_dataset.scan(schema_name="schema2").to_arrow(),
+        extended_schema,
+        extended_data,
+    )
 
     # Verify a combined scan retrieves data matching the combined schema
-    verify_pyarrow_scan(sample_dataset.scan().to_arrow(), combined_schema, combined_data)
+    verify_pyarrow_scan(
+        sample_dataset.scan().to_arrow(), combined_schema, combined_data
+    )

--- a/deltacat/tests/storage/rivulet/test_sst_interval_tree.py
+++ b/deltacat/tests/storage/rivulet/test_sst_interval_tree.py
@@ -173,9 +173,8 @@ def test_build_sst_with_bounds(
     expected = _build_ordered_block_groups(expected_block_groups[0:1])
     assert expected == block_groups_filtered
 
-def test_build_sst_with_non_zero_min_key_matching_global_min_key(
-        manifest_context1
-):
+
+def test_build_sst_with_non_zero_min_key_matching_global_min_key(manifest_context1):
     # Using a non-0 value since 0 evaluates to False
     min_key = 1
     max_key = 95
@@ -185,9 +184,19 @@ def test_build_sst_with_non_zero_min_key_matching_global_min_key(
     t.add_sst_table(SSTable([sst_row], min_key, max_key), manifest_context1)
 
     block_groups_filtered = t.get_sorted_block_groups(min_key, min_key + 1)
-    expected = _build_ordered_block_groups([
-        BlockGroup(min_key, max_key, {manifest_context1.schema: frozenset([Block(sst_row, manifest_context1)])})
-    ])
+    expected = _build_ordered_block_groups(
+        [
+            BlockGroup(
+                min_key,
+                max_key,
+                {
+                    manifest_context1.schema: frozenset(
+                        [Block(sst_row, manifest_context1)]
+                    )
+                },
+            )
+        ]
+    )
     assert expected == block_groups_filtered
 
 

--- a/deltacat/tests/storage/rivulet/test_utils.py
+++ b/deltacat/tests/storage/rivulet/test_utils.py
@@ -8,7 +8,6 @@ from deltacat.storage.rivulet.reader.query_expression import QueryExpression
 from deltacat.storage.rivulet.writer.dataset_writer import DatasetWriter
 
 from deltacat.storage.rivulet.mvp.Table import MvpTable, MvpRow
-from deltacat.storage.rivulet.reader.data_scan import DataScan
 from deltacat.storage.rivulet import Schema
 from typing import Dict, List, Generator, Set
 
@@ -96,7 +95,12 @@ def create_dataset_for_method(temp_dir: str):
         dataset_name=f"dataset-${caller_frame.function}", metadata_uri=dataset_dir
     )
 
-def verify_pyarrow_scan(scan_result: Generator[RecordBatch, None, None], expected_schema: Schema, expected_data: dict):
+
+def verify_pyarrow_scan(
+    scan_result: Generator[RecordBatch, None, None],
+    expected_schema: Schema,
+    expected_data: dict,
+):
     record_batches = list(scan_result)
     assert record_batches, "Scan should return at least one record batch."
 
@@ -104,12 +108,14 @@ def verify_pyarrow_scan(scan_result: Generator[RecordBatch, None, None], expecte
 
     expected_fields = {field.name for field in expected_schema.values()}
     scanned_fields = set(combined_table.schema.names)
-    assert scanned_fields == expected_fields, (
-        f"Scanned fields {scanned_fields} do not match expected fields {expected_fields}."
-    )
+    assert (
+        scanned_fields == expected_fields
+    ), f"Scanned fields {scanned_fields} do not match expected fields {expected_fields}."
 
     for field in expected_fields:
-        assert field in combined_table.column_names, f"Field '{field}' is missing in the scan result."
-        assert combined_table[field].to_pylist() == expected_data[field], (
-            f"Field '{field}' data does not match expected values."
-        )
+        assert (
+            field in combined_table.column_names
+        ), f"Field '{field}' is missing in the scan result."
+        assert (
+            combined_table[field].to_pylist() == expected_data[field]
+        ), f"Field '{field}' data does not match expected values."

--- a/deltacat/tests/test_utils/message_pack_utils.py
+++ b/deltacat/tests/test_utils/message_pack_utils.py
@@ -4,31 +4,34 @@ import json
 import os
 import shutil
 
+
 def _convert_bytes_to_base64_str(obj):
-        if isinstance(obj, dict):
-            for key, value in obj.items():
-                if isinstance(value, bytes):
-                    obj[key] = base64.b64encode(value).decode('utf-8')
-                elif isinstance(value, list):
-                    _convert_bytes_to_base64_str(value)
-                elif isinstance(value,dict):
-                    _convert_bytes_to_base64_str(value)
-        elif isinstance(obj, list):
-            for i, item in enumerate(obj):
-                if isinstance(item, bytes):
-                    obj[i] = base64.b64encode(item).decode('utf-8')
-                elif isinstance(item, (dict, list)):
-                    _convert_bytes_to_base64_str(item)
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if isinstance(value, bytes):
+                obj[key] = base64.b64encode(value).decode("utf-8")
+            elif isinstance(value, list):
+                _convert_bytes_to_base64_str(value)
+            elif isinstance(value, dict):
+                _convert_bytes_to_base64_str(value)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            if isinstance(item, bytes):
+                obj[i] = base64.b64encode(item).decode("utf-8")
+            elif isinstance(item, (dict, list)):
+                _convert_bytes_to_base64_str(item)
+
 
 def copy_and_convert(src_dir, dst_dir=None):
-    '''
+    """
     Helper function for copying a metastore recursively and converting all messagepack files to json
     This can be used manually to more easily introspect metastore metadata
-    '''
+    """
     if dst_dir is None:
         from tempfile import mkdtemp
+
         dst_dir = mkdtemp()
-        print(f'destination is: {dst_dir}')
+        print(f"destination is: {dst_dir}")
     if not os.path.exists(dst_dir):
         os.makedirs(dst_dir)
 
@@ -39,12 +42,12 @@ def copy_and_convert(src_dir, dst_dir=None):
         if os.path.isdir(src_path):
             copy_and_convert(src_path, dst_path)
         else:
-            if item.endswith('.mpk'):
-                with open(src_path, 'rb') as f:
+            if item.endswith(".mpk"):
+                with open(src_path, "rb") as f:
                     data = msgpack.unpackb(f.read(), raw=False)
                     _convert_bytes_to_base64_str(data)
-                dst_path = dst_path[:-4] + '.json'
-                with open(dst_path, 'w') as f:
+                dst_path = dst_path[:-4] + ".json"
+                with open(dst_path, "w") as f:
                     json.dump(data, f)
             else:
                 shutil.copy2(src_path, dst_path)

--- a/deltacat/utils/export.py
+++ b/deltacat/utils/export.py
@@ -6,21 +6,25 @@ from typing import Callable, Dict
 
 from deltacat.storage.rivulet.reader.query_expression import QueryExpression
 
-def export_parquet(dataset, file_uri: str, query: QueryExpression=QueryExpression()):
+
+def export_parquet(dataset, file_uri: str, query: QueryExpression = QueryExpression()):
     records = dataset.scan(query).to_arrow()
     table = pa.Table.from_batches(records)
     pyarrow.parquet.write_table(table, file_uri)
 
-def export_feather(dataset, file_uri: str, query: QueryExpression=QueryExpression()):
+
+def export_feather(dataset, file_uri: str, query: QueryExpression = QueryExpression()):
     records = dataset.scan(query).to_arrow()
     table = pa.Table.from_batches(records)
     pyarrow.feather.write_feather(table, file_uri)
 
-def export_json(dataset, file_uri: str, query: QueryExpression=QueryExpression()):
+
+def export_json(dataset, file_uri: str, query: QueryExpression = QueryExpression()):
     with open(file_uri, "w") as f:
         for batch in dataset.scan(query).to_pydict():
             json.dump(batch, f, indent=2)
             f.write("\n")
+
 
 def export_dataset(dataset, file_uri: str, format: str = "parquet", query=None):
     """
@@ -42,7 +46,9 @@ def export_dataset(dataset, file_uri: str, format: str = "parquet", query=None):
     }
 
     if format not in export_handlers:
-        raise ValueError(f"Unsupported format: {format}. Supported formats are {list(export_handlers.keys())}")
+        raise ValueError(
+            f"Unsupported format: {format}. Supported formats are {list(export_handlers.keys())}"
+        )
 
     export_handlers[format](dataset, file_uri, query or QueryExpression())
 


### PR DESCRIPTION
## Summary

Pycln was failing due to a missing pyproject.toml file. After upgrading to the most recent release, it does not fail. Ran linter an applied formatting changes in this CR