### PR TITLE
Partial DeltaCAT Native Storage Implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,6 @@ benchmark-aws: install
 
 benchmark: install
 	pytest -m benchmark deltacat/benchmarking
+
+publish: test test-integration rebuild
+	twine upload dist/*

--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -53,7 +53,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.27"
+__version__ = "2.0"
 
 
 __all__ = [

--- a/deltacat/storage/__init__.py
+++ b/deltacat/storage/__init__.py
@@ -29,6 +29,7 @@ from deltacat.storage.model.namespace import (
 from deltacat.storage.model.partition import (
     Partition,
     PartitionLocator,
+    PartitionLocatorAlias,
     PartitionKey,
     PartitionScheme,
     PartitionSchemeList,
@@ -43,7 +44,11 @@ from deltacat.storage.model.schema import (
     Schema,
     SchemaList,
 )
-from deltacat.storage.model.stream import Stream, StreamLocator
+from deltacat.storage.model.stream import (
+    Stream,
+    StreamLocator,
+    StreamLocatorAlias,
+)
 from deltacat.storage.model.table import (
     Table,
     TableLocator,
@@ -132,6 +137,7 @@ __all__ = [
     "Partition",
     "PartitionKey",
     "PartitionLocator",
+    "PartitionLocatorAlias",
     "PartitionScheme",
     "PartitionSchemeList",
     "PartitionValues",
@@ -145,6 +151,7 @@ __all__ = [
     "Stream",
     "StreamFormat",
     "StreamLocator",
+    "StreamLocatorAlias",
     "Table",
     "TableLocator",
     "TableProperties",

--- a/deltacat/storage/interface.py
+++ b/deltacat/storage/interface.py
@@ -343,23 +343,31 @@ def stage_stream(
     namespace: str,
     table_name: str,
     table_version: Optional[str] = None,
+    stream_format: StreamFormat = StreamFormat.DELTACAT,
     *args,
     **kwargs,
 ) -> Stream:
     """
     Stages a new delta stream for the given table version. Resolves to the
-    latest active table version if no table version is given. Returns the
-    staged stream. Raises an error if the table version does not exist.
+    latest active table version if no table version is given. Resolves to the
+    DeltaCAT stream format if no stream format is given. If this stream
+    will replace another stream with the same format and scheme, then it will
+    have its previous stream ID set to the ID of the stream being replaced.
+    Returns the staged stream. Raises an error if the table version does not
+    exist.
     """
     raise NotImplementedError("stage_stream not implemented")
 
 
-def commit_stream(stream: Stream, *args, **kwargs) -> Stream:
+def commit_stream(
+    stream: Stream,
+    *args,
+    **kwargs,
+) -> Stream:
     """
     Registers a delta stream with a target table version, replacing any
-    previous stream registered for the same table version. If the stream
-    format is not set prior to commit, then it is defaulted to the DeltaCAT
-    stream format. Returns the committed stream.
+    previous stream registered for the same table version. Returns the
+    committed stream.
     """
     raise NotImplementedError("commit_stream not implemented")
 
@@ -436,20 +444,32 @@ def commit_partition(
 
 
 def delete_partition(
-    namespace: str,
-    table_name: str,
-    table_version: Optional[str] = None,
+    stream_locator: StreamLocator,
     partition_values: Optional[PartitionValues] = None,
+    partition_scheme_id: Optional[str] = None,
     *args,
     **kwargs,
 ) -> None:
     """
-    Deletes the given partition from the specified table version. Resolves to
-    the latest active table version if no table version is given. Partition
+    Deletes the given partition from the specified stream. Partition
     values should not be specified for unpartitioned tables. Raises an error
-    if the table version or partition does not exist.
+    if the partition does not exist.
     """
     raise NotImplementedError("delete_partition not implemented")
+
+
+def get_staged_partition(
+    stream_locator: StreamLocator,
+    partition_id: str,
+    *args,
+    **kwargs,
+) -> Optional[Partition]:
+    """
+    Gets the staged partition for the given stream locator and partition ID.
+    Returns None if the partition does not exist. Raises an error if the
+    given stream locator does not exist.
+    """
+    raise NotImplementedError("get_staged_partition not implemented")
 
 
 def get_partition(
@@ -462,7 +482,9 @@ def get_partition(
     Gets the most recently committed partition for the given stream locator and
     partition key values. Returns None if no partition has been committed for
     the given table version and/or partition key values. Partition values
-    should not be specified for unpartitioned tables.
+    should not be specified for unpartitioned tables. Partition scheme ID
+    resolves to the table version's current partition scheme by default.
+    Raises an error if the given stream locator does not exist.
     """
     raise NotImplementedError("get_partition not implemented")
 

--- a/deltacat/storage/interface.py
+++ b/deltacat/storage/interface.py
@@ -21,7 +21,9 @@ from deltacat.storage import (
     Schema,
     SortScheme,
     Stream,
+    StreamFormat,
     StreamLocator,
+    StreamLocatorAlias,
     Table,
     TableProperties,
     TableVersion,
@@ -234,7 +236,7 @@ def get_delta_manifest(
 ) -> Manifest:
     """
     Get the manifest associated with the given delta or delta locator. This
-    always retrieves the authoritative remote copy of the delta manifest, and
+    always retrieves the authoritative durable copy of the delta manifest, and
     never the local manifest defined for any input delta.
     """
     raise NotImplementedError("get_delta_manifest not implemented")
@@ -255,7 +257,7 @@ def create_namespace(
 
 def update_namespace(
     namespace: str,
-    properties: NamespaceProperties = None,
+    properties: Optional[NamespaceProperties] = None,
     new_namespace: Optional[str] = None,
     *args,
     **kwargs,
@@ -320,6 +322,8 @@ def update_table_version(
     schema: Optional[Schema] = None,
     description: Optional[str] = None,
     properties: Optional[TableVersionProperties] = None,
+    partition_scheme: Optional[PartitionScheme] = None,
+    sort_keys: Optional[SortScheme] = None,
     *args,
     **kwargs,
 ) -> None:
@@ -353,8 +357,9 @@ def stage_stream(
 def commit_stream(stream: Stream, *args, **kwargs) -> Stream:
     """
     Registers a delta stream with a target table version, replacing any
-    previous stream registered for the same table version. Returns the
-    committed stream.
+    previous stream registered for the same table version. If the stream
+    format is not set prior to commit, then it is defaulted to the DeltaCAT
+    stream format. Returns the committed stream.
     """
     raise NotImplementedError("commit_stream not implemented")
 
@@ -363,12 +368,14 @@ def delete_stream(
     namespace: str,
     table_name: str,
     table_version: Optional[str] = None,
+    stream_format: StreamFormat = StreamFormat.DELTACAT,
     *args,
     **kwargs,
 ) -> None:
     """
     Deletes the delta stream currently registered with the given table version.
     Resolves to the latest active table version if no table version is given.
+    Resolves to the deltacat stream format if no stream format is given.
     Raises an error if the table version does not exist.
     """
     raise NotImplementedError("delete_stream not implemented")
@@ -378,13 +385,15 @@ def get_stream(
     namespace: str,
     table_name: str,
     table_version: Optional[str] = None,
+    stream_format: StreamFormat = StreamFormat.DELTACAT,
     *args,
     **kwargs,
 ) -> Optional[Stream]:
     """
-    Gets the most recently committed stream for the given table version and
-    partition key values. Resolves to the latest active table version if no
-    table version is given. Returns None if the table version does not exist.
+    Gets the most recently committed stream for the given table version.
+    Resolves to the latest active table version if no table version is given.
+    Resolves to the deltacat stream format if no stream format is given.
+    Returns None if the table version or stream format does not exist.
     """
     raise NotImplementedError("get_stream not implemented")
 

--- a/deltacat/storage/interface.py
+++ b/deltacat/storage/interface.py
@@ -23,10 +23,10 @@ from deltacat.storage import (
     Stream,
     StreamFormat,
     StreamLocator,
-    StreamLocatorAlias,
     Table,
     TableProperties,
     TableVersion,
+    TableVersionLocator,
     TableVersionProperties,
 )
 from deltacat.storage.model.manifest import Manifest
@@ -389,6 +389,20 @@ def delete_stream(
     raise NotImplementedError("delete_stream not implemented")
 
 
+def get_staged_stream(
+    table_version_locator: TableVersionLocator,
+    stream_id: str,
+    *args,
+    **kwargs,
+) -> Optional[Partition]:
+    """
+    Gets the staged stream for the given table version locator and stream ID.
+    Returns None if the stream does not exist. Raises an error if the given
+    table version locator does not exist.
+    """
+    raise NotImplementedError("get_staged_stream not implemented")
+
+
 def get_stream(
     namespace: str,
     table_name: str,
@@ -429,10 +443,15 @@ def commit_partition(
     **kwargs,
 ) -> Partition:
     """
-    Commits the given partition to its associated table version stream,
-    replacing any previous partition (i.e., "partition being replaced") registered for the same stream and
+    Commits the staged partition to its associated table version stream,
+    replacing any previous partition registered for the same stream and
     partition values.
-    If the previous_partition is passed as an argument, the specified previous_partition will be the partition being replaced, otherwise it will be retrieved.
+
+    If previous partition is given then it will be replaced with its deltas
+    prepended to the new partition being committed. Otherwise the latest
+    committed partition with the same keys and partition scheme ID will be
+    retrieved.
+
     Returns the registered partition. If the partition's
     previous delta stream position is specified, then the commit will
     be rejected if it does not match the actual previous stream position of

--- a/deltacat/storage/main/impl.py
+++ b/deltacat/storage/main/impl.py
@@ -799,12 +799,7 @@ def create_table_version(
         new_table: Table = Metafile.update_for(prev_table)
         prev_table_version = prev_table.latest_table_version
         if not table_version:
-            try:
-                # if the last table version was an int then increment it by 1
-                table_version = str(int(prev_table_version) + 1)
-            except ValueError:
-                # if it isn't, set it to a UUID
-                table_version = str(uuid.uuid4())
+            table_version = TableVersion.next_version(prev_table_version)
     new_table.description = table_description or table_version_description
     new_table.properties = table_properties
     new_table.latest_table_version = table_version

--- a/deltacat/storage/main/impl.py
+++ b/deltacat/storage/main/impl.py
@@ -15,15 +15,14 @@ from deltacat.storage.model.delta import (
     DeltaType,
 )
 from deltacat.storage.model.types import (
+    CommitState,
     DistributedDataset,
     LifecycleState,
     LocalDataset,
     LocalTable,
-    StreamFormat,
     TransactionType,
     TransactionOperationType,
     StreamFormat,
-    CommitState,
 )
 from deltacat.storage.model.list_result import ListResult
 from deltacat.storage.model.namespace import (

--- a/deltacat/storage/model/list_result.py
+++ b/deltacat/storage/model/list_result.py
@@ -21,6 +21,14 @@ class ListResult(dict, Generic[T]):
         list_result["nextPageProvider"] = next_page_provider
         return list_result
 
+    @staticmethod
+    def empty() -> ListResult:
+        list_result = ListResult()
+        list_result["items"] = []
+        list_result["paginationKey"] = None
+        list_result["nextPageProvider"] = None
+        return list_result
+
     def read_page(self) -> Optional[List[T]]:
         return self.get("items")
 

--- a/deltacat/storage/model/locator.py
+++ b/deltacat/storage/model/locator.py
@@ -55,6 +55,12 @@ class LocatorName:
         """
         return separator.join(self.parts())
 
+    def exists(self) -> bool:
+        """
+        Returns True if this locator name is defined, False otherwise.
+        """
+        return self.immutable_id or all(self.parts())
+
 
 class Locator:
     """

--- a/deltacat/storage/model/metafile.py
+++ b/deltacat/storage/model/metafile.py
@@ -180,7 +180,7 @@ class MetafileRevisionInfo(dict):
             ignore_missing_revision=is_create_txn,
         )
         # validate the transaction operation type
-        if mri.revision:
+        if mri.exists():
             # update/delete fails if the last metafile was deleted
             if mri.txn_op_type == TransactionOperationType.DELETE:
                 if current_txn_op_type != TransactionOperationType.CREATE:
@@ -371,6 +371,9 @@ class MetafileRevisionInfo(dict):
             else None
         )
 
+    def exists(self) -> bool:
+        return bool(self.revision)
+
 
 class Metafile(dict):
     """
@@ -490,6 +493,9 @@ class Metafile(dict):
                 pagination_key=None,
                 next_page_provider=None,
             )
+        else:
+            # Could not find any revisions in list operations - return no results
+            return ListResult.empty()
 
     @classmethod
     def read(
@@ -675,6 +681,7 @@ class Metafile(dict):
             parent_obj_path,
             self.id,
         )
+        # List metafiles with respect to this metafile's URI as root
         return self._list_metafiles(
             success_txn_log_dir=success_txn_log_dir,
             metafile_root_dir_path=metafile_root_dir_path,
@@ -742,15 +749,34 @@ class Metafile(dict):
             filesystem=filesystem,
         )
         metafile_root = posixpath.join(*[catalog_root] + ancestor_ids)
-        # TODO(pdames): Refactor id lazy assignment into explicit getter/setter
-        immutable_id = self.get("id") or Metafile._locator_to_id(
-            locator=self.locator,
-            catalog_root=catalog_root,
-            metafile_root=metafile_root,
-            filesystem=filesystem,
-            txn_start_time=current_txn_start_time,
-            txn_id=current_txn_id,
-        )
+        try:
+            locator = (
+                self.locator
+                if self.locator.name.exists()
+                else self.locator_alias
+                if self.locator_alias and self.locator_alias.name.exists()
+                else None
+            )
+            immutable_id = (
+                # TODO(pdames): Refactor id lazy assignment into explicit getter/setter
+                self.get("id")
+                or Metafile._locator_to_id(
+                    locator=locator,
+                    catalog_root=catalog_root,
+                    metafile_root=metafile_root,
+                    filesystem=filesystem,
+                    txn_start_time=current_txn_start_time,
+                    txn_id=current_txn_id,
+                )
+                if locator
+                else None
+            )
+        except ValueError:
+            # the metafile has been deleted - return an empty list result
+            return ListResult.empty()
+        if not immutable_id:
+            # the metafile does not exist - return an empty list result
+            return ListResult.empty()
         revision_dir_path = posixpath.join(
             metafile_root,
             immutable_id,
@@ -766,7 +792,7 @@ class Metafile(dict):
         )
         items = []
         for mri in revisions:
-            if mri.revision:
+            if mri.exists():
                 metafile = (
                     {}
                     if not materialize_revisions
@@ -841,6 +867,9 @@ class Metafile(dict):
                     txn_start_time=current_txn_start_time,
                     txn_id=current_txn_id,
                 )
+                if not ancestor_id:
+                    err_msg = f"Ancestor does not exist: {parent_locator}."
+                    raise ValueError(err_msg)
                 metafile_root = posixpath.join(
                     metafile_root,
                     ancestor_id,
@@ -886,9 +915,12 @@ class Metafile(dict):
         filesystem: pyarrow.fs.FileSystem,
         txn_start_time: Optional[int] = None,
         txn_id: Optional[str] = None,
-    ) -> str:
+    ) -> Optional[str]:
         """
-        Resolves the metafile ID for the given locator.
+        Resolves the immutable metafile ID for the given locator.
+
+        :return: Immutable ID read from mapping file. None if no mapping exists.
+        :raises: ValueError if the id is found but has been deleted
         """
         metafile_id = locator.name.immutable_id
         if not metafile_id:
@@ -906,7 +938,10 @@ class Metafile(dict):
                 success_txn_log_dir=success_txn_log_dir,
                 current_txn_start_time=txn_start_time,
                 current_txn_id=txn_id,
+                ignore_missing_revision=True,
             )
+            if not mri.exists():
+                return None
             if mri.txn_op_type == TransactionOperationType.DELETE:
                 err_msg = (
                     f"Locator {locator} to metafile ID resolution failed "
@@ -929,6 +964,8 @@ class Metafile(dict):
         filesystem: pyarrow.fs.FileSystem,
     ) -> None:
         name_resolution_dir_path = locator.path(parent_obj_path)
+        # TODO(pdames): Don't write updated revisions with the same mapping as
+        #  the latest revision.
         mri = MetafileRevisionInfo.new_revision(
             revision_dir_path=name_resolution_dir_path,
             current_txn_op_type=current_txn_op_type,
@@ -991,6 +1028,7 @@ class Metafile(dict):
         parent_obj_path = posixpath.join(*[catalog_root] + ancestor_path_elements)
         mutable_src_locator = None
         mutable_dest_locator = None
+        # metafiles without named immutable IDs have mutable name mappings
         if not self.named_immutable_id:
             mutable_src_locator = (
                 current_txn_op.src_metafile.locator
@@ -998,6 +1036,7 @@ class Metafile(dict):
                 else None
             )
             mutable_dest_locator = current_txn_op.dest_metafile.locator
+        # metafiles with named immutable IDs may have aliases
         elif self.locator_alias:
             mutable_src_locator = (
                 current_txn_op.src_metafile.locator_alias
@@ -1010,6 +1049,7 @@ class Metafile(dict):
             # from the locator back to its immutable metafile ID
             if (
                 current_txn_op.type == TransactionOperationType.UPDATE
+                and mutable_src_locator is not None
                 and mutable_src_locator != mutable_dest_locator
             ):
                 # this update includes a rename
@@ -1072,16 +1112,23 @@ class Metafile(dict):
                 current_txn_id=current_txn_id,
                 filesystem=filesystem,
             )
-            # mark the dest metafile as created
-            self._write_metafile_revision(
-                success_txn_log_dir=success_txn_log_dir,
-                revision_dir_path=metafile_revision_dir_path,
-                current_txn_op=current_txn_op,
-                current_txn_op_type=TransactionOperationType.CREATE,
-                current_txn_start_time=current_txn_start_time,
-                current_txn_id=current_txn_id,
-                filesystem=filesystem,
-            )
+            try:
+                # mark the dest metafile as created
+                self._write_metafile_revision(
+                    success_txn_log_dir=success_txn_log_dir,
+                    revision_dir_path=metafile_revision_dir_path,
+                    current_txn_op=current_txn_op,
+                    current_txn_op_type=TransactionOperationType.CREATE,
+                    current_txn_start_time=current_txn_start_time,
+                    current_txn_id=current_txn_id,
+                    filesystem=filesystem,
+                )
+            except ValueError as e:
+                # TODO(pdames): raise/catch a DuplicateMetafileCreate exception.
+                if "already exists" not in str(e):
+                    raise e
+                # src metafile is being replaced by an existing dest metafile
+
         else:
             self._write_metafile_revision(
                 success_txn_log_dir=success_txn_log_dir,
@@ -1123,7 +1170,7 @@ class Metafile(dict):
                 current_txn_id=current_txn_id,
                 ignore_missing_revision=True,
             )
-            if mri.revision:
+            if mri.exists():
                 item = self.read(
                     path=mri.path,
                     filesystem=filesystem,
@@ -1162,7 +1209,7 @@ class Metafile(dict):
             current_txn_id=current_txn_id,
             ignore_missing_revision=True,
         )
-        if mri.revision:
+        if mri.exists():
             return mri.revision.ancestor_ids
         else:
             raise ValueError(f"Metafile {self.id} does not exist.")

--- a/deltacat/storage/model/partition.py
+++ b/deltacat/storage/model/partition.py
@@ -258,7 +258,9 @@ class Partition(Metafile):
         filesystem: Optional[pyarrow.fs.FileSystem] = None,
     ) -> Partition:
         self["schema"] = (
-            Schema.deserialize(pa.py_buffer(self["schema"])) if self["schema"] else None
+            Schema.deserialize(pa.py_buffer(self["schema"]))
+            if self.get("schema")
+            else None
         )
         # restore the table locator from its mapped immutable metafile ID
         if self.table_locator and self.table_locator.table_name == self.id:

--- a/deltacat/storage/model/partition.py
+++ b/deltacat/storage/model/partition.py
@@ -579,16 +579,20 @@ class PartitionLocatorAliasName(LocatorName):
 class PartitionLocatorAlias(Locator, dict):
     @staticmethod
     def of(parent_partition: Partition):
-        return PartitionLocatorAlias(
-            {
-                "partition_values": parent_partition.partition_values,
-                "partition_scheme_id": parent_partition.partition_scheme_id,
-                "parent": (
-                    parent_partition.locator.parent
-                    if parent_partition.locator
-                    else None
-                ),
-            }
+        return (
+            PartitionLocatorAlias(
+                {
+                    "partition_values": parent_partition.partition_values,
+                    "partition_scheme_id": parent_partition.partition_scheme_id,
+                    "parent": (
+                        parent_partition.locator.parent
+                        if parent_partition.locator
+                        else None
+                    ),
+                }
+            )
+            if parent_partition.state == CommitState.COMMITTED
+            else None  # only committed partitions can be resolved by alias
         )
 
     @property

--- a/deltacat/storage/model/stream.py
+++ b/deltacat/storage/model/stream.py
@@ -373,13 +373,17 @@ class StreamLocatorAlias(Locator, dict):
     def of(
         parent_stream: Stream,
     ) -> StreamLocatorAlias:
-        return StreamLocatorAlias(
-            {
-                "format": parent_stream.stream_format,
-                "parent": (
-                    parent_stream.locator.parent if parent_stream.locator else None
-                ),
-            }
+        return (
+            StreamLocatorAlias(
+                {
+                    "format": parent_stream.stream_format,
+                    "parent": (
+                        parent_stream.locator.parent if parent_stream.locator else None
+                    ),
+                }
+            )
+            if parent_stream.state == CommitState.COMMITTED
+            else None  # only committed streams can be resolved by alias
         )
 
     @property

--- a/deltacat/storage/model/table.py
+++ b/deltacat/storage/model/table.py
@@ -29,12 +29,16 @@ class Table(Metafile):
         locator: Optional[TableLocator],
         description: Optional[str] = None,
         properties: Optional[TableProperties] = None,
+        latest_active_table_version: Optional[str] = None,
+        latest_table_version: Optional[str] = None,
         native_object: Optional[Any] = None,
     ) -> Table:
         table = Table()
         table.locator = locator
         table.description = description
         table.properties = properties
+        table.latest_active_table_version = latest_active_table_version
+        table.latest_table_version = latest_table_version
         table.native_object = native_object
         return table
 
@@ -64,6 +68,28 @@ class Table(Metafile):
     @properties.setter
     def properties(self, properties: Optional[TableProperties]) -> None:
         self["properties"] = properties
+
+    @property
+    def latest_active_table_version(self) -> Optional[str]:
+        return self.get("latest_active_table_version")
+
+    @latest_active_table_version.setter
+    def latest_active_table_version(
+        self,
+        latest_active_table_version: Optional[str],
+    ) -> None:
+        self["latest_active_table_version"] = latest_active_table_version
+
+    @property
+    def latest_table_version(self) -> Optional[str]:
+        return self.get("latest_table_version")
+
+    @latest_table_version.setter
+    def latest_table_version(
+        self,
+        latest_table_version: Optional[str],
+    ) -> None:
+        self["latest_table_version"] = latest_table_version
 
     @property
     def native_object(self) -> Optional[Any]:

--- a/deltacat/storage/model/table_version.py
+++ b/deltacat/storage/model/table_version.py
@@ -273,16 +273,19 @@ class TableVersion(Metafile):
         filesystem: Optional[pyarrow.fs.FileSystem] = None,
     ) -> TableVersion:
         self["schema"] = (
-            Schema.deserialize(pa.py_buffer(self["schema"])) if self["schema"] else None
+            Schema.deserialize(pa.py_buffer(self["schema"]))
+            if self.get("schema")
+            else None
         )
         self.schemas = (
             [Schema.deserialize(pa.py_buffer(_)) for _ in self["schemas"]]
-            if self["schemas"]
+            if self.get("schemas")
             else None
         )
-        # force list-to-tuple conversion of sort keys via property invocation
-        self.sort_scheme.keys
-        [sort_scheme.keys for sort_scheme in self.sort_schemes]
+        if self.sort_scheme:
+            # force list-to-tuple conversion of sort keys via property invocation
+            self.sort_scheme.keys
+            [sort_scheme.keys for sort_scheme in self.sort_schemes]
         # restore the table locator from its mapped immutable metafile ID
         if self.table_locator and self.table_locator.table_name == self.id:
             parent_rev_dir_path = Metafile._parent_metafile_rev_dir_path(

--- a/deltacat/storage/model/table_version.py
+++ b/deltacat/storage/model/table_version.py
@@ -43,6 +43,7 @@ class TableVersion(Metafile):
         schemas: Optional[SchemaList] = None,
         partition_schemes: Optional[partition.PartitionSchemeList] = None,
         sort_schemes: Optional[SortSchemeList] = None,
+        previous_table_version: Optional[str] = None,
         native_object: Optional[Any] = None,
     ) -> TableVersion:
         table_version = TableVersion()
@@ -58,6 +59,7 @@ class TableVersion(Metafile):
         table_version.schemas = schemas
         table_version.partition_schemes = partition_schemes
         table_version.sort_schemes = sort_schemes
+        table_version.previous_table_version = previous_table_version
         table_version.native_object = native_object
         return table_version
 
@@ -166,6 +168,14 @@ class TableVersion(Metafile):
     @description.setter
     def description(self, description: Optional[str]) -> None:
         self["description"] = description
+
+    @property
+    def previous_table_version(self) -> Optional[str]:
+        return self.get("previous_table_version")
+
+    @previous_table_version.setter
+    def previous_table_version(self, previous_table_version: Optional[str]) -> None:
+        self["previous_table_version"] = previous_table_version
 
     @property
     def properties(self) -> Optional[TableVersionProperties]:

--- a/deltacat/storage/model/table_version.py
+++ b/deltacat/storage/model/table_version.py
@@ -1,7 +1,9 @@
 # Allow classes to use self-referencing Type hints in Python 3.7.
 from __future__ import annotations
 
+import re
 import posixpath
+import uuid
 from typing import Any, Dict, List, Optional
 
 import pyarrow
@@ -310,6 +312,23 @@ class TableVersion(Metafile):
             )
             self.locator.table_locator = table.locator
         return self
+
+    @staticmethod
+    def next_version(previous_version: Optional[str] = None) -> str:
+        """
+        Assigns the next table version string given the previous table version.
+        Attempts to use the convention of 1-based incrementing integers of
+        the form "v1", "v2", etc. or of the form "1", "2", etc.
+        If the previous table version is not of this form, then assigns a UUID
+        to the next table version.
+        """
+        if previous_version is not None:
+            version_match = re.match(r"^(v?)(\d+)$", previous_version)
+            if version_match:
+                prefix, version_number = version_match.groups()
+                new_version_number = int(version_number) + 1
+                return f"{prefix}{new_version_number}"
+        return str(uuid.uuid4())
 
 
 class TableVersionLocatorName(LocatorName):

--- a/deltacat/storage/model/transaction.py
+++ b/deltacat/storage/model/transaction.py
@@ -448,6 +448,17 @@ class Transaction(dict):
         # reduce file size (they can be reconstructed from their corresponding
         # files as required).
         for operation in serializable.operations:
+            # Sanity check that IDs exist on source and dest metafiles
+            if operation.dest_metafile and operation.dest_metafile.id is None:
+                raise ValueError(
+                    f"Transaction operation ${operation} dest metafile does "
+                    f"not have ID: ${operation.dest_metafile}"
+                )
+            if operation.src_metafile and operation.src_metafile.id is None:
+                raise ValueError(
+                    f"Transaction operation ${operation} src metafile does "
+                    f"not have ID: ${operation.src_metafile}"
+                )
             operation.dest_metafile = {
                 "id": operation.dest_metafile.id,
                 "locator": operation.dest_metafile.locator,

--- a/deltacat/storage/model/transaction.py
+++ b/deltacat/storage/model/transaction.py
@@ -81,7 +81,9 @@ class TransactionSystemTimeProvider(TransactionTimeProvider):
 
     def start_time(self) -> int:
         """
-        Gets the current system time in nanoseconds since the epoch.
+        Gets the current system time in nanoseconds since the epoch. Ensures
+        that the start time returned is greater than the last known end time
+        recorded at the time this method is invoked.
         :return: Current epoch time in nanoseconds.
         """
         # ensure serial transactions in a single process have start times after
@@ -112,7 +114,9 @@ class TransactionSystemTimeProvider(TransactionTimeProvider):
 
     def end_time(self) -> int:
         """
-        Gets the current system time in nanoseconds since the epoch.
+        Gets the current system time in nanoseconds since the epoch. Ensures
+        that the end time returned is no less than the last known start time
+        recorded at the time this method is invoked.
         :return: Current epoch time in nanoseconds.
         """
         # ensure serial transactions in a single process have end times no less

--- a/deltacat/tests/storage/main/test_main_storage.py
+++ b/deltacat/tests/storage/main/test_main_storage.py
@@ -1,41 +1,316 @@
+import shutil
+import tempfile
+
+import pytest
+
+from deltacat import Schema, Field
 from deltacat.storage import (
     metastore,
     Namespace,
     NamespaceLocator,
+    Table,
+    TableVersion,
 )
+from deltacat.catalog.main.impl import PropertyCatalog
+import pyarrow as pa
 
 
-class TestMainStorage:
-    def test_list_namespaces(self, temp_catalog):
-        # given a namespace to create
-        namespace_name = "test_namespace"
+@pytest.fixture
+def schema():
+    return Schema.of(
+        [
+            Field.of(
+                field=pa.field("some_string", pa.string(), nullable=False),
+                field_id=1,
+                is_merge_key=True,
+            ),
+            Field.of(
+                field=pa.field("some_int32", pa.int32(), nullable=False),
+                field_id=2,
+                is_merge_key=True,
+            ),
+            Field.of(
+                field=pa.field("some_float64", pa.float64()),
+                field_id=3,
+                is_merge_key=False,
+            ),
+        ]
+    )
 
-        # when the namespace is created
-        created_namespace = metastore.create_namespace(
-            namespace=namespace_name,
-            catalog=temp_catalog,
+
+class TestNamespace:
+    @classmethod
+    def setup_class(cls):
+        cls.tmpdir = tempfile.mkdtemp()
+        cls.catalog = PropertyCatalog(cls.tmpdir)
+        cls.namespace1 = metastore.create_namespace(
+            namespace="namespace1",
+            catalog=cls.catalog,
+        )
+        cls.namespace2 = metastore.create_namespace(
+            namespace="namespace2",
+            catalog=cls.catalog,
         )
 
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.tmpdir)
+
+    def test_list_namespaces(self):
         # expect the namespace returned to match the input namespace to create
-        namespace_locator = NamespaceLocator.of(namespace=namespace_name)
+        namespace_locator = NamespaceLocator.of(namespace="namespace1")
         expected_namespace = Namespace.of(locator=namespace_locator)
-        assert expected_namespace.equivalent_to(created_namespace)
+        assert expected_namespace.equivalent_to(self.namespace1)
 
         # expect the namespace to exist
         assert metastore.namespace_exists(
-            namespace=namespace_name,
-            catalog=temp_catalog,
+            namespace="namespace1",
+            catalog=self.catalog,
         )
 
         # expect the namespace to also be returned when listing namespaces
-        list_result = metastore.list_namespaces(catalog=temp_catalog)
-        namespaces = list_result.all_items()
-        assert len(namespaces) == 1
-        assert namespaces[0].equivalent_to(expected_namespace)
+        list_result = metastore.list_namespaces(catalog=self.catalog)
+        namespaces_by_name = {n.locator.namespace: n for n in list_result.all_items()}
+        assert len(namespaces_by_name.items()) == 2
+        assert namespaces_by_name["namespace1"].equivalent_to(self.namespace1)
+        assert namespaces_by_name["namespace2"].equivalent_to(self.namespace2)
 
+    def test_get_namespace(self):
         # expect the namespace to also be returned when explicitly retrieved
         read_namespace = metastore.get_namespace(
-            namespace=namespace_name,
-            catalog=temp_catalog,
+            namespace="namespace1",
+            catalog=self.catalog,
         )
-        assert read_namespace and read_namespace.equivalent_to(expected_namespace)
+        assert read_namespace and read_namespace.equivalent_to(self.namespace1)
+
+    def test_namespace_exists_existing(self):
+        assert metastore.namespace_exists(
+            "namespace1",
+            catalog=self.catalog,
+        )
+
+    def test_namespace_exists_nonexisting(self):
+        assert not metastore.namespace_exists(
+            "foobar",
+            catalog=self.catalog,
+        )
+
+
+class TestTable:
+    @classmethod
+    def setup_class(cls):
+        cls.tmpdir = tempfile.mkdtemp()
+        cls.catalog = PropertyCatalog(cls.tmpdir)
+        # Create a namespace to hold our tables
+        cls.namespace_obj = metastore.create_namespace(
+            namespace="test_table_ns",
+            catalog=cls.catalog,
+        )
+        # Create two tables
+        cls.table1 = metastore.create_table_version(
+            namespace="test_table_ns",
+            table_name="table1",
+            table_version="v1",
+            catalog=cls.catalog,
+        )
+        cls.table2 = metastore.create_table_version(
+            namespace="test_table_ns",
+            table_name="table2",
+            table_version="v1",
+            catalog=cls.catalog,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.tmpdir)
+
+    def test_list_tables(self):
+        # list the tables under our namespace
+        list_result = metastore.list_tables(
+            "test_table_ns",
+            catalog=self.catalog,
+        )
+        all_tables = list_result.all_items()
+
+        # we expect 2 distinct tables
+        table_names = {t.table_name for t in all_tables if isinstance(t, Table)}
+        assert "table1" in table_names
+        assert "table2" in table_names
+
+    def test_get_table(self):
+        # test we can retrieve table1 by name
+        tbl = metastore.get_table(
+            "test_table_ns",
+            "table1",
+            catalog=self.catalog,
+        )
+        assert tbl is not None
+        # In your architecture, you might check equivalence:
+        # e.g. tbl.equivalent_to(...) if you have that method:
+        assert tbl.table_name == "table1"
+
+    def test_table_exists_existing(self):
+        # table1 should exist
+        assert metastore.table_exists(
+            "test_table_ns",
+            "table1",
+            catalog=self.catalog,
+        )
+
+    def test_table_exists_nonexisting(self):
+        assert not metastore.table_exists(
+            "test_table_ns",
+            "no_such_table",
+            catalog=self.catalog,
+        )
+
+
+class TestTableVersion:
+    @classmethod
+    def setup_class(cls):
+        cls.tmpdir = tempfile.mkdtemp()
+        cls.catalog = PropertyCatalog(cls.tmpdir)
+        # Create a namespace and single table
+        cls.namespace_obj = metastore.create_namespace(
+            namespace="test_tv_ns",
+            catalog=cls.catalog,
+        )
+        # Create a "base" table to attach versions to
+        metastore.create_table_version(
+            namespace="test_tv_ns",
+            table_name="mytable",
+            table_version="v1",
+            catalog=cls.catalog,
+        )
+        # Now create an additional version
+        cls.stream2 = metastore.create_table_version(
+            namespace="test_tv_ns",
+            table_name="mytable",
+            table_version="v2",
+            catalog=cls.catalog,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.tmpdir)
+
+    def test_list_table_versions(self):
+        list_result = metastore.list_table_versions(
+            "test_tv_ns",
+            "mytable",
+            catalog=self.catalog,
+        )
+        tvs = list_result.all_items()
+        # we expect v1 and v2
+        version_ids = []
+        for tv in tvs:
+            if isinstance(tv, TableVersion):
+                version_ids.append(tv.table_version)
+        assert set(version_ids) == {"v1", "v2"}
+
+    def test_get_table_version(self):
+        tv = metastore.get_table_version(
+            "test_tv_ns",
+            "mytable",
+            "v1",
+            catalog=self.catalog,
+        )
+        assert tv is not None
+        assert tv.table_version == "v1"
+
+    def test_table_version_exists(self):
+        # v2 should exist
+        assert metastore.table_version_exists(
+            "test_tv_ns",
+            "mytable",
+            "v2",
+            catalog=self.catalog,
+        )
+
+    def test_table_version_exists_nonexisting(self):
+        # "v999" should not exist
+        assert not metastore.table_version_exists(
+            "test_tv_ns",
+            "mytable",
+            "v999",
+            catalog=self.catalog,
+        )
+
+
+class TestStream:
+    @classmethod
+    def setup_class(cls):
+        cls.tmpdir = tempfile.mkdtemp()
+        cls.catalog = PropertyCatalog(cls.tmpdir)
+        # Create a table version
+        metastore.create_namespace("test_stream_ns", catalog=cls.catalog)
+        metastore.create_table_version(
+            namespace="test_stream_ns",
+            table_name="mystreamtable",
+            table_version="v1",
+            catalog=cls.catalog,
+        )
+        # Stage & commit a stream
+        cls.stream = metastore.stage_stream(
+            namespace="test_stream_ns",
+            table_name="mystreamtable",
+            table_version="v1",
+            catalog=cls.catalog,
+        )
+        cls.committed_stream = metastore.commit_stream(
+            cls.stream,
+            catalog=cls.catalog,
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.tmpdir)
+
+    def test_list_streams(self):
+        list_result = metastore.list_streams(
+            "test_stream_ns",
+            "mystreamtable",
+            "v1",
+            catalog=self.catalog,
+        )
+        streams = list_result.all_items()
+        # This will list the staged stream and the committed stream
+        assert len(streams) == 2
+        # TODO - add more assertions
+
+    def test_get_stream(self):
+        # The stream is created and committed in setup
+        stream = metastore.get_stream(
+            namespace="test_stream_ns",
+            table_name="mystreamtable",
+            table_version="v1",
+            catalog=self.catalog,
+        )
+        # TODO this is broken, stream is table version
+        assert stream is not None
+
+    def test_list_stream_partitions_empty(self):
+        # no partitions yet
+        list_result = metastore.list_stream_partitions(
+            self.committed_stream,
+            catalog=self.catalog,
+        )
+        partitions = list_result.all_items()
+        assert len(partitions) == 0
+
+    def test_delete_stream(self):
+        # We can delete the stream
+        metastore.delete_stream(
+            "test_stream_ns",
+            "mystreamtable",
+            "v1",
+            catalog=self.catalog,
+        )
+        # Now get_stream should return None
+        stream = metastore.get_stream(
+            "test_stream_ns",
+            "mystreamtable",
+            "v1",
+            catalog=self.catalog,
+        )
+        assert stream is None

--- a/deltacat/tests/storage/main/test_main_storage.py
+++ b/deltacat/tests/storage/main/test_main_storage.py
@@ -286,7 +286,6 @@ class TestStream:
             table_version="v1",
             catalog=self.catalog,
         )
-        # TODO this is broken, stream is table version
         assert stream is not None
 
     def test_list_stream_partitions_empty(self):

--- a/deltacat/tests/storage/model/test_metafile_io.py
+++ b/deltacat/tests/storage/model/test_metafile_io.py
@@ -2723,3 +2723,7 @@ class TestMetafileIO:
         # expect the table created to otherwise match the table given
         table.properties = expected_properties
         assert table.equivalent_to(deserialized_table)
+
+    def test_metafile_read_bad_path(self, temp_dir):
+        with pytest.raises(FileNotFoundError):
+            Delta.read("foobar")

--- a/deltacat/tests/storage/model/test_table_version.py
+++ b/deltacat/tests/storage/model/test_table_version.py
@@ -1,0 +1,26 @@
+import pytest
+import uuid
+from deltacat.storage.model.table_version import TableVersion
+
+
+@pytest.mark.parametrize(
+    "previous_version, expected_new_version",
+    [
+        (None, None),
+        ("v1", "v2"),
+        ("1", "2"),
+        (
+            "version1",
+            None,
+        ),
+        ("v999", "v1000"),
+    ],
+)
+def test_new_version(previous_version, expected_new_version):
+    new_version = TableVersion.next_version(previous_version)
+    assert isinstance(new_version, str)
+    if expected_new_version:
+        assert new_version == expected_new_version
+    else:
+        # ensure that the new version is a valid UUID
+        uuid.UUID(new_version)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     name="deltacat",
     version=find_version("deltacat", "__init__.py"),
     author="Ray Team",
-    description="A scalable, fast, ACID-compliant Data Catalog powered by Ray.",
+    description="A portable, scalable, fast, and Pythonic Data Lakehouse for AI.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ray-project/deltacat",


### PR DESCRIPTION
## Summary

Initial implementation of DeltaCAT storage w/o implementations of methods operating on deltas. TODOs show most pending work. One of the larger changes between this and the final implementation will involve ensuring that each storage interface method completes within the context of a single transaction.

This PR merges common changes from https://github.com/ray-project/deltacat/pull/484 into a single implementation.

Partial unit test coverage is provided over basic storage methods from Namespace to Stream. Additional unit tests will be added in a follow-up PR.

## Checklist

- [X] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed
