### PR TITLE
chore: support json metafile format for debugging

### DIFF
--- a/deltacat/constants.py
+++ b/deltacat/constants.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+
 from deltacat.utils.common import env_string, env_bool
 
 # Environment variables
@@ -37,6 +38,9 @@ DELTACAT_LOGGER_USE_SINGLE_HANDLER = env_bool(
     False,
 )
 
+DELTACAT_METAFILE_FORMAT = env_string("DELTACAT_METAFILE_FORMAT", "msgpack")
+
+
 # Byte Units
 BYTES_PER_KIBIBYTE = 2**10
 BYTES_PER_MEBIBYTE = 2**20
@@ -72,7 +76,7 @@ NULL_SIZE_BYTES = 4
 
 # Metastore Constants
 REVISION_DIR_NAME: str = "rev"
-METAFILE_EXT = ".mpk"
+METAFILE_EXT = ".json" if DELTACAT_METAFILE_FORMAT == "json" else ".mpk"
 TXN_DIR_NAME: str = "txn"
 RUNNING_TXN_DIR_NAME: str = "running"
 FAILED_TXN_DIR_NAME: str = "failed"


### PR DESCRIPTION
## Summary

Add environment variable DELTACAT_METAFILE_FORMAT to support json for debugging.


## Testing

- `make test` for existing tests.
-  created a rivulet dataset and verified metafiles were written to json

## Regression Risk

If this is a bugfix, assess the risk of regression caused by this fix and steps taken to mitigate it.

## Checklist

- [ ] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed
