### PR TITLE
[Converter][Test]Add working end-to-end converter compute test with Minio S3 endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ test-integration: install
 	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml up -d
 	sleep 3
 	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
+	export SPARK_LOCAL_IP="127.0.0.1"
 	venv/bin/python -m pytest deltacat/tests/integ -v -m integration
 
 test-converter:
@@ -52,6 +53,7 @@ test-converter:
 	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml up -d
 	sleep 3
 	docker-compose -f dev/iceberg-integration/docker-compose-integration.yml exec -T spark-iceberg ipython ./provision.py
+	export SPARK_LOCAL_IP="127.0.0.1"
 	venv/bin/python -m pytest deltacat/tests/compute/converter -vv
 
 test-integration-rebuild:

--- a/deltacat/compute/converter/model/convert_input.py
+++ b/deltacat/compute/converter/model/convert_input.py
@@ -7,23 +7,26 @@ class ConvertInput(Dict):
     def of(
         files_for_each_bucket,
         convert_task_index,
-        iceberg_warehouse_bucket_name,
+        iceberg_table_warehouse_prefix,
         identifier_fields,
         compact_small_files,
         position_delete_for_multiple_data_files,
         max_parallel_data_file_download,
+        s3_file_system,
     ) -> ConvertInput:
 
         result = ConvertInput()
         result["files_for_each_bucket"] = files_for_each_bucket
         result["convert_task_index"] = convert_task_index
         result["identifier_fields"] = identifier_fields
-        result["iceberg_warehouse_bucket_name"] = iceberg_warehouse_bucket_name
+        result["iceberg_table_warehouse_prefix"] = iceberg_table_warehouse_prefix
         result["compact_small_files"] = compact_small_files
         result[
             "position_delete_for_multiple_data_files"
         ] = position_delete_for_multiple_data_files
         result["max_parallel_data_file_download"] = max_parallel_data_file_download
+        result["s3_file_system"] = s3_file_system
+
         return result
 
     @property
@@ -39,8 +42,8 @@ class ConvertInput(Dict):
         return self["convert_task_index"]
 
     @property
-    def iceberg_warehouse_bucket_name(self) -> str:
-        return self["iceberg_warehouse_bucket_name"]
+    def iceberg_table_warehouse_prefix(self) -> str:
+        return self["iceberg_table_warehouse_prefix"]
 
     @property
     def compact_small_files(self) -> bool:
@@ -53,3 +56,7 @@ class ConvertInput(Dict):
     @property
     def max_parallel_data_file_download(self) -> int:
         return self["max_parallel_data_file_download"]
+
+    @property
+    def s3_file_system(self):
+        return self["s3_file_system"]

--- a/deltacat/compute/converter/model/converter_session_params.py
+++ b/deltacat/compute/converter/model/converter_session_params.py
@@ -18,6 +18,9 @@ class ConverterSessionParams(dict):
         assert (
             params.get("iceberg_warehouse_bucket_name") is not None
         ), "iceberg_warehouse_bucket_name is a required arg"
+        assert (
+            params.get("iceberg_namespace") is not None
+        ), "iceberg_namespace is a required arg"
         result = ConverterSessionParams(params)
 
         result.compact_small_files = params.get("compact_small_files", False)
@@ -43,6 +46,10 @@ class ConverterSessionParams(dict):
     @property
     def iceberg_warehouse_bucket_name(self) -> str:
         return self["iceberg_warehouse_bucket_name"]
+
+    @property
+    def iceberg_namespace(self) -> str:
+        return self["iceberg_namespace"]
 
     @property
     def compact_small_files(self) -> bool:

--- a/deltacat/compute/converter/pyiceberg/replace_snapshot.py
+++ b/deltacat/compute/converter/pyiceberg/replace_snapshot.py
@@ -12,7 +12,7 @@ from pyiceberg.manifest import (
 )
 import itertools
 from pyiceberg.utils.concurrent import ExecutorFactory
-from pyiceberg.table import UpdateSnapshot, _SnapshotProducer
+from pyiceberg.table.update.snapshot import UpdateSnapshot, _SnapshotProducer
 
 
 class _ReplaceFiles(_SnapshotProducer["_ReplaceFiles"]):

