### PR TITLE
Allow overriding content encoding

### DIFF
--- a/deltacat/utils/pyarrow.py
+++ b/deltacat/utils/pyarrow.py
@@ -47,6 +47,7 @@ logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 RAISE_ON_EMPTY_CSV_KWARG = "raise_on_empty_csv"
 READER_TYPE_KWARG = "reader_type"
+OVERRIDE_CONTENT_ENCODING_FOR_PARQUET_KWARG = "override_content_encoding_for_parquet"
 
 """
 By default, round decimal values using half_to_even round mode when
@@ -542,6 +543,15 @@ def s3_file_to_table(
 
     if pa_read_func_kwargs_provider is not None:
         kwargs = pa_read_func_kwargs_provider(content_type, kwargs)
+
+    if OVERRIDE_CONTENT_ENCODING_FOR_PARQUET_KWARG in kwargs:
+        new_content_encoding = kwargs.pop(OVERRIDE_CONTENT_ENCODING_FOR_PARQUET_KWARG)
+        if content_type == ContentType.PARQUET.value:
+            logger.debug(
+                f"Overriding {s3_url} content encoding from {content_encoding} "
+                f"to {new_content_encoding}"
+            )
+            content_encoding = new_content_encoding
 
     if (
         content_type == ContentType.PARQUET.value


### PR DESCRIPTION
## Summary

This change adds a new kwarg that can be used to override the content encoding in the metadata. This applies to every parquet file. The reason we are adding this is to gradually dial up all parquet files to read via identity encoding. 

## Rationale

The internal catalog metadata incorrectly sets content type of parquet files as gzip even though full file isn't gzip compressed.

## Changes

Add a new kwarg which can be used to override the content encoding for parquet

## Impact

Unblocks compaction of new tables.

## Testing

Functional tests

## Regression Risk

Very low as it doesn't affect the current codepath unless the kwarg is set. 

## Checklist

- [x] Unit tests covering the changes have been added
  - [x] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
