### PR TITLE
Initial Test Setup for Converter using Spark and Pyiceberg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,14 @@ test-integration: install
 	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
 	venv/bin/python -m pytest deltacat/tests/integ -v -m integration
 
+test-converter:
+	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml kill
+	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml rm -f
+	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml up -d
+	sleep 3
+	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
+	venv/bin/python -m pytest deltacat/tests/compute/converter -vv
+
 test-integration-rebuild:
 	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml kill
 	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml rm -f

--- a/deltacat/tests/compute/converter/conftest.py
+++ b/deltacat/tests/compute/converter/conftest.py
@@ -1,0 +1,72 @@
+import pytest
+from pyspark.sql import SparkSession
+import os
+from pyiceberg.catalog import Catalog, load_catalog
+
+
+@pytest.fixture
+def spark():
+    import importlib.metadata
+
+    spark_version = ".".join(importlib.metadata.version("pyspark").split(".")[:2])
+    scala_version = "2.12"
+    iceberg_version = "1.6.0"
+
+    os.environ["PYSPARK_SUBMIT_ARGS"] = (
+        f"--packages org.apache.iceberg:iceberg-spark-runtime-{spark_version}_{scala_version}:{iceberg_version},"
+        f"org.apache.iceberg:iceberg-aws-bundle:{iceberg_version} pyspark-shell"
+    )
+    os.environ["AWS_REGION"] = "us-east-1"
+    os.environ["AWS_ACCESS_KEY_ID"] = "admin"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "password"
+
+    spark = (
+        SparkSession.builder.appName("PyIceberg integration test")
+        .config("spark.sql.session.timeZone", "UTC")
+        .config(
+            "spark.sql.extensions",
+            "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+        )
+        .config(
+            "spark.sql.catalog.integration", "org.apache.iceberg.spark.SparkCatalog"
+        )
+        .config(
+            "spark.sql.catalog.integration.catalog-impl",
+            "org.apache.iceberg.rest.RESTCatalog",
+        )
+        .config("spark.sql.catalog.integration.cache-enabled", "false")
+        .config("spark.sql.catalog.integration.uri", "http://localhost:8181")
+        .config(
+            "spark.sql.catalog.integration.io-impl",
+            "org.apache.iceberg.aws.s3.S3FileIO",
+        )
+        .config("spark.sql.catalog.integration.warehouse", "s3://warehouse/wh/")
+        .config("spark.sql.catalog.integration.s3.endpoint", "http://localhost:9000")
+        .config("spark.sql.catalog.integration.s3.path-style-access", "true")
+        .config("spark.sql.defaultCatalog", "integration")
+        .config("spark.sql.catalog.hive", "org.apache.iceberg.spark.SparkCatalog")
+        .config("spark.sql.catalog.hive.type", "hive")
+        .config("spark.sql.catalog.hive.uri", "http://localhost:9083")
+        .config("spark.sql.catalog.hive.io-impl", "org.apache.iceberg.aws.s3.S3FileIO")
+        .config("spark.sql.catalog.hive.warehouse", "s3://warehouse/hive/")
+        .config("spark.sql.catalog.hive.s3.endpoint", "http://localhost:9000")
+        .config("spark.sql.catalog.hive.s3.path-style-access", "true")
+        .config("spark.sql.execution.arrow.pyspark.enabled", "true")
+        .getOrCreate()
+    )
+
+    return spark
+
+
+@pytest.fixture(scope="session")
+def session_catalog() -> Catalog:
+    return load_catalog(
+        "local",
+        **{
+            "type": "rest",
+            "uri": "http://localhost:8181",
+            "s3.endpoint": "http://localhost:9000",
+            "s3.access-key-id": "admin",
+            "s3.secret-access-key": "password",
+        },
+    )

--- a/deltacat/tests/compute/converter/test_convert_session.py
+++ b/deltacat/tests/compute/converter/test_convert_session.py
@@ -1,0 +1,115 @@
+import pytest
+from typing import List
+from pyiceberg.catalog.rest import RestCatalog
+from pyiceberg.expressions import EqualTo
+
+
+def run_spark_commands(spark, sqls: List[str]) -> None:
+    for sql in sqls:
+        spark.sql(sql)
+
+
+@pytest.mark.integration
+def test_pyiceberg_spark_setup_sanity(spark, session_catalog: RestCatalog) -> None:
+    """
+    This Test was copied over from Pyiceberg integ test: https://github.com/apache/iceberg-python/blob/main/tests/integration/test_deletes.py#L62
+    First sanity check to ensure all integration with Pyiceberg and Spark are working as expected.
+    """
+    identifier = "default.table_partitioned_delete"
+
+    run_spark_commands(
+        spark,
+        [
+            f"DROP TABLE IF EXISTS {identifier}",
+            f"""
+            CREATE TABLE {identifier} (
+                number_partitioned  int,
+                number              int
+            )
+            USING iceberg
+            PARTITIONED BY (number_partitioned)
+            TBLPROPERTIES('format-version' = 2)
+        """,
+            f"""
+            INSERT INTO {identifier} VALUES (10, 20), (10, 30)
+        """,
+            f"""
+            INSERT INTO {identifier} VALUES (11, 20), (11, 30)
+        """,
+        ],
+    )
+
+    tbl = session_catalog.load_table(identifier)
+    tbl.delete(EqualTo("number_partitioned", 10))
+
+    # No overwrite operation
+    assert [snapshot.summary.operation.value for snapshot in tbl.snapshots()] == [
+        "append",
+        "append",
+        "delete",
+    ]
+    assert tbl.scan().to_arrow().to_pydict() == {
+        "number_partitioned": [11, 11],
+        "number": [20, 30],
+    }
+
+
+@pytest.mark.integration
+def test_spark_position_delete_production_sanity(
+    spark, session_catalog: RestCatalog
+) -> None:
+    """
+    Sanity test to ensure Spark position delete production is successful with `merge-on-read` spec V2.
+    Table has two partition levels. 1. BucketTransform on primary key
+    """
+    identifier = "default.table_spark_position_delete_production_sanity"
+
+    run_spark_commands(
+        spark,
+        [
+            f"DROP TABLE IF EXISTS {identifier}",
+            f"""
+            CREATE TABLE {identifier} (
+                number_partitioned INT,
+                primary_key STRING
+            )
+            USING iceberg
+            PARTITIONED BY (bucket(3, primary_key), number_partitioned)
+            TBLPROPERTIES(
+                'format-version' = 2,
+                'write.delete.mode'='merge-on-read',
+                'write.update.mode'='merge-on-read',
+                'write.merge.mode'='merge-on-read'
+            )
+            """,
+            f"""
+            INSERT INTO {identifier} VALUES (0, 'pk1'), (0, 'pk2'), (0, 'pk3')
+            """,
+            f"""
+            INSERT INTO {identifier} VALUES (1, 'pk1'), (1, 'pk2'), (1, 'pk3')
+            """,
+        ],
+    )
+
+    run_spark_commands(
+        spark,
+        [
+            f"""
+                DELETE FROM {identifier} WHERE primary_key in ("pk1")
+            """,
+        ],
+    )
+
+    tbl = session_catalog.load_table(identifier)
+    tbl.refresh()
+
+    assert [snapshot.summary.operation.value for snapshot in tbl.snapshots()] == [
+        "append",
+        "append",
+        "delete",
+    ]
+
+    assert tbl.scan().to_arrow().to_pydict() == {
+        "number_partitioned": [1, 1, 0, 0],
+        "primary_key": ["pk2", "pk3", "pk2", "pk3"],
+    }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ memray == 1.6.0; platform_system != "Windows" and sys_platform != "darwin" and p
 moto == 4.1.12
 Pillow == 11.0.0
 pre-commit == 2.20.0
+pyspark == 3.5.3
 pytest == 7.2.0
 pytest-benchmark == 4.0.0
 pytest-cov == 4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pyarrow == 17.0.0
 #pyiceberg[glue] @ git+https://github.com/apache/iceberg-python
 pyiceberg[glue] >= 0.6.0
 pymemcache == 4.0.0
+pyspark == 3.5.3
 ray[default] >= 2.20.0,<2.31.0
 redis == 4.6.0
 s3fs == 2024.5.0

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setuptools.setup(
         "typing-extensions == 4.6.1",
         "redis == 4.6.0",
         "schedule == 1.2.0",
+        "pyspark == 3.5.3",
     ],
     setup_requires=["wheel"],
     package_data={


### PR DESCRIPTION
## Summary
This PR adds Initial test setup for converter using Spark and Pyiceberg. It reuse the MakeFile and docker setup in DeltaCAT. 

## Testing

make test-converter

## Additional Notes

Will follow up with test cases that use Pyiceberg to generate equality deletes and Spark to read the position deletes we produced to mimic the end-to-end converter workflow and validate the results. 
For read, since Spark can't produce equality deletes currently, we should explore to generate equality deletes using Pyiceberg directly. 
For write, this test setup could also validate the position delete converter write in sense of position delete file link, naming, table properties convertion, etc.