--- a/deltacat/compute/converter/steps/convert.py
+++ b/deltacat/compute/converter/steps/convert.py
@@ -17,14 +17,14 @@ logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 def convert(convert_input: ConvertInput):
     files_for_each_bucket = convert_input.files_for_each_bucket
     convert_task_index = convert_input.convert_task_index
-    iceberg_warehouse_bucket_name = convert_input.iceberg_warehouse_bucket_name
+    iceberg_table_warehouse_prefix = convert_input.iceberg_table_warehouse_prefix
     identifier_fields = convert_input.identifier_fields
     compact_small_files = convert_input.compact_small_files
     position_delete_for_multiple_data_files = (
         convert_input.position_delete_for_multiple_data_files
     )
     max_parallel_data_file_download = convert_input.max_parallel_data_file_download
-
+    s3_file_system = convert_input.s3_file_system
     if not position_delete_for_multiple_data_files:
         raise NotImplementedError(
             f"Distributed file level position delete compute is not supported yet"
@@ -34,7 +34,17 @@ def convert(convert_input: ConvertInput):
 
     logger.info(f"Starting convert task index: {convert_task_index}")
     data_files, equality_delete_files, position_delete_files = files_for_each_bucket[1]
+    # Get string representation of partition value out of Record[partition_value]
+    partition_value_str = (
+        files_for_each_bucket[0].__repr__().split("[", 1)[1].split("]")[0]
+    )
+    partition_value_str = (
+        files_for_each_bucket[0].__repr__().split("[", 1)[1].split("]")[0]
+    )
     partition_value = files_for_each_bucket[0]
+    iceberg_table_warehouse_prefix_with_partition = (
+        f"{iceberg_table_warehouse_prefix}/{partition_value_str}"
+    )
     (
         to_be_deleted_files_list,
         to_be_added_files_list,
@@ -42,8 +52,9 @@ def convert(convert_input: ConvertInput):
         data_files_list=data_files,
         identifier_columns=identifier_fields,
         equality_delete_files_list=equality_delete_files,
-        iceberg_warehouse_bucket_name=iceberg_warehouse_bucket_name,
+        iceberg_table_warehouse_prefix_with_partition=iceberg_table_warehouse_prefix_with_partition,
         max_parallel_data_file_download=max_parallel_data_file_download,
+        s3_file_system=s3_file_system,
     )
     to_be_delete_files_dict = defaultdict()
     to_be_delete_files_dict[partition_value] = to_be_deleted_files_list
@@ -68,7 +79,9 @@ def filter_rows_to_be_deleted(
             f"length_pos_delete_table, {len(positional_delete_table)}, length_data_table:{len(data_file_table)}"
         )
     if positional_delete_table:
-        positional_delete_table = positional_delete_table.drop(["primarykey"])
+        # TODO: Add support for multiple identify columns
+        identifier_column = identifier_columns[0]
+        positional_delete_table = positional_delete_table.drop(identifier_column)
     if len(positional_delete_table) == len(data_file_table):
         return True, None
     return False, positional_delete_table
@@ -78,7 +91,8 @@ def compute_pos_delete(
     equality_delete_table,
     data_file_table,
     identifier_columns,
-    iceberg_warehouse_bucket_name,
+    iceberg_table_warehouse_prefix_with_partition,
+    s3_file_system,
 ):
     delete_whole_file, new_position_delete_table = filter_rows_to_be_deleted(
         data_file_table=data_file_table,
@@ -89,7 +103,10 @@ def compute_pos_delete(
         logger.info(f"compute_pos_delete_table:{new_position_delete_table.to_pydict()}")
     if new_position_delete_table:
         new_pos_delete_s3_link = upload_table_with_retry(
-            new_position_delete_table, iceberg_warehouse_bucket_name, {}
+            table=new_position_delete_table,
+            s3_url_prefix=iceberg_table_warehouse_prefix_with_partition,
+            s3_table_writer_kwargs={},
+            s3_file_system=s3_file_system,
         )
     return delete_whole_file, new_pos_delete_s3_link
 
@@ -126,8 +143,9 @@ def compute_pos_delete_with_limited_parallelism(
     data_files_list,
     identifier_columns,
     equality_delete_files_list,
-    iceberg_warehouse_bucket_name,
+    iceberg_table_warehouse_prefix_with_partition,
     max_parallel_data_file_download,
+    s3_file_system,
 ):
     to_be_deleted_file_list = []
     to_be_added_pos_delete_file_list = []
@@ -144,8 +162,9 @@ def compute_pos_delete_with_limited_parallelism(
         delete_whole_file, new_pos_delete_s3_link = compute_pos_delete(
             equality_delete_table=equality_delete_table,
             data_file_table=data_table,
-            iceberg_warehouse_bucket_name=iceberg_warehouse_bucket_name,
+            iceberg_table_warehouse_prefix_with_partition=iceberg_table_warehouse_prefix_with_partition,
             identifier_columns=identifier_columns,
+            s3_file_system=s3_file_system,
         )
         if delete_whole_file:
             to_be_deleted_file_list.extend(data_files)
@@ -182,7 +201,6 @@ def download_parquet_with_daft_hash_applied(
         io_config=io_config,
         coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,
     )
-    logger.info(f"debug_identify_columns:{identify_columns}")
     df = df.select(daft.col(identify_columns[0]).hash())
     arrow_table = df.to_arrow()
     return arrow_table

--- a/deltacat/compute/converter/utils/converter_session_utils.py
+++ b/deltacat/compute/converter/utils/converter_session_utils.py
@@ -54,3 +54,9 @@ def construct_iceberg_table_prefix(
     iceberg_warehouse_bucket_name, table_name, iceberg_namespace
 ):
     return f"{iceberg_warehouse_bucket_name}/{iceberg_namespace}/{table_name}/data"
+
+
+def partition_value_record_to_partition_value_string(partition):
+    # Get string representation of partition value out of Record[partition_value]
+    partition_value_str = partition.__repr__().split("[", 1)[1].split("]")[0]
+    return partition_value_str

--- a/deltacat/compute/converter/utils/converter_session_utils.py
+++ b/deltacat/compute/converter/utils/converter_session_utils.py
@@ -48,3 +48,9 @@ def append_larger_sequence_number_data_files(data_files_list):
             sublist_file_list.append(file)
         result.append(sublist_file_list)
     return result
+
+
+def construct_iceberg_table_prefix(
+    iceberg_warehouse_bucket_name, table_name, iceberg_namespace
+):
+    return f"{iceberg_warehouse_bucket_name}/{iceberg_namespace}/{table_name}/data"

--- a/deltacat/compute/converter/utils/iceberg_columns.py
+++ b/deltacat/compute/converter/utils/iceberg_columns.py
@@ -1,6 +1,12 @@
 import pyarrow as pa
 from typing import Union
 
+# Refer to: https://iceberg.apache.org/spec/#reserved-field-ids for reserved field ids
+ICEBERG_RESERVED_FIELD_ID_FOR_FILE_PATH_COLUMN = 2147483546
+
+# Refer to: https://iceberg.apache.org/spec/#reserved-field-ids for reserved field ids
+ICEBERG_RESERVED_FIELD_ID_FOR_POS_COLUMN = 2147483545
+
 
 def _get_iceberg_col_name(suffix):
     return suffix
@@ -8,7 +14,9 @@ def _get_iceberg_col_name(suffix):
 
 _ORDERED_RECORD_IDX_COLUMN_NAME = _get_iceberg_col_name("pos")
 _ORDERED_RECORD_IDX_COLUMN_TYPE = pa.int64()
-_ORDERED_RECORD_IDX_FIELD_METADATA = {b"PARQUET:field_id": "2147483545"}
+_ORDERED_RECORD_IDX_FIELD_METADATA = {
+    b"PARQUET:field_id": f"{ICEBERG_RESERVED_FIELD_ID_FOR_POS_COLUMN}"
+}
 _ORDERED_RECORD_IDX_COLUMN_FIELD = pa.field(
     _ORDERED_RECORD_IDX_COLUMN_NAME,
     _ORDERED_RECORD_IDX_COLUMN_TYPE,
@@ -35,7 +43,9 @@ def append_record_idx_col(table: pa.Table, ordered_record_indices) -> pa.Table:
 
 _FILE_PATH_COLUMN_NAME = _get_iceberg_col_name("file_path")
 _FILE_PATH_COLUMN_TYPE = pa.string()
-_FILE_PATH_FIELD_METADATA = {b"PARQUET:field_id": "2147483546"}
+_FILE_PATH_FIELD_METADATA = {
+    b"PARQUET:field_id": f"{ICEBERG_RESERVED_FIELD_ID_FOR_FILE_PATH_COLUMN}"
+}
 _FILE_PATH_COLUMN_FIELD = pa.field(
     _FILE_PATH_COLUMN_NAME,
     _FILE_PATH_COLUMN_TYPE,

--- a/deltacat/compute/converter/utils/iceberg_columns.py
+++ b/deltacat/compute/converter/utils/iceberg_columns.py
@@ -3,14 +3,17 @@ from typing import Union
 
 
 def _get_iceberg_col_name(suffix):
-    return f"{suffix}"
+    return suffix
 
 
 _ORDERED_RECORD_IDX_COLUMN_NAME = _get_iceberg_col_name("pos")
 _ORDERED_RECORD_IDX_COLUMN_TYPE = pa.int64()
+_ORDERED_RECORD_IDX_FIELD_METADATA = {b"PARQUET:field_id": "2147483545"}
 _ORDERED_RECORD_IDX_COLUMN_FIELD = pa.field(
     _ORDERED_RECORD_IDX_COLUMN_NAME,
     _ORDERED_RECORD_IDX_COLUMN_TYPE,
+    metadata=_ORDERED_RECORD_IDX_FIELD_METADATA,
+    nullable=False,
 )
 
 
@@ -32,7 +35,10 @@ def append_record_idx_col(table: pa.Table, ordered_record_indices) -> pa.Table:
 
 _FILE_PATH_COLUMN_NAME = _get_iceberg_col_name("file_path")
 _FILE_PATH_COLUMN_TYPE = pa.string()
+_FILE_PATH_FIELD_METADATA = {b"PARQUET:field_id": "2147483546"}
 _FILE_PATH_COLUMN_FIELD = pa.field(
     _FILE_PATH_COLUMN_NAME,
     _FILE_PATH_COLUMN_TYPE,
+    metadata=_FILE_PATH_FIELD_METADATA,
+    nullable=False,
 )

--- a/deltacat/compute/converter/utils/s3u.py
+++ b/deltacat/compute/converter/utils/s3u.py
@@ -57,6 +57,7 @@ def upload_table_with_retry(
     s3_table_writer_kwargs: Optional[Dict[str, Any]],
     content_type: ContentType = ContentType.PARQUET,
     max_records_per_file: Optional[int] = 4000000,
+    s3_file_system=None,
     **s3_client_kwargs,
 ) -> List[str]:
     """
@@ -72,9 +73,12 @@ def upload_table_with_retry(
     if s3_table_writer_kwargs is None:
         s3_table_writer_kwargs = {}
 
-    s3_file_system = get_s3_file_system(content_type=content_type)
+    if not s3_file_system:
+        s3_file_system = get_s3_file_system(content_type=content_type)
     capture_object = CapturedBlockWritePaths()
-    block_write_path_provider = UuidBlockWritePathProvider(capture_object)
+    block_write_path_provider = UuidBlockWritePathProvider(
+        capture_object=capture_object
+    )
     s3_table_writer_func = get_table_writer(table)
     table_record_count = get_table_length(table)
     if max_records_per_file is None or not table_record_count:

--- a/deltacat/tests/compute/converter/conftest.py
+++ b/deltacat/tests/compute/converter/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from pyspark.sql import SparkSession
 import os
+import ray
 from pyiceberg.catalog import Catalog, load_catalog
 
 
@@ -70,3 +71,10 @@ def session_catalog() -> Catalog:
             "s3.secret-access-key": "password",
         },
     )
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup_ray_cluster():
+    ray.init(local_mode=True, ignore_reinit_error=True)
+    yield
+    ray.shutdown()

--- a/deltacat/tests/compute/converter/test_convert_session.py
+++ b/deltacat/tests/compute/converter/test_convert_session.py
@@ -1,7 +1,36 @@
 import pytest
+import ray
 from typing import List
 from pyiceberg.catalog.rest import RestCatalog
 from pyiceberg.expressions import EqualTo
+from deltacat.tests.compute.converter.utils import commit_equality_delete_to_table
+from pyiceberg.schema import Schema
+from pyiceberg.types import (
+    NestedField,
+    StringType,
+    LongType,
+)
+from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.transforms import IdentityTransform
+import pyarrow as pa
+from pyiceberg.typedef import Record
+from deltacat.compute.converter.steps.convert import convert
+from deltacat.compute.converter.model.convert_input import ConvertInput
+from deltacat.compute.converter.pyiceberg.overrides import (
+    fetch_all_bucket_files,
+    parquet_files_dict_to_iceberg_data_files,
+)
+from collections import defaultdict
+from deltacat.compute.converter.utils.converter_session_utils import (
+    check_data_files_sequence_number,
+)
+from deltacat.tests.compute.converter.utils import (
+    get_s3_file_system,
+    drop_table_if_exists,
+)
+from deltacat.compute.converter.pyiceberg.replace_snapshot import (
+    commit_overwrite_snapshot,
+)
 
 
 def run_spark_commands(spark, sqls: List[str]) -> None:
@@ -113,3 +142,174 @@ def test_spark_position_delete_production_sanity(
         "number_partitioned": [1, 1, 0, 0],
         "primary_key": ["pk2", "pk3", "pk2", "pk3"],
     }
+
+
+@pytest.mark.integration
+def test_converter_success(
+    spark, session_catalog: RestCatalog, setup_ray_cluster, mocker
+) -> None:
+    """
+    Test for convert compute remote function happy case. Download file results are mocked.
+    """
+
+    # 1. Create Iceberg table
+    namespace = "default"
+    table_name = "table_converter_ray_pos_delete_compute"
+    identifier = f"{namespace}.{table_name}"
+
+    schema = Schema(
+        NestedField(
+            field_id=1, name="number_partitioned", field_type=LongType(), required=False
+        ),
+        NestedField(
+            field_id=2, name="primary_key", field_type=StringType(), required=False
+        ),
+        NestedField(
+            field_id=2147483546,
+            name="file_path",
+            field_type=StringType(),
+            required=False,
+        ),
+        NestedField(
+            field_id=2147483545, name="pos", field_type=LongType(), required=False
+        ),
+        schema_id=0,
+    )
+
+    partition_field_identity = PartitionField(
+        source_id=1,
+        field_id=101,
+        transform=IdentityTransform(),
+        name="number_partitioned",
+    )
+    partition_spec = PartitionSpec(partition_field_identity)
+
+    properties = dict()
+    properties["write.format.default"] = "parquet"
+    properties["write.delete.mode"] = "merge-on-read"
+    properties["write.update.mode"] = "merge-on-read"
+    properties["write.merge.mode"] = "merge-on-read"
+    properties["format-version"] = "2"
+
+    drop_table_if_exists(identifier, session_catalog)
+    session_catalog.create_table(
+        identifier,
+        schema=schema,
+        partition_spec=partition_spec,
+        properties=properties,
+    )
+
+    # Use Spark to generate initial data files
+    tbl = session_catalog.load_table(identifier)
+    tbl.refresh()
+    run_spark_commands(
+        spark,
+        [
+            f"""
+            INSERT INTO {identifier} VALUES (0, "pk1", "path1", 1), (0, "pk2", "path2", 2), (0, "pk3", "path3", 3)
+            """
+        ],
+    )
+
+    # 3. Append to table self-generated equality delete files
+    tbl = session_catalog.load_table(identifier)
+    df = tbl.inspect.entries()
+    data_files = df.to_pydict()["data_file"]
+    file_link = data_files[0]["file_path"]
+    file_prefix = "/".join(file_link.split("/")[:-1])
+    file_prefix = file_prefix.split("//")[1]
+    number_partitioned_array = pa.array([0], type=pa.int32())
+    primary_key_array = pa.array(["pk1"])
+    names = ["number_partitioned", "primary_key"]
+    equality_delete_table = pa.Table.from_arrays(
+        [number_partitioned_array, primary_key_array], names=names
+    )
+
+    partition_value = Record(number_partitioned=0)
+    commit_equality_delete_to_table(
+        table=tbl,
+        partition_value=partition_value,
+        equality_delete_table=equality_delete_table,
+        file_link_prefix=file_prefix,
+    )
+
+    # 4. Use convert.remote() function to compute position deletes
+    data_file_dict, equality_delete_dict, pos_delete_dict = fetch_all_bucket_files(tbl)
+
+    files_for_each_bucket = defaultdict(tuple)
+    for partition_value, equality_delete_file_list in equality_delete_dict.items():
+        (
+            result_equality_delete_file,
+            result_data_file,
+        ) = check_data_files_sequence_number(
+            data_files_list=data_file_dict[partition_value],
+            equality_delete_files_list=equality_delete_dict[partition_value],
+        )
+        files_for_each_bucket[partition_value] = (
+            result_data_file,
+            result_equality_delete_file,
+            [],
+        )
+
+    s3_file_system = get_s3_file_system()
+    for i, one_bucket_files in enumerate(files_for_each_bucket.items()):
+        convert_input = ConvertInput.of(
+            files_for_each_bucket=one_bucket_files,
+            convert_task_index=i,
+            iceberg_table_warehouse_prefix="warehouse/default",
+            identifier_fields=["primary_key"],
+            compact_small_files=False,
+            position_delete_for_multiple_data_files=True,
+            max_parallel_data_file_download=10,
+            s3_file_system=s3_file_system,
+        )
+
+    number_partitioned_array = pa.array([0, 0, 0], type=pa.int32())
+    primary_key_array = pa.array(["pk1", "pk2", "pk3"])
+    names = ["number_partitioned", "primary_key"]
+    data_table = pa.Table.from_arrays(
+        [number_partitioned_array, primary_key_array], names=names
+    )
+
+    number_partitioned_array = pa.array([0], type=pa.int32())
+    primary_key_array = pa.array(["pk1"])
+    names = ["number_partitioned", "primary_key"]
+    equality_delete_table = pa.Table.from_arrays(
+        [number_partitioned_array, primary_key_array], names=names
+    )
+    download_data_mock = mocker.patch(
+        "deltacat.compute.converter.steps.convert.download_parquet_with_daft_hash_applied"
+    )
+    download_data_mock.side_effect = (data_table, equality_delete_table)
+
+    convert_ref = convert.remote(convert_input)
+
+    to_be_deleted_files_list = []
+    to_be_added_files_dict_list = []
+    convert_result = ray.get(convert_ref)
+
+    to_be_deleted_files_list.extend(convert_result[0].values())
+    file_location = convert_result[1][partition_value][0]
+    to_be_added_files = f"s3://{file_location}"
+
+    to_be_added_files_dict = defaultdict()
+    to_be_added_files_dict[partition_value] = [to_be_added_files]
+    to_be_added_files_dict_list.append(to_be_added_files_dict)
+
+    # 5. Commit position delete, delete equality deletes from table
+    new_position_delete_files = parquet_files_dict_to_iceberg_data_files(
+        io=tbl.io,
+        table_metadata=tbl.metadata,
+        files_dict_list=to_be_added_files_dict_list,
+    )
+    commit_overwrite_snapshot(
+        iceberg_table=tbl,
+        # equality_delete_files + data file that all rows are deleted
+        to_be_deleted_files_list=to_be_deleted_files_list[0],
+        new_position_delete_files=new_position_delete_files,
+    )
+    tbl.refresh()
+
+    # 6. Only primary key 2 and 3 should exist in table, as primary key 1 is deleted.
+    pyicberg_scan_table_rows = tbl.scan().to_arrow().to_pydict()["primary_key"]
+    assert pyicberg_scan_table_rows == ["pk2", "pk3"]

--- a/deltacat/tests/compute/converter/utils.py
+++ b/deltacat/tests/compute/converter/utils.py
@@ -1,0 +1,123 @@
+import uuid
+import logging
+from pyiceberg.exceptions import NoSuchTableError
+from deltacat import logs
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
+
+
+def get_s3_file_system():
+    import pyarrow
+
+    return pyarrow.fs.S3FileSystem(
+        access_key="admin",
+        secret_key="password",
+        endpoint_override="http://localhost:9000",
+    )
+    #        'region="us-east-1", proxy_options={'scheme': 'http', 'host': 'localhost',
+    # 'port': 9000, 'username': 'admin',
+    # 'password': 'password'})
+
+
+def write_equality_data_table(
+    file_link_prefix, table, partition_value, equality_delete_table
+):
+    import pyarrow.parquet as pq
+
+    uuid_path = uuid.uuid4()
+    deletes_file_path = f"{file_link_prefix}/{uuid_path}_deletes.parquet"
+    file_system = get_s3_file_system()
+    pq.write_table(equality_delete_table, deletes_file_path, filesystem=file_system)
+    return f"s3://{deletes_file_path}"
+
+
+def add_equality_data_files(file_paths, table, partition_value):
+    with table.transaction() as tx:
+        if table.metadata.name_mapping() is None:
+            tx.set_properties(
+                **{
+                    "schema.name-mapping.default": table.metadata.schema().name_mapping.model_dump_json()
+                }
+            )
+        with tx.update_snapshot().fast_append() as update_snapshot:
+            data_files = parquet_files_to_equality_data_files(
+                table_metadata=table.metadata,
+                file_paths=file_paths,
+                io=table.io,
+                partition_value=partition_value,
+            )
+            for data_file in data_files:
+                update_snapshot.append_data_file(data_file)
+
+
+def parquet_files_to_equality_data_files(
+    io, table_metadata, file_paths, partition_value
+):
+    from pyiceberg.io.pyarrow import (
+        _check_pyarrow_schema_compatible,
+        data_file_statistics_from_parquet_metadata,
+        compute_statistics_plan,
+        parquet_path_to_id_mapping,
+    )
+    from pyiceberg.manifest import (
+        DataFile,
+        DataFileContent,
+        FileFormat,
+    )
+    import pyarrow.parquet as pq
+
+    for file_path in file_paths:
+        input_file = io.new_input(file_path)
+        with input_file.open() as input_stream:
+            parquet_metadata = pq.read_metadata(input_stream)
+
+        schema = table_metadata.schema()
+        _check_pyarrow_schema_compatible(
+            schema, parquet_metadata.schema.to_arrow_schema()
+        )
+
+        statistics = data_file_statistics_from_parquet_metadata(
+            parquet_metadata=parquet_metadata,
+            stats_columns=compute_statistics_plan(schema, table_metadata.properties),
+            parquet_column_mapping=parquet_path_to_id_mapping(schema),
+        )
+        data_file = DataFile(
+            content=DataFileContent.EQUALITY_DELETES,
+            file_path=file_path,
+            file_format=FileFormat.PARQUET,
+            partition=partition_value,
+            file_size_in_bytes=len(input_file),
+            sort_order_id=None,
+            spec_id=table_metadata.default_spec_id,
+            equality_ids=None,
+            key_metadata=None,
+            **statistics.to_serialized_dict(),
+        )
+
+        yield data_file
+
+
+def commit_equality_delete_to_table(
+    table, file_link_prefix, partition_value, equality_delete_table
+):
+
+    data_files = [
+        write_equality_data_table(
+            table=table,
+            file_link_prefix=file_link_prefix,
+            partition_value=partition_value,
+            equality_delete_table=equality_delete_table,
+        )
+    ]
+
+    add_equality_data_files(
+        file_paths=data_files, partition_value=partition_value, table=table
+    )
+    return data_files
+
+
+def drop_table_if_exists(table, catalog):
+    try:
+        catalog.drop_table(table)
+    except NoSuchTableError:
+        logger.warning(f"table:{table} doesn't exist, not dropping table.")

--- a/dev/_sandbox/compute/converter/example_single_merge_key_converter.py
+++ b/dev/_sandbox/compute/converter/example_single_merge_key_converter.py
@@ -27,7 +27,7 @@ def get_s3_path(
 
 
 def get_bucket_name():
-    return "metadata-py4j-zyiqin1"
+    return "converter-test"
 
 
 def get_credential():


### PR DESCRIPTION
## Summary
This PR adds working end-to-end converter find deletes compute happy case test. 
With 1. Minio S3 endpoint replaced in S3 file system 2. Daft download parquet file mocked, 
We are able to test the compute part end-to-end. 
Future dev work adding new features can use the same setup to test correctness.

## Rationale

Explain the reasoning behind the changes and their benefits to the project.

## Changes

List the major changes made in this pull request.

## Impact

Discuss any potential impacts the changes may have on existing functionalities.

## Testing

Describe how the changes have been tested, including both automated and manual testing strategies.
If this is a bugfix, explain how the fix has been tested to ensure the bug is resolved without introducing new issues.

## Regression Risk

If this is a bugfix, assess the risk of regression caused by this fix and steps taken to mitigate it.

## Checklist

- [x] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

## Additional Notes

1. More test cases pending: null primary key, multiple primary key concatenating.
2. We'd also want to add using Pyspark to read position delete we produced and assert same record count. 
