### PR TITLE
Bugfix: ZeroDivisionError possible when calculating previous_inflation and average_record_size

### DIFF
--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -86,7 +86,10 @@ def _get_merge_task_options(
         and compacted_delta_manifest
         and round_completion_info.hb_index_to_entry_range
     ):
-
+        logger.debug_conditional(
+            f"[Merge task {index}]: Using previous compaction rounds to calculate merge memory: {round_completion_info.compacted_pyarrow_write_result}",
+            memory_logs_enabled,
+        )
         previous_inflation: float = (
             (
                 round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
@@ -146,8 +149,9 @@ def _get_merge_task_options(
                         operation_type=OperationType.PYARROW_DOWNLOAD,
                         estimate_resources_params=estimate_resources_params,
                     )
-                    if pk_size is None:
-                        pk_size_bytes += current_entry_size
+                    if not pk_size:
+                        pk_size_bytes += current_entry_size if current_entry_size else 0
+                        # NOTE: We can treat the current entry size as 0 for the purpose of this calculation as a None estimated entry size implies that the entry size is 0
                     else:
                         pk_size_bytes += pk_size
 

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -123,23 +123,25 @@ def _get_merge_task_options(
             ]
             for entry_index in range(entry_start, entry_end):
                 entry: ManifestEntry = compacted_delta_manifest.entries[entry_index]
-
-                current_entry_size: Optional[
-                    float
-                ] = estimate_manifest_entry_size_bytes(
-                    entry=entry,
-                    operation_type=OperationType.PYARROW_DOWNLOAD,
-                    estimate_resources_params=estimate_resources_params,
+                current_entry_size: float = (
+                    estimate_manifest_entry_size_bytes(
+                        entry=entry,
+                        operation_type=OperationType.PYARROW_DOWNLOAD,
+                        estimate_resources_params=estimate_resources_params,
+                    )
+                    or 0.0
                 )
-                current_entry_rows: Optional[int] = estimate_manifest_entry_num_rows(
-                    entry=entry,
-                    operation_type=OperationType.PYARROW_DOWNLOAD,
-                    estimate_resources_params=estimate_resources_params,
+                current_entry_rows: int = (
+                    estimate_manifest_entry_num_rows(
+                        entry=entry,
+                        operation_type=OperationType.PYARROW_DOWNLOAD,
+                        estimate_resources_params=estimate_resources_params,
+                    )
+                    or 0
                 )
-                if current_entry_size:
-                    data_size += current_entry_size
-                if current_entry_rows:
-                    num_rows += current_entry_rows
+                # NOTE: We can treat the current_entry_size and current_entry_rows as 0 as a None estimated entry size implies a 0 value
+                data_size += current_entry_size
+                num_rows += current_entry_rows
                 if primary_keys:
                     pk_size: Optional[
                         float
@@ -150,8 +152,7 @@ def _get_merge_task_options(
                         estimate_resources_params=estimate_resources_params,
                     )
                     if not pk_size:
-                        pk_size_bytes += current_entry_size if current_entry_size else 0
-                        # NOTE: We can treat the current entry size as 0 for the purpose of this calculation as a None estimated entry size implies that the entry size is 0
+                        pk_size_bytes += current_entry_size
                     else:
                         pk_size_bytes += pk_size
 

--- a/deltacat/compute/compactor_v2/utils/task_options.py
+++ b/deltacat/compute/compactor_v2/utils/task_options.py
@@ -1,6 +1,10 @@
 import logging
 from typing import Dict, Optional, List, Tuple, Any
 from deltacat import logs
+from deltacat.constants import PYARROW_INFLATION_MULTIPLIER
+from deltacat.compute.compactor_v2.constants import (
+    AVERAGE_RECORD_SIZE_BYTES as DEFAULT_AVERAGE_RECORD_SIZE_BYTES,
+)
 from deltacat.compute.compactor_v2.model.merge_file_group import (
     LocalMergeFileGroupsProvider,
 )
@@ -83,14 +87,22 @@ def _get_merge_task_options(
     ):
 
         previous_inflation = (
-            round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
-            / round_completion_info.compacted_pyarrow_write_result.file_bytes
+            (
+                round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
+                / round_completion_info.compacted_pyarrow_write_result.file_bytes
+            )
+            if round_completion_info.compacted_pyarrow_write_result.file_bytes
+            else PYARROW_INFLATION_MULTIPLIER
         )
         debug_memory_params["previous_inflation"] = previous_inflation
 
         average_record_size = (
-            round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
-            / round_completion_info.compacted_pyarrow_write_result.records
+            (
+                round_completion_info.compacted_pyarrow_write_result.pyarrow_bytes
+                / round_completion_info.compacted_pyarrow_write_result.records
+            )
+            if round_completion_info.compacted_pyarrow_write_result.records
+            else DEFAULT_AVERAGE_RECORD_SIZE_BYTES
         )
         debug_memory_params["average_record_size"] = average_record_size
 

--- a/deltacat/tests/compute/compactor_v2/utils/test_task_options.py
+++ b/deltacat/tests/compute/compactor_v2/utils/test_task_options.py
@@ -1,6 +1,37 @@
 import unittest
 import ray
-from deltacat.compute.compactor_v2.utils.task_options import _get_task_options
+from deltacat.compute.compactor_v2.utils.task_options import (
+    _get_task_options,
+    _get_merge_task_options,
+    logger,
+)
+from deltacat.compute.resource_estimation.model import (
+    EstimateResourcesParams,
+    ResourceEstimationMethod,
+)
+from deltacat.constants import PYARROW_INFLATION_MULTIPLIER
+from deltacat.compute.compactor import (
+    PyArrowWriteResult,
+    RoundCompletionInfo,
+)
+from deltacat.types.media import (
+    ContentType,
+    ContentEncoding,
+)
+from deltacat.storage import (
+    DeltaLocator,
+    Manifest,
+    ManifestMeta,
+    ManifestEntry,
+    ManifestEntryList,
+    PartitionValues,
+)
+from unittest.mock import MagicMock
+from typing import Optional
+
+from deltacat.compute.compactor_v2.constants import (
+    AVERAGE_RECORD_SIZE_BYTES as DEFAULT_AVERAGE_RECORD_SIZE_BYTES,
+)
 
 
 @ray.remote
@@ -14,10 +45,94 @@ def throwing_func():
 
 
 class TestTaskOptions(unittest.TestCase):
+    TEST_INDEX = 0
+    TEST_HB_GROUP_IDX = 0
+    TEST_STREAM_POSITION = 1_000_000
+    TEST_NUM_HASH_GROUPS = 1
+
     @classmethod
     def setUpClass(cls):
         ray.init(local_mode=True, ignore_reinit_error=True)
         super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        ray.shutdown()
+
+    def make_estimate_resource_params(
+        cls,
+        resource_estimation_method: Optional[
+            ResourceEstimationMethod
+        ] = ResourceEstimationMethod.DEFAULT,
+        previous_inflation: Optional[int] = 7,
+        average_record_size_bytes: Optional[int] = 1000,
+    ):
+        return EstimateResourcesParams.of(
+            resource_estimation_method=resource_estimation_method,
+            previous_inflation=previous_inflation,
+            average_record_size_bytes=average_record_size_bytes,
+        )
+
+    def make_manifest(
+        self,
+        source_content_length: Optional[int] = 1000,
+        content_type: Optional[ContentType] = ContentType.PARQUET,
+        content_encoding: Optional[ContentEncoding] = ContentEncoding.IDENTITY,
+        partition_values: Optional[PartitionValues] = None,
+        uri: Optional[str] = "test",
+        url: Optional[str] = "test",
+        author: Optional[str] = "foo",
+        entry_uuid: Optional[str] = "fooo",
+        manifest_uuid: Optional[str] = "bar",
+    ) -> Manifest:
+        meta = ManifestMeta.of(
+            10,
+            10,
+            content_type=content_type,
+            content_encoding=content_encoding,
+            source_content_length=source_content_length,
+            partition_values=partition_values,
+        )
+
+        return Manifest.of(
+            entries=ManifestEntryList.of(
+                [
+                    ManifestEntry.of(
+                        uri=uri, url=url, meta=meta, mandatory=True, uuid=entry_uuid
+                    )
+                ]
+            ),
+            author=author,
+            uuid=manifest_uuid,
+        )
+
+    def make_round_completion_info(
+        self,
+        high_watermark: Optional[int] = 1_000_000,
+        compacted_delta_locator: Optional[DeltaLocator] = None,
+        records_written: Optional[int] = 10,
+        bytes_written: Optional[int] = 10,
+        files_written: Optional[int] = 10,
+        rows_dropped: Optional[int] = 10,
+        sort_keys_bit_width: Optional[int] = 0,
+        hash_bucket_count: Optional[int] = 1,
+        hb_index_to_entry_range: Optional[dict] = None,
+    ) -> RoundCompletionInfo:
+        if compacted_delta_locator is None:
+            compacted_delta_locator = MagicMock(spec=DeltaLocator)
+
+        hb_index_to_entry_range = hb_index_to_entry_range or {"0": (0, 1)}
+
+        return RoundCompletionInfo.of(
+            compacted_delta_locator=compacted_delta_locator,
+            high_watermark=high_watermark,
+            compacted_pyarrow_write_result=PyArrowWriteResult.of(
+                records_written, bytes_written, files_written, rows_dropped
+            ),
+            sort_keys_bit_width=sort_keys_bit_width,
+            hb_index_to_entry_range=hb_index_to_entry_range,
+            hash_bucket_count=hash_bucket_count,
+        )
 
     def test_get_task_options_sanity(self):
         opts = _get_task_options(0.01, 0.01)
@@ -31,3 +146,101 @@ class TestTaskOptions(unittest.TestCase):
         result_ref = throwing_func.options(**opts).remote()
 
         self.assertRaises(ConnectionAbortedError, lambda: ray.get(result_ref))
+
+    def test_get_merge_task_options_memory_logs_enabled_sanity(self):
+        test_index = 0
+        test_hb_group_idx = 0
+        test_debug_memory_params = {"merge_task_index": test_index}
+        test_estimate_memory_params = self.make_estimate_resource_params()
+        test_ray_custom_resources = {}
+        test_rcf = self.make_round_completion_info()
+        test_manifest = self.make_manifest()
+        expected_task_opts = {
+            "max_retries": 3,
+            "memory": 1680.64,
+            "num_cpus": 0.01,
+            "scheduling_strategy": "SPREAD",
+        }
+        expected_previous_inflation = 1.0
+        expected_average_record_size = 1.0
+        with self.assertLogs(logger=logger.name, level="DEBUG") as cm:
+            # At least one log of level DEBUG must be emitted
+            actual_merge_tasks_opts = _get_merge_task_options(
+                index=test_index,
+                hb_group_idx=test_hb_group_idx,
+                data_size=1,
+                pk_size_bytes=1,
+                num_rows=1,
+                num_hash_groups=1,
+                total_memory_buffer_percentage=1,
+                incremental_index_array_size=1,
+                debug_memory_params=test_debug_memory_params,
+                ray_custom_resources=test_ray_custom_resources,
+                estimate_resources_params=test_estimate_memory_params,
+                round_completion_info=test_rcf,
+                compacted_delta_manifest=test_manifest,
+                memory_logs_enabled=True,
+            )
+            assert {k: actual_merge_tasks_opts[k] for k in expected_task_opts}
+        log_message = cm.records[0].getMessage()
+        self.assertIn(
+            f"[Merge task {test_index}]: Params used for calculating merge memory",
+            log_message,
+        )
+        self.assertIn(
+            f"'previous_inflation': {expected_previous_inflation}", log_message
+        )
+        self.assertIn(
+            f"'average_record_size': {expected_average_record_size}", log_message
+        )
+
+    def test_get_merge_task_options_memory_logs_enabled_fallback_previous_inflation_fallback_average_record_size(
+        self,
+    ):
+        test_index = 0
+        test_hb_group_idx = 0
+        test_debug_memory_params = {"merge_task_index": test_index}
+        test_estimate_memory_params = self.make_estimate_resource_params()
+        test_ray_custom_resources = {}
+        test_rcf = self.make_round_completion_info(
+            bytes_written=0, records_written=0, files_written=0, rows_dropped=0
+        )
+        test_manifest = self.make_manifest()
+        expected_task_opts = {
+            "max_retries": 3,
+            "memory": 1680.64,
+            "num_cpus": 0.01,
+            "scheduling_strategy": "SPREAD",
+        }
+        expected_previous_inflation = PYARROW_INFLATION_MULTIPLIER
+        expected_average_record_size = DEFAULT_AVERAGE_RECORD_SIZE_BYTES
+        with self.assertLogs(logger=logger.name, level="DEBUG") as cm:
+            # At least one log of level DEBUG must be emitted
+            actual_merge_tasks_opts = _get_merge_task_options(
+                index=test_index,
+                hb_group_idx=test_hb_group_idx,
+                data_size=1,
+                pk_size_bytes=1,
+                num_rows=1,
+                num_hash_groups=1,
+                total_memory_buffer_percentage=1,
+                incremental_index_array_size=1,
+                debug_memory_params=test_debug_memory_params,
+                ray_custom_resources=test_ray_custom_resources,
+                estimate_resources_params=test_estimate_memory_params,
+                round_completion_info=test_rcf,
+                compacted_delta_manifest=test_manifest,
+                memory_logs_enabled=True,
+            )
+            assert {k: actual_merge_tasks_opts[k] for k in expected_task_opts}
+        log_message = cm.records[0].getMessage()
+        self.assertIn(
+            f"[Merge task {test_index}]: Params used for calculating merge memory",
+            log_message,
+        )
+        self.assertIn(
+            f"'previous_inflation': {expected_previous_inflation}", log_message
+        )
+        self.assertIn(
+            f"'average_record_size': {expected_average_record_size}", log_message
+        )


### PR DESCRIPTION
## Summary
This change fixes a possible ZeroDivisionError error case in `_get_merge_task_options`

## Rationale
-It's plausible and permissible for the round completion info parameter object to contain zero values for `compacted_pyarrow_write_result.records` and `compacted_pyarrow_write_result.file_bytes` round completion info argument may contain

## Changes
- Falling back to the `PYARROW_INFLATION_MULTIPLIER` and `DEFAULT_AVERAGE_RECORD_SIZE_BYTES` for calculating previous_inflation and average_record_size respectively when `compacted_pyarrow_write_result.records` or `compacted_pyarrow_write_result.file_bytes` are zero
- Adding unit testing coverage for `_get_merge_task_options` from no coverage including the default case
- Adding additional type hints

## Impact
- Small blast radius - this should enable the compaction of incremental tables that previously failed because of this ZeroDivisionError error

## Testing
- Added unit testing coverage

## Regression Risk
Very low as the fallback only occurs if there is a ZeroDivisionError **would** have happened which resulted in failed compaction in any case 

## Checklist

- [x] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
