### PR TITLE
Initial Working Prototype of DeltaCAT FS API w/ Limited Catalog & Namespace Get/Put/Copy Functionality

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -29,6 +29,7 @@ from deltacat.catalog.model.catalog import (  # noqa: F401
     get_catalog,
 )
 from deltacat.catalog.iceberg import impl as IcebergCatalog
+from deltacat.catalog.main import impl as deltacatalog
 from deltacat.catalog.model.table_definition import TableDefinition
 from deltacat.storage import (
     DistributedDataset,

--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -1,6 +1,11 @@
 import logging
 
 import deltacat.logs  # noqa: F401
+from deltacat.api import (
+    copy,
+    get,
+    put,
+)
 from deltacat.catalog.delegate import (
     alter_namespace,
     alter_table,
@@ -25,11 +30,12 @@ from deltacat.catalog.model.catalog import (  # noqa: F401
     Catalog,
     Catalogs,
     all_catalogs,
+    is_initialized,
     init,
     get_catalog,
+    put_catalog,
 )
 from deltacat.catalog.iceberg import impl as IcebergCatalog
-from deltacat.catalog.main import impl as deltacatalog
 from deltacat.catalog.model.table_definition import TableDefinition
 from deltacat.storage import (
     DistributedDataset,
@@ -59,6 +65,9 @@ __version__ = "2.0"
 
 __all__ = [
     "__version__",
+    "copy",
+    "get",
+    "put",
     "all_catalogs",
     "alter_table",
     "create_table",
@@ -79,6 +88,8 @@ __all__ = [
     "write_to_table",
     "read_table",
     "get_catalog",
+    "put_catalog",
+    "is_initialized",
     "init",
     "Catalog",
     "ContentType",

--- a/deltacat/api.py
+++ b/deltacat/api.py
@@ -1,0 +1,165 @@
+from typing import Any
+
+
+import deltacat as dc
+
+
+def copy(source, destination):
+    src_parts = source.split("/")
+    src_parts = [part for part in src_parts if part]
+    dst_parts = destination.split("/")
+    dst_parts = [part for part in dst_parts if part]
+    if not dc.is_initialized():
+        raise ValueError("Catalog not initialized.")
+    if len(src_parts) != len(dst_parts) and len(src_parts) != len(dst_parts) + 1:
+        # TODO(pdames): Better error message.
+        raise ValueError(
+            f"Cannot copy {source} to {destination}. "
+            f"Source and destination must share the same type."
+        )
+    src_obj = get(source)
+    if len(src_parts) == 1:
+        # copy the given catalog
+        raise NotImplementedError
+    elif len(src_parts) == 2:
+        # TODO(pdames): Make catalog specification optional if there is only
+        #  one catalog (e.g., auto-retrieve src_parts[0]/dst_parts[0])
+        # copy the given namespace
+        src_namespace_name = src_parts[1]
+        dst_catalog_name = dst_parts[0]
+        dst_namespace_name = dst_parts[1] if len(dst_parts) >= 2 else src_namespace_name
+        new_namespace = dc.create_namespace(
+            namespace=dst_namespace_name,
+            properties=src_obj.properties,
+            catalog=dst_catalog_name,
+        )
+        return new_namespace
+    elif len(src_parts) == 3:
+        # copy the given table
+        raise NotImplementedError
+    elif len(src_parts) == 4:
+        # copy the given table version
+        raise NotImplementedError
+    elif len(src_parts) == 5:
+        # copy the given stream
+        raise NotImplementedError
+    elif len(src_parts) == 6:
+        # copy the given partition
+        raise NotImplementedError
+    elif len(src_parts) == 7:
+        # copy the given partition delta
+        raise NotImplementedError
+    raise ValueError(f"Invalid path: {src_parts}")
+
+
+def concat(source, destination):
+    pass
+
+
+def delete(source):
+    pass
+
+
+def move(source, destination):
+    pass
+
+
+def list(path):
+    pass
+
+
+def get(path) -> Any:
+    parts = path.split("/")
+    parts = [part for part in parts if part]
+    if not dc.is_initialized():
+        # TODO(pdames): Re-initialize DeltaCAT with all catalogs from the
+        #  last session.
+        raise ValueError("Catalog not initialized.")
+    if len(parts) == 1:
+        # TODO(pdames): Save all catalogs registered from the last session on
+        #  disk so that users don't need to re-initialize them every time.
+        # get the given catalog
+        catalog_name = parts[0]
+        return dc.get_catalog(catalog_name)
+    elif len(parts) == 2:
+        # get the given namespace
+        catalog_name = parts[0]
+        namespace_name = parts[1]
+        return dc.get_namespace(
+            namespace=namespace_name,
+            catalog=catalog_name,
+        )
+    elif len(parts) == 3:
+        # get the given table
+        raise NotImplementedError
+    elif len(parts) == 4:
+        # get the given table version
+        raise NotImplementedError
+    elif len(parts) == 5:
+        # get the given stream
+        raise NotImplementedError
+    elif len(parts) == 6:
+        # get the given partition
+        raise NotImplementedError
+    elif len(parts) == 7:
+        # get the given partition delta
+        raise NotImplementedError
+    raise ValueError(f"Invalid path: {path}")
+
+
+def put(path, *args, **kwargs) -> Any:
+    parts = path.split("/")
+    parts = [part for part in parts if part]
+    if len(parts) == 1:
+        # TODO(pdames): Save all catalogs registered from the last session on
+        #  disk so that users don't need to re-initialize them every time.
+        # register the given catalog
+        catalog_name = parts[0]
+        return dc.put_catalog(catalog_name, *args, **kwargs)
+    elif len(parts) == 2:
+        # register the given namespace
+        catalog_name = parts[0]
+        namespace_name = parts[1]
+        if not dc.is_initialized():
+            # TODO(pdames): Re-initialize DeltaCAT with all catalogs from the
+            #  last session.
+            raise ValueError("Catalog not initialized.")
+        new_namespace = dc.create_namespace(
+            namespace=namespace_name,
+            catalog=catalog_name,
+            *args,
+            **kwargs,
+        )
+        return new_namespace
+    elif len(parts) == 3:
+        # register the given table
+        raise NotImplementedError
+    elif len(parts) == 4:
+        # register the given table version
+        raise NotImplementedError
+    elif len(parts) == 5:
+        # register the given stream
+        raise NotImplementedError
+    elif len(parts) == 6:
+        # register the given partition
+        raise NotImplementedError
+    elif len(parts) == 7:
+        # register the given partition delta
+        raise NotImplementedError
+    raise ValueError(f"Invalid path: {path}")
+
+
+def exists(path):
+    pass
+
+
+def query(path, expression):
+    pass
+
+
+def tail(path):
+    pass
+
+
+def head(path):
+    pass

--- a/deltacat/api.py
+++ b/deltacat/api.py
@@ -53,19 +53,19 @@ def copy(source, destination):
 
 
 def concat(source, destination):
-    pass
+    raise NotImplementedError
 
 
 def delete(source):
-    pass
+    raise NotImplementedError
 
 
 def move(source, destination):
-    pass
+    raise NotImplementedError
 
 
 def list(path):
-    pass
+    raise NotImplementedError
 
 
 def get(path) -> Any:
@@ -150,16 +150,16 @@ def put(path, *args, **kwargs) -> Any:
 
 
 def exists(path):
-    pass
+    raise NotImplementedError
 
 
 def query(path, expression):
-    pass
+    raise NotImplementedError
 
 
 def tail(path):
-    pass
+    raise NotImplementedError
 
 
 def head(path):
-    pass
+    raise NotImplementedError

--- a/deltacat/catalog/__init__.py
+++ b/deltacat/catalog/__init__.py
@@ -1,4 +1,4 @@
-from deltacat.catalog.catalog_properties import (  # noqa: F401
+from deltacat.catalog.model.properties import (  # noqa: F401
     CatalogProperties,
     get_catalog_properties,
     initialize_properties,

--- a/deltacat/catalog/delegate.py
+++ b/deltacat/catalog/delegate.py
@@ -276,7 +276,10 @@ def list_namespaces(
 
 
 def get_namespace(
-    namespace: str, catalog: Optional[str] = None, *args, **kwargs
+    namespace: str,
+    catalog: Optional[str] = None,
+    *args,
+    **kwargs,
 ) -> Optional[Namespace]:
     """Get table namespace metadata for the specified table namespace. Returns
     None if the given namespace does not exist."""

--- a/deltacat/catalog/delegate.py
+++ b/deltacat/catalog/delegate.py
@@ -290,7 +290,10 @@ def get_namespace(
 
 
 def namespace_exists(
-    namespace: str, catalog: Optional[str] = None, *args, **kwargs
+    namespace: str,
+    catalog: Optional[str] = None,
+    *args,
+    **kwargs,
 ) -> bool:
     """Returns True if the given table namespace exists, False if not."""
     catalog = get_catalog(catalog)
@@ -304,7 +307,7 @@ def namespace_exists(
 
 def create_namespace(
     namespace: str,
-    properties: NamespaceProperties,
+    properties: Optional[NamespaceProperties] = None,
     catalog: Optional[str] = None,
     *args,
     **kwargs,

--- a/deltacat/catalog/interface.py
+++ b/deltacat/catalog/interface.py
@@ -25,7 +25,7 @@ def write_to_table(
     mode: TableWriteMode = TableWriteMode.AUTO,
     content_type: ContentType = ContentType.PARQUET,
     *args,
-    **kwargs
+    **kwargs,
 ) -> None:
     """Write local or distributed data to a table. Raises an error if the
     table does not exist and the table write mode is not CREATE or AUTO.
@@ -54,7 +54,7 @@ def alter_table(
     description: Optional[str] = None,
     properties: Optional[TableProperties] = None,
     *args,
-    **kwargs
+    **kwargs,
 ) -> None:
     """Alter table definition."""
     raise NotImplementedError("alter_table not implemented")
@@ -73,7 +73,7 @@ def create_table(
     content_types: Optional[List[ContentType]] = None,
     fail_if_exists: bool = True,
     *args,
-    **kwargs
+    **kwargs,
 ) -> TableDefinition:
     """Create an empty table. Raises an error if the table already exists and
     `fail_if_exists` is True (default behavior)."""
@@ -146,7 +146,10 @@ def namespace_exists(namespace: str, *args, **kwargs) -> bool:
 
 
 def create_namespace(
-    namespace: str, properties: NamespaceProperties, *args, **kwargs
+    namespace: str,
+    properties: Optional[NamespaceProperties] = None,
+    *args,
+    **kwargs,
 ) -> Namespace:
     """Creates a table namespace with the given name and properties. Returns
     the created namespace. Raises an error if the namespace already exists."""
@@ -158,7 +161,7 @@ def alter_namespace(
     properties: Optional[NamespaceProperties] = None,
     new_namespace: Optional[str] = None,
     *args,
-    **kwargs
+    **kwargs,
 ) -> None:
     """Alter table namespace definition."""
     raise NotImplementedError("alter_namespace not implemented")

--- a/deltacat/catalog/main/impl.py
+++ b/deltacat/catalog/main/impl.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
-from deltacat.catalog.catalog_properties import initialize_properties
+import deltacat.catalog.v2.catalog_impl as v2
+from deltacat.catalog.model.properties import CatalogProperties
 from deltacat.storage.model.partition import PartitionScheme
 from deltacat.catalog.model.table_definition import TableDefinition
 from deltacat.storage.model.sort_key import SortScheme
@@ -26,7 +27,7 @@ def write_to_table(
     mode: TableWriteMode = TableWriteMode.AUTO,
     content_type: ContentType = ContentType.PARQUET,
     *args,
-    **kwargs
+    **kwargs,
 ) -> None:
     """Write local or distributed data to a table. Raises an error if the
     table does not exist and the table write mode is not CREATE or AUTO.
@@ -55,7 +56,7 @@ def alter_table(
     description: Optional[str] = None,
     properties: Optional[TableProperties] = None,
     *args,
-    **kwargs
+    **kwargs,
 ) -> None:
     """Alter table definition."""
     raise NotImplementedError("alter_table not implemented")
@@ -74,7 +75,7 @@ def create_table(
     content_types: Optional[List[ContentType]] = None,
     fail_if_exists: bool = True,
     *args,
-    **kwargs
+    **kwargs,
 ) -> TableDefinition:
     """Create an empty table. Raises an error if the table already exists and
     `fail_if_exists` is True (default behavior)."""
@@ -135,10 +136,18 @@ def list_namespaces(*args, **kwargs) -> ListResult[Namespace]:
     raise NotImplementedError("list_namespaces not implemented")
 
 
-def get_namespace(namespace: str, *args, **kwargs) -> Optional[Namespace]:
+def get_namespace(
+    namespace: str,
+    *args,
+    **kwargs,
+) -> Optional[Namespace]:
     """Gets table namespace metadata for the specified table namespace. Returns
     None if the given namespace does not exist."""
-    raise NotImplementedError("get_namespace not implemented")
+    return v2.get_namespace(
+        namespace=namespace,
+        *args,
+        **kwargs,
+    )
 
 
 def namespace_exists(namespace: str, *args, **kwargs) -> bool:
@@ -147,11 +156,19 @@ def namespace_exists(namespace: str, *args, **kwargs) -> bool:
 
 
 def create_namespace(
-    namespace: str, properties: NamespaceProperties, *args, **kwargs
+    namespace: str,
+    properties: Optional[NamespaceProperties] = None,
+    *args,
+    **kwargs,
 ) -> Namespace:
     """Creates a table namespace with the given name and properties. Returns
     the created namespace. Raises an error if the namespace already exists."""
-    raise NotImplementedError("create_namespace not implemented")
+    return v2.create_namespace(
+        namespace=namespace,
+        properties=properties,
+        *args,
+        **kwargs,
+    )
 
 
 def alter_namespace(
@@ -159,7 +176,7 @@ def alter_namespace(
     properties: Optional[NamespaceProperties] = None,
     new_namespace: Optional[str] = None,
     *args,
-    **kwargs
+    **kwargs,
 ) -> None:
     """Alter table namespace definition."""
     raise NotImplementedError("alter_namespace not implemented")
@@ -178,4 +195,4 @@ def default_namespace(*args, **kwargs) -> str:
 
 # catalog functions
 def initialize(*args, **kwargs) -> Optional[Any]:
-    initialize_properties(*args, **kwargs)
+    return CatalogProperties(*args, **kwargs)

--- a/deltacat/catalog/model/catalog.py
+++ b/deltacat/catalog/model/catalog.py
@@ -8,7 +8,7 @@ from functools import partial
 import ray
 
 from deltacat import logs
-from deltacat.catalog import interface as catalog_interface
+from deltacat.catalog.main import impl as deltacat_catalog
 
 all_catalogs: Optional[Catalogs] = None
 
@@ -16,7 +16,7 @@ logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
 class Catalog:
-    def __init__(self, impl=catalog_interface, *args, **kwargs):
+    def __init__(self, impl=deltacat_catalog, *args, **kwargs):
         if not isinstance(self, Catalog):
             # self may contain the tuple returned from __reduce__ (ray pickle bug?)
             if callable(self[0]) and isinstance(self[1], tuple):

--- a/deltacat/catalog/model/catalog.py
+++ b/deltacat/catalog/model/catalog.py
@@ -44,6 +44,19 @@ class Catalog:
         # (e.g. Iceberg catalog w/ unserializable SSLContext from boto3 client)
         return partial(self.__class__, **self._kwargs), (self._impl, *self._args)
 
+    def __str__(self):
+        string_rep = f"{self.__class__.__name__}("
+        if self._args:
+            string_rep += f"args={self._args}, "
+        if self._kwargs:
+            string_rep += f"kwargs={self._kwargs}, "
+        if self._native_object:
+            string_rep += f"native_object={self._native_object})"
+        return string_rep
+
+    def __repr__(self):
+        return self.__str__()
+
 
 @ray.remote
 class Catalogs:
@@ -88,6 +101,10 @@ class Catalogs:
         return self.default_catalog
 
 
+def is_initialized() -> bool:
+    return all_catalogs is not None
+
+
 def init(
     catalogs: Dict[str, Catalog],
     default_catalog_name: Optional[str] = None,
@@ -95,6 +112,9 @@ def init(
     *args,
     **kwargs,
 ) -> None:
+    if is_initialized():
+        logger.warning("DeltaCAT already initialized.")
+        return
 
     if not ray.is_initialized():
         if ray_init_args:
@@ -134,3 +154,19 @@ def get_catalog(name: Optional[str] = None) -> Catalog:
             f"Catalog '{name}' not found. Available catalogs: " f"{available_catalogs}."
         )
     return catalog
+
+
+def put_catalog(name: str, *args, **kwargs) -> Catalog:
+    from deltacat.catalog.model.catalog import all_catalogs
+
+    new_catalog = Catalog(*args, **kwargs)
+    if is_initialized():
+        try:
+            get_catalog(name)
+            raise ValueError(f"Catalog {name} already exists.")
+        except ValueError:
+            # TODO(pdames): Create dc.put_catalog() helper.
+            ray.get(all_catalogs.put.remote(name, new_catalog))
+    else:
+        init({name: new_catalog})
+    return new_catalog

--- a/deltacat/catalog/model/properties.py
+++ b/deltacat/catalog/model/properties.py
@@ -10,7 +10,7 @@ from deltacat.utils.filesystem import resolve_path_and_filesystem
 Global (i.e., interpreter-level) DeltaCAT catalog property config attributes.
 
 These will be set to catalog property system environment variables by
-default, unless overridden by custom catalog properties provided to catalog or 
+default, unless overridden by custom catalog properties provided to catalog or
 storage APIs directly.
 
 Example: injecting custom CatalogProperties

--- a/deltacat/catalog/v2/catalog_impl.py
+++ b/deltacat/catalog/v2/catalog_impl.py
@@ -54,7 +54,10 @@ def write_to_table(
 
 
 def read_table(
-    table: str, *args, namespace: Optional[str] = None, **kwargs
+    table: str,
+    *args,
+    namespace: Optional[str] = None,
+    **kwargs,
 ) -> DistributedDataset:
     """Read data from a DeltaCat table.
 
@@ -239,7 +242,12 @@ def drop_table(
     )
 
 
-def refresh_table(table: str, *args, namespace: Optional[str] = None, **kwargs) -> None:
+def refresh_table(
+    table: str,
+    *args,
+    namespace: Optional[str] = None,
+    **kwargs,
+) -> None:
     """Refresh metadata cached on the Ray cluster for the given table.
 
     Args:
@@ -253,7 +261,9 @@ def refresh_table(table: str, *args, namespace: Optional[str] = None, **kwargs) 
 
 
 def list_tables(
-    *args, namespace: Optional[str] = None, **kwargs
+    *args,
+    namespace: Optional[str] = None,
+    **kwargs,
 ) -> ListResult[TableDefinition]:
     """List a page of table definitions.
 
@@ -337,7 +347,10 @@ def get_table(
 
 
 def truncate_table(
-    table: str, *args, namespace: Optional[str] = None, **kwargs
+    table: str,
+    *args,
+    namespace: Optional[str] = None,
+    **kwargs,
 ) -> None:
     """Truncate table data.
 
@@ -352,7 +365,11 @@ def truncate_table(
 
 
 def rename_table(
-    table: str, new_name: str, *args, namespace: Optional[str] = None, **kwargs
+    table: str,
+    new_name: str,
+    *args,
+    namespace: Optional[str] = None,
+    **kwargs,
 ) -> None:
     """Rename an existing table.
 
@@ -373,7 +390,12 @@ def rename_table(
     )
 
 
-def table_exists(table: str, *args, namespace: Optional[str] = None, **kwargs) -> bool:
+def table_exists(
+    table: str,
+    *args,
+    namespace: Optional[str] = None,
+    **kwargs,
+) -> bool:
     """Check if a table exists in the catalog.
 
     Args:
@@ -385,7 +407,10 @@ def table_exists(table: str, *args, namespace: Optional[str] = None, **kwargs) -
     """
     namespace = namespace or default_namespace()
     return storage_impl.table_exists(
-        *args, table_name=table, namespace=namespace, **kwargs
+        *args,
+        table_name=table,
+        namespace=namespace,
+        **kwargs,
     )
 
 
@@ -401,7 +426,11 @@ def list_namespaces(*args, **kwargs) -> ListResult[Namespace]:
     return storage_impl.list_namespaces(*args, **kwargs)
 
 
-def get_namespace(namespace: str, *args, **kwargs) -> Optional[Namespace]:
+def get_namespace(
+    namespace: str,
+    *args,
+    **kwargs,
+) -> Optional[Namespace]:
     """Get metadata for a specific table namespace.
 
     Args:
@@ -410,23 +439,37 @@ def get_namespace(namespace: str, *args, **kwargs) -> Optional[Namespace]:
     Returns:
         Namespace object if the namespace exists, None otherwise.
     """
-    return storage_impl.get_namespace(*args, namespace=namespace, **kwargs)
+    return storage_impl.get_namespace(
+        namespace=namespace,
+        *args,
+        **kwargs,
+    )
 
 
-def namespace_exists(namespace: str, *args, **kwargs) -> bool:
-    """Check if a namespace exists.
-
+def namespace_exists(
+    namespace: str,
+    *args,
+    **kwargs,
+) -> bool:
+    """
     Args:
         namespace: Name of the namespace to check.
 
     Returns:
         True if the namespace exists, False otherwise.
     """
-    return storage_impl.namespace_exists(*args, namespace=namespace, **kwargs)
+    return storage_impl.namespace_exists(
+        namespace=namespace,
+        *args,
+        **kwargs,
+    )
 
 
 def create_namespace(
-    namespace: str, *args, properties: Optional[NamespaceProperties] = None, **kwargs
+    namespace: str,
+    *args,
+    properties: Optional[NamespaceProperties] = None,
+    **kwargs,
 ) -> Namespace:
     """Create a new namespace.
 
@@ -440,11 +483,14 @@ def create_namespace(
     Raises:
         NamespaceAlreadyExistsError: If the namespace already exists.
     """
-    if namespace_exists(namespace):
+    if namespace_exists(namespace, *args, **kwargs):
         raise NamespaceAlreadyExistsError(f"Namespace {namespace} already exists")
 
     return storage_impl.create_namespace(
-        *args, namespace=namespace, properties=properties, **kwargs
+        namespace=namespace,
+        properties=properties,
+        *args,
+        **kwargs,
     )
 
 

--- a/deltacat/constants.py
+++ b/deltacat/constants.py
@@ -38,8 +38,9 @@ DELTACAT_LOGGER_USE_SINGLE_HANDLER = env_bool(
     "DELTACAT_LOGGER_USE_SINGLE_HANDLER",
     False,
 )
-DELTACAT_CATALOG_PROPERTY_ROOT = os.environ.get(
-    "DELTACAT_ROOT", os.path.join(os.getcwd(), ".deltacat")
+DELTACAT_ROOT = env_string(
+    "DELTACAT_ROOT",
+    os.path.join(os.getcwd(), ".deltacat"),
 )
 
 # CLI Args

--- a/deltacat/env.py
+++ b/deltacat/env.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import argparse
 from typing import Dict, Any
 
 from deltacat import logs

--- a/deltacat/env.py
+++ b/deltacat/env.py
@@ -1,0 +1,52 @@
+import os
+import logging
+import argparse
+from typing import Dict, Any
+
+from deltacat import logs
+
+from deltacat.constants import (
+    DELTACAT_APP_LOG_LEVEL,
+    DELTACAT_SYS_LOG_LEVEL,
+    DELTACAT_APP_LOG_DIR,
+    DELTACAT_SYS_LOG_DIR,
+    DELTACAT_APP_INFO_LOG_BASE_FILE_NAME,
+    DELTACAT_SYS_INFO_LOG_BASE_FILE_NAME,
+    DELTACAT_APP_DEBUG_LOG_BASE_FILE_NAME,
+    DELTACAT_SYS_DEBUG_LOG_BASE_FILE_NAME,
+    DELTACAT_LOGGER_USE_SINGLE_HANDLER,
+)
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
+
+
+def create_ray_runtime_environment() -> Dict[str, Any]:
+    # log the system environment for debugging
+    logger.debug(f"System Environment: {os.environ}")
+
+    # read the stage (e.g. alpha, beta, dev, etc.) from system environment vars
+    stage = os.environ.get("STAGE")
+    logger.debug(f"Runtime Environment Stage: {stage}")
+    runtime_environment = None
+    if stage:
+        worker_env_vars = {
+            # forward the STAGE environment variable to workers
+            "STAGE": stage,
+            # forward deltacat logging environment variables to workers
+            "DELTACAT_APP_LOG_LEVEL": DELTACAT_APP_LOG_LEVEL,
+            "DELTACAT_SYS_LOG_LEVEL": DELTACAT_SYS_LOG_LEVEL,
+            "DELTACAT_APP_LOG_DIR": DELTACAT_APP_LOG_DIR,
+            "DELTACAT_SYS_LOG_DIR": DELTACAT_SYS_LOG_DIR,
+            "DELTACAT_APP_INFO_LOG_BASE_FILE_NAME": DELTACAT_APP_INFO_LOG_BASE_FILE_NAME,
+            "DELTACAT_SYS_INFO_LOG_BASE_FILE_NAME": DELTACAT_SYS_INFO_LOG_BASE_FILE_NAME,
+            "DELTACAT_APP_DEBUG_LOG_BASE_FILE_NAME": DELTACAT_APP_DEBUG_LOG_BASE_FILE_NAME,
+            "DELTACAT_SYS_DEBUG_LOG_BASE_FILE_NAME": DELTACAT_SYS_DEBUG_LOG_BASE_FILE_NAME,
+            "DELTACAT_LOGGER_USE_SINGLE_HANDLER": str(
+                DELTACAT_LOGGER_USE_SINGLE_HANDLER
+            ),
+        }
+        # setup runtime environment from system environment variables:
+        runtime_environment = {
+            "env_vars": worker_env_vars,
+        }
+    return runtime_environment

--- a/deltacat/examples/basic_logging.py
+++ b/deltacat/examples/basic_logging.py
@@ -5,9 +5,9 @@ import logging
 from deltacat import logs
 from deltacat.constants import DELTACAT_APP_LOG_DIR, DELTACAT_SYS_LOG_DIR
 from deltacat.examples.common.fixtures import (
-    create_runtime_environment,
     store_cli_args_in_os_environ,
 )
+from deltacat.env import create_ray_runtime_environment
 
 # initialize the driver logger
 driver_logger = logs.configure_application_logger(logging.getLogger(__name__))
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     store_cli_args_in_os_environ(example_script_args)
 
     # create any runtime environment required to run the example
-    runtime_env = create_runtime_environment()
+    runtime_env = create_ray_runtime_environment()
 
     # initialize ray
     ray.init(runtime_env=runtime_env)

--- a/deltacat/examples/common/fixtures.py
+++ b/deltacat/examples/common/fixtures.py
@@ -3,18 +3,6 @@ import logging
 import argparse
 from deltacat import logs
 
-from deltacat.constants import (
-    DELTACAT_APP_LOG_LEVEL,
-    DELTACAT_SYS_LOG_LEVEL,
-    DELTACAT_APP_LOG_DIR,
-    DELTACAT_SYS_LOG_DIR,
-    DELTACAT_APP_INFO_LOG_BASE_FILE_NAME,
-    DELTACAT_SYS_INFO_LOG_BASE_FILE_NAME,
-    DELTACAT_APP_DEBUG_LOG_BASE_FILE_NAME,
-    DELTACAT_SYS_DEBUG_LOG_BASE_FILE_NAME,
-    DELTACAT_LOGGER_USE_SINGLE_HANDLER,
-)
-
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
@@ -25,35 +13,3 @@ def store_cli_args_in_os_environ(script_args_list=[]):
     args = parser.parse_args()
     print(f"Command Line Arguments: {args}")
     os.environ.update(vars(args))
-
-
-def create_runtime_environment():
-    # log the job run system environment for debugging
-    logger.debug(f"Job Run System Environment: {os.environ}")
-
-    # read the stage (e.g. alpha, beta, dev, etc.) from the system environment vars
-    stage = os.environ.get("STAGE")
-    logger.debug(f"Job Run Stage: {stage}")
-    runtime_environment = None
-    if stage:
-        worker_env_vars = {
-            # forward the STAGE environment variable to workers
-            "STAGE": stage,
-            # forward deltacat logging environment variables to workers
-            "DELTACAT_APP_LOG_LEVEL": DELTACAT_APP_LOG_LEVEL,
-            "DELTACAT_SYS_LOG_LEVEL": DELTACAT_SYS_LOG_LEVEL,
-            "DELTACAT_APP_LOG_DIR": DELTACAT_APP_LOG_DIR,
-            "DELTACAT_SYS_LOG_DIR": DELTACAT_SYS_LOG_DIR,
-            "DELTACAT_APP_INFO_LOG_BASE_FILE_NAME": DELTACAT_APP_INFO_LOG_BASE_FILE_NAME,
-            "DELTACAT_SYS_INFO_LOG_BASE_FILE_NAME": DELTACAT_SYS_INFO_LOG_BASE_FILE_NAME,
-            "DELTACAT_APP_DEBUG_LOG_BASE_FILE_NAME": DELTACAT_APP_DEBUG_LOG_BASE_FILE_NAME,
-            "DELTACAT_SYS_DEBUG_LOG_BASE_FILE_NAME": DELTACAT_SYS_DEBUG_LOG_BASE_FILE_NAME,
-            "DELTACAT_LOGGER_USE_SINGLE_HANDLER": str(
-                DELTACAT_LOGGER_USE_SINGLE_HANDLER
-            ),
-        }
-        # setup runtime environment from system environment variables:
-        runtime_environment = {
-            "env_vars": worker_env_vars,
-        }
-    return runtime_environment

--- a/deltacat/examples/iceberg/iceberg_bucket_writer.py
+++ b/deltacat/examples/iceberg/iceberg_bucket_writer.py
@@ -7,7 +7,6 @@ import deltacat as dc
 from deltacat import logs
 from deltacat import IcebergCatalog
 from deltacat.examples.common.fixtures import (
-    create_runtime_environment,
     store_cli_args_in_os_environ,
 )
 
@@ -24,6 +23,7 @@ from deltacat.storage.iceberg.model import (
     SchemaMapper,
     PartitionSchemeMapper,
 )
+from deltacat.env import create_ray_runtime_environment
 
 # initialize the driver logger
 driver_logger = logs.configure_application_logger(logging.getLogger(__name__))
@@ -31,7 +31,7 @@ driver_logger = logs.configure_application_logger(logging.getLogger(__name__))
 
 def run(warehouse="s3://my-bucket/my/key/prefix", **kwargs):
     # create any runtime environment required to run the example
-    runtime_env = create_runtime_environment()
+    runtime_env = create_ray_runtime_environment()
 
     # Start by initializing DeltaCAT and registering available Catalogs.
     # Ray will be initialized automatically via `ray.init()`.

--- a/deltacat/examples/iceberg/iceberg_reader.py
+++ b/deltacat/examples/iceberg/iceberg_reader.py
@@ -5,7 +5,6 @@ import deltacat as dc
 from deltacat import logs
 from deltacat import IcebergCatalog
 from deltacat.examples.common.fixtures import (
-    create_runtime_environment,
     store_cli_args_in_os_environ,
 )
 
@@ -28,6 +27,7 @@ from deltacat.storage.iceberg.model import (
     PartitionSchemeMapper,
     SortSchemeMapper,
 )
+from deltacat.env import create_ray_runtime_environment
 
 # initialize the driver logger
 driver_logger = logs.configure_application_logger(logging.getLogger(__name__))
@@ -35,7 +35,7 @@ driver_logger = logs.configure_application_logger(logging.getLogger(__name__))
 
 def run(warehouse="s3://my-bucket/my/key/prefix", **kwargs):
     # create any runtime environment required to run the example
-    runtime_env = create_runtime_environment()
+    runtime_env = create_ray_runtime_environment()
 
     # Start by initializing DeltaCAT and registering available Catalogs.
     # Ray will be initialized automatically via `ray.init()`.

--- a/deltacat/exceptions.py
+++ b/deltacat/exceptions.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 from enum import Enum
-import botocore
-import ray
+from typing import Callable
 import logging
+
 import tenacity
-from deltacat import logs
+
+from pyarrow.lib import ArrowException, ArrowInvalid, ArrowCapacityError
+
+import botocore
+from botocore.exceptions import BotoCoreError
+
+import ray
 from ray.exceptions import (
     RayError,
     RayTaskError,
@@ -13,14 +19,14 @@ from ray.exceptions import (
     NodeDiedError,
     OutOfMemoryError,
 )
-from deltacat.storage import interface as DeltaCatStorage
-from pyarrow.lib import ArrowException, ArrowInvalid, ArrowCapacityError
-from botocore.exceptions import BotoCoreError
-from typing import Callable
+
+from daft.exceptions import DaftTransientError, DaftCoreException
+
+import deltacat as dc
+from deltacat import logs
 from deltacat.utils.ray_utils.runtime import (
     get_current_ray_task_id,
 )
-from daft.exceptions import DaftTransientError, DaftCoreException
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
@@ -274,7 +280,7 @@ def categorize_errors(func: Callable):
 
 def categorize_deltacat_exception(
     e: BaseException,
-    deltacat_storage: DeltaCatStorage = None,
+    deltacat_storage: dc.storage.interface = None,
     deltacat_storage_kwargs: dict = None,
 ):
     if deltacat_storage_kwargs is None:

--- a/deltacat/tests/catalog/main/test_catalog_impl_namespace_operations.py
+++ b/deltacat/tests/catalog/main/test_catalog_impl_namespace_operations.py
@@ -105,14 +105,25 @@ class TestCatalogNamespaceOperations:
 
         # Create namespace
         catalog.create_namespace(
-            namespace=namespace, properties=properties, catalog=catalog
+            namespace=namespace,
+            properties=properties,
+            catalog=self.catalog_properties,
         )
 
         # Verify namespace exists
-        assert catalog.namespace_exists(namespace, catalog=catalog)
+        assert catalog.namespace_exists(
+            namespace,
+            catalog=self.catalog_properties,
+        )
 
         # Drop namespace
-        catalog.drop_namespace(namespace, catalog=catalog)
+        catalog.drop_namespace(
+            namespace,
+            catalog=self.catalog_properties,
+        )
 
         # Verify namespace does not exist
-        assert not catalog.namespace_exists(namespace, catalog=catalog)
+        assert not catalog.namespace_exists(
+            namespace,
+            catalog=self.catalog_properties,
+        )

--- a/deltacat/tests/catalog/main/test_catalog_impl_namespace_operations.py
+++ b/deltacat/tests/catalog/main/test_catalog_impl_namespace_operations.py
@@ -27,16 +27,14 @@ class TestCatalogNamespaceOperations:
 
         # Create namespace
         catalog.create_namespace(
-            namespace=namespace, properties=properties, catalog=catalog
+            namespace=namespace, properties=properties, catalog=self.catalog_properties
         )
 
         # Verify namespace exists
-        assert catalog.namespace_exists(namespace, catalog=catalog)
+        assert catalog.namespace_exists(namespace, catalog=self.catalog_properties)
 
         # Get namespace and verify properties
-        namespace = catalog.get_namespace(
-            namespace, catalog_properties=self.catalog_properties
-        )
+        namespace = catalog.get_namespace(namespace, catalog=self.catalog_properties)
         assert namespace.namespace == "test_create_namespace"
         assert namespace.properties["description"] == "Test Namespace"
 
@@ -47,7 +45,7 @@ class TestCatalogNamespaceOperations:
 
         # Create namespace
         catalog.create_namespace(
-            namespace=namespace, properties=properties, catalog=catalog
+            namespace=namespace, properties=properties, catalog=self.catalog_properties
         )
 
         # Get namespace properties
@@ -64,14 +62,18 @@ class TestCatalogNamespaceOperations:
 
         # Create namespace
         catalog.create_namespace(
-            namespace=existing_namespace, properties={}, catalog=catalog
+            namespace=existing_namespace, properties={}, catalog=self.catalog_properties
         )
 
         # Check existing namespace
-        assert catalog.namespace_exists(existing_namespace, catalog=catalog)
+        assert catalog.namespace_exists(
+            existing_namespace, catalog=self.catalog_properties
+        )
 
         # Check non-existing namespace
-        assert not catalog.namespace_exists(non_existing_namespace, catalog=catalog)
+        assert not catalog.namespace_exists(
+            non_existing_namespace, catalog=self.catalog_properties
+        )
 
     def test_create_namespace_already_exists(self):
         """Test creating a namespace that already exists should fail"""
@@ -82,16 +84,18 @@ class TestCatalogNamespaceOperations:
         catalog.create_namespace(
             namespace=namespace,
             properties=properties,
-            catalog_properties=self.catalog_properties,
+            catalog=self.catalog_properties,
         )
 
         # Verify namespace exists
-        assert catalog.namespace_exists(namespace, catalog=catalog)
+        assert catalog.namespace_exists(namespace, catalog=self.catalog_properties)
 
         # Try to create the same namespace again, should raise ValueError
         with pytest.raises(NamespaceAlreadyExistsError, match=namespace):
             catalog.create_namespace(
-                namespace=namespace, properties=properties, catalog=catalog
+                namespace=namespace,
+                properties=properties,
+                catalog=self.catalog_properties,
             )
 
     def test_drop_namespace(self):

--- a/deltacat/tests/catalog/main/test_catalog_impl_namespace_operations.py
+++ b/deltacat/tests/catalog/main/test_catalog_impl_namespace_operations.py
@@ -3,7 +3,7 @@ from deltacat.exceptions import NamespaceAlreadyExistsError
 import pytest
 import tempfile
 import deltacat.catalog.v2.catalog_impl as catalog
-from deltacat.catalog.catalog_properties import initialize_properties
+from deltacat.catalog.model.properties import initialize_properties
 
 
 class TestCatalogNamespaceOperations:

--- a/deltacat/tests/catalog/main/test_catalog_impl_table_operations.py
+++ b/deltacat/tests/catalog/main/test_catalog_impl_table_operations.py
@@ -4,7 +4,7 @@ import pytest
 import pyarrow as pa
 
 import deltacat.catalog.v2.catalog_impl as catalog
-from deltacat.catalog.catalog_properties import initialize_properties
+from deltacat.catalog.model.properties import initialize_properties
 from deltacat.storage.model.schema import Schema
 from deltacat.storage.model.sort_key import SortKey, SortScheme, SortOrder, NullOrder
 from deltacat.storage.model.table import TableProperties

--- a/deltacat/tests/storage/main/test_main_storage.py
+++ b/deltacat/tests/storage/main/test_main_storage.py
@@ -39,11 +39,11 @@ class TestNamespace:
         cls.catalog = CatalogProperties(cls.tmpdir)
         cls.namespace1 = metastore.create_namespace(
             namespace="namespace1",
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
         cls.namespace2 = metastore.create_namespace(
             namespace="namespace2",
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
 
     @classmethod
@@ -59,11 +59,11 @@ class TestNamespace:
         # expect the namespace to exist
         assert metastore.namespace_exists(
             namespace="namespace1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
 
         # expect the namespace to also be returned when listing namespaces
-        list_result = metastore.list_namespaces(catalog_properties=self.catalog)
+        list_result = metastore.list_namespaces(catalog=self.catalog)
         namespaces_by_name = {n.locator.namespace: n for n in list_result.all_items()}
         assert len(namespaces_by_name.items()) == 2
         assert namespaces_by_name["namespace1"].equivalent_to(self.namespace1)
@@ -73,20 +73,20 @@ class TestNamespace:
         # expect the namespace to also be returned when explicitly retrieved
         read_namespace = metastore.get_namespace(
             namespace="namespace1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         assert read_namespace and read_namespace.equivalent_to(self.namespace1)
 
     def test_namespace_exists_existing(self):
         assert metastore.namespace_exists(
             "namespace1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
 
     def test_namespace_not_exists(self):
         assert not metastore.namespace_exists(
             "foobar",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
 
 
@@ -99,7 +99,7 @@ class TestTable:
         cls.test_namespace = create_test_namespace()
         cls.namespace_obj = metastore.create_namespace(
             namespace=cls.test_namespace.namespace,
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
         cls.test_table1 = create_test_table()
         cls.test_table1.latest_table_version = "v.1"
@@ -113,7 +113,7 @@ class TestTable:
             table_version=cls.test_table1.latest_table_version,
             table_description=cls.test_table1.description,
             table_properties=cls.test_table1.properties,
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
         cls.table2, cls.tv2, cls.stream2 = metastore.create_table_version(
             namespace=cls.test_table2.namespace,
@@ -121,7 +121,7 @@ class TestTable:
             table_version=cls.test_table2.latest_table_version,
             table_description=cls.test_table2.description,
             table_properties=cls.test_table2.properties,
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
 
     @classmethod
@@ -132,7 +132,7 @@ class TestTable:
         # list the tables under our namespace
         list_result = metastore.list_tables(
             namespace=self.test_namespace.namespace,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         all_tables = list_result.all_items()
 
@@ -148,7 +148,7 @@ class TestTable:
         tbl = metastore.get_table(
             namespace=self.test_namespace.namespace,
             table_name=self.test_table1.table_name,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         assert tbl is not None
         assert tbl.equivalent_to(self.test_table1)
@@ -158,14 +158,14 @@ class TestTable:
         assert metastore.table_exists(
             namespace=self.test_namespace.namespace,
             table_name=self.test_table1.table_name,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
 
     def test_table_not_exists(self):
         assert not metastore.table_exists(
             namespace=self.test_namespace.namespace,
             table_name="no_such_table",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
 
 
@@ -189,7 +189,7 @@ class TestTableVersion:
         # create a namespace and single table
         cls.namespace_obj = metastore.create_namespace(
             namespace=cls.namespace.namespace,
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
 
         # create a "base" table with single table version attached
@@ -205,7 +205,7 @@ class TestTableVersion:
             table_description=cls.table.description,
             table_properties=cls.table.properties,
             supported_content_types=cls.table_version.content_types,
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
         # now attach a second table version to the same base table
         cls.table2, cls.tv2, cls.stream2 = metastore.create_table_version(
@@ -220,7 +220,7 @@ class TestTableVersion:
             table_description=cls.table.description,
             table_properties=cls.table.properties,
             supported_content_types=cls.table_version2.content_types,
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
         cls.table.latest_table_version = cls.table_version2.table_version
 
@@ -246,7 +246,7 @@ class TestTableVersion:
                 table_description=self.table.description,
                 table_properties=self.table.properties,
                 supported_content_types=table_version.content_types,
-                catalog_properties=self.catalog,
+                catalog=self.catalog,
             )
 
     def test_create_next_table_version(self):
@@ -268,13 +268,13 @@ class TestTableVersion:
             table_description=self.table.description,
             table_properties=self.table.properties,
             supported_content_types=table_version.content_types,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect ordinal table version 3 to be successfully created
         table_version3 = metastore.get_latest_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         table_version.previous_table_version = self.table_version2.table_version
         assert table_version3.equivalent_to(table_version)
@@ -292,13 +292,13 @@ class TestTableVersion:
             table_description=self.table.description,
             table_properties=self.table.properties,
             supported_content_types=self.table_version.content_types,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we retrieve this table version
         table_version = metastore.get_latest_table_version(
             namespace=self.table.namespace,
             table_name="test_table_2",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to have the correct default table version ID assigned
         table_version.previous_table_version = self.table_version2.table_version
@@ -311,7 +311,7 @@ class TestTableVersion:
         list_result = metastore.list_table_versions(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we list all table versions
         # expect the table versions fetched to be equivalent to those created
@@ -335,7 +335,7 @@ class TestTableVersion:
             # expect an error to be raised
             with pytest.raises(ValueError):
                 metastore.list_table_versions(
-                    catalog_properties=self.catalog,
+                    catalog=self.catalog,
                     **kwargs_copy,
                 )
 
@@ -345,7 +345,7 @@ class TestTableVersion:
         tv = metastore.get_latest_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equivalent ot the last created table version
         assert tv.equivalent_to(self.table_version2)
@@ -363,7 +363,7 @@ class TestTableVersion:
             # expect an error to be raised
             with pytest.raises(ValueError):
                 metastore.get_latest_table_version(
-                    catalog_properties=self.catalog,
+                    catalog=self.catalog,
                     **kwargs_copy,
                 )
 
@@ -386,14 +386,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             schema=new_schema,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get the new schema of table version 1
         actual_schema = metastore.get_table_version_schema(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equivalent to the expected schema
         assert actual_schema.equivalent_to(new_schema)
@@ -403,7 +403,7 @@ class TestTableVersion:
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         assert len(tv.schemas) == 2
         assert tv.schemas[0].equivalent_to(old_schema)
@@ -435,7 +435,7 @@ class TestTableVersion:
                 table_name=self.table.table_name,
                 table_version=self.table_version.table_version,
                 schema=new_schema,
-                catalog_properties=self.catalog,
+                catalog=self.catalog,
             )
 
     def test_update_table_version_schema_equivalent_schema_noop(self):
@@ -449,14 +449,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             schema=new_schema,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get the new schema of table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equivalent to the old schema (including metadata)
         assert tv.schema.equivalent_to(old_schema, True)
@@ -478,14 +478,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             schema=new_schema,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get the new schema of table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equivalent to the old schema (ignoring metadata)
         assert tv.schema.equivalent_to(old_schema)
@@ -520,14 +520,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             partition_scheme=new_scheme,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get the new partition scheme of table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equivalent to the expected scheme
         assert tv.partition_scheme.equivalent_to(new_scheme, True)
@@ -569,7 +569,7 @@ class TestTableVersion:
                 table_name=self.table.table_name,
                 table_version=self.table_version.table_version,
                 partition_scheme=new_scheme,
-                catalog_properties=self.catalog,
+                catalog=self.catalog,
             )
 
     def test_update_table_version_partition_scheme_equivalent_scheme_noop(self):
@@ -581,14 +581,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             partition_scheme=new_scheme,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get the new partition scheme of table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equal the old scheme (including identifiers)
         assert tv.partition_scheme.equivalent_to(old_scheme, True)
@@ -613,14 +613,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             partition_scheme=new_scheme,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equivalent to the old scheme (ignoring identifiers)
         assert tv.partition_scheme.equivalent_to(old_scheme, False)
@@ -646,14 +646,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             partition_scheme=new_scheme,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equivalent to the old scheme (ignoring identifiers)
         assert tv.partition_scheme.equivalent_to(old_scheme, False)
@@ -687,14 +687,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             sort_keys=new_scheme,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get the new sort scheme of table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equivalent to the expected scheme
         assert tv.sort_scheme.equivalent_to(new_scheme, True)
@@ -733,7 +733,7 @@ class TestTableVersion:
                 table_name=self.table.table_name,
                 table_version=self.table_version.table_version,
                 sort_keys=new_scheme,
-                catalog_properties=self.catalog,
+                catalog=self.catalog,
             )
 
     def test_update_table_version_sort_scheme_equivalent_scheme_noop(self):
@@ -745,14 +745,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             sort_keys=new_scheme,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get the new sort scheme of table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equal the old scheme (including identifiers)
         assert tv.sort_scheme.equivalent_to(old_scheme, True)
@@ -777,14 +777,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             sort_keys=new_scheme,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equivalent to the old scheme (ignoring identifiers)
         assert tv.sort_scheme.equivalent_to(old_scheme, False)
@@ -810,14 +810,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             sort_keys=new_scheme,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be equivalent to the old scheme (ignoring identifiers)
         assert tv.sort_scheme.equivalent_to(old_scheme, False)
@@ -841,14 +841,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             description=new_description,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to contain the new description
         assert tv.description == new_description != self.table_version.description
@@ -865,14 +865,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             description=new_description,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to contain the new description
         assert tv.description == new_description != self.table_version.description
@@ -884,14 +884,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             description=None,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to contain the old description (None == noop)
         assert tv.description == self.table_version.description
@@ -906,14 +906,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             properties=new_properties,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to contain the new properties
         assert tv.properties == new_properties != self.table_version.properties
@@ -930,14 +930,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             properties=new_properties,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to contain the new properties
         assert tv.properties == new_properties != self.table_version.properties
@@ -949,14 +949,14 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             properties=None,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get table version 1
         tv = metastore.get_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to contain the old properties (None == noop)
         assert tv.properties == self.table_version.properties
@@ -969,7 +969,7 @@ class TestTableVersion:
         tv = metastore.get_latest_active_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be undefined
         assert tv is None
@@ -977,7 +977,7 @@ class TestTableVersion:
         table = metastore.get_table(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect its latest table version to be table version 2
         assert table.latest_table_version == self.table_version2.table_version
@@ -992,13 +992,13 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
             lifecycle_state=LifecycleState.ACTIVE,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get the latest active table version
         tv = metastore.get_latest_active_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be table version 1
         active_table_version: TableVersion = Metafile.update_for(self.table_version)
@@ -1010,13 +1010,13 @@ class TestTableVersion:
             table_name=self.table.table_name,
             table_version=self.table_version2.table_version,
             lifecycle_state=LifecycleState.ACTIVE,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # when we get the latest active table version
         tv = metastore.get_latest_active_table_version(
             namespace=self.table.namespace,
             table_name=self.table.table_name,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect it to be table version 2
         active_table_version2: TableVersion = Metafile.update_for(self.table_version2)
@@ -1036,7 +1036,7 @@ class TestTableVersion:
             # expect an error to be raised
             with pytest.raises(ValueError):
                 metastore.get_latest_active_table_version(
-                    catalog_properties=self.catalog,
+                    catalog=self.catalog,
                     **kwargs_copy,
                 )
 
@@ -1047,7 +1047,7 @@ class TestTableVersion:
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect the table version returned to be equivalent to the one created
         assert tv.equivalent_to(self.table_version)
@@ -1059,7 +1059,7 @@ class TestTableVersion:
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version="v.999",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # expect nothing to be returned
         assert tv is None
@@ -1078,7 +1078,7 @@ class TestTableVersion:
             assert (
                 metastore.get_table_version(
                     table_version=self.table_version.table_version,
-                    catalog_properties=self.catalog,
+                    catalog=self.catalog,
                     **kwargs_copy,
                 )
                 is None
@@ -1092,7 +1092,7 @@ class TestTableVersion:
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version=self.table_version.table_version,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
 
     def test_table_version_not_exists(self):
@@ -1103,7 +1103,7 @@ class TestTableVersion:
             namespace=self.table.namespace,
             table_name=self.table.table_name,
             table_version="v.999",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
 
     def test_table_version_exists_bad_parent_locator(self):
@@ -1119,7 +1119,7 @@ class TestTableVersion:
             # expect empty results
             assert not metastore.table_version_exists(
                 table_version=self.table_version.table_version,
-                catalog_properties=self.catalog,
+                catalog=self.catalog,
                 **kwargs_copy,
             )
 
@@ -1132,7 +1132,7 @@ class TestTableVersion:
                 namespace=self.table.namespace,
                 table_name=self.table.table_name,
                 table_version=self.table_version.table_version,
-                catalog_properties=self.catalog,
+                catalog=self.catalog,
             )
 
 
@@ -1143,7 +1143,7 @@ class TestStream:
         cls.catalog = CatalogProperties(cls.tmpdir)
         metastore.create_namespace(
             "test_stream_ns",
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
         # Create a table version.
         # This call should automatically create a default DeltaCAT stream.
@@ -1151,14 +1151,14 @@ class TestStream:
             namespace="test_stream_ns",
             table_name="mystreamtable",
             table_version="v.1",
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
         # Retrieve the auto-created default stream.
         cls.default_stream = metastore.get_stream(
             namespace="test_stream_ns",
             table_name="mystreamtable",
             table_version="v.1",
-            catalog_properties=cls.catalog,
+            catalog=cls.catalog,
         )
         # Ensure that the default stream was auto-created.
         assert cls.default_stream is not None, "Default stream not found."
@@ -1173,7 +1173,7 @@ class TestStream:
             "test_stream_ns",
             "mystreamtable",
             "v.1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         streams = list_result.all_items()
         # We expect exactly one stream (the default "deltacat" stream).
@@ -1185,7 +1185,7 @@ class TestStream:
             namespace="test_stream_ns",
             table_name="mystreamtable",
             table_version="v.1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         assert exists
 
@@ -1195,7 +1195,7 @@ class TestStream:
             table_name="mystreamtable",
             table_version="v.1",
             stream_format=StreamFormat.ICEBERG,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         assert not exists
 
@@ -1210,7 +1210,7 @@ class TestStream:
             # table version format must be v.N to not raise a ValueError
             kwargs_copy[key] = "i_dont_exist" if key != "table_version" else "v.1000"
             assert not metastore.stream_exists(
-                catalog_properties=self.catalog,
+                catalog=self.catalog,
                 **kwargs_copy,
             )
 
@@ -1225,7 +1225,7 @@ class TestStream:
             kwargs_copy[key] = "i_dont_exist"
             with pytest.raises(ValueError):
                 metastore.list_streams(
-                    catalog_properties=self.catalog,
+                    catalog=self.catalog,
                     **kwargs_copy,
                 )
 
@@ -1234,7 +1234,7 @@ class TestStream:
             namespace="test_stream_ns",
             table_name="mystreamtable",
             table_version="v.1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         assert stream.equivalent_to(self.default_stream)
 
@@ -1250,7 +1250,7 @@ class TestStream:
             kwargs_copy[key] = "i_dont_exist" if key != "table_version" else "v.1000"
             assert (
                 metastore.get_stream(
-                    catalog_properties=self.catalog,
+                    catalog=self.catalog,
                     **kwargs_copy,
                 )
                 is None
@@ -1262,7 +1262,7 @@ class TestStream:
             table_name="mystreamtable",
             table_version="v.1",
             stream_format=StreamFormat.ICEBERG,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         assert stream is None
 
@@ -1270,7 +1270,7 @@ class TestStream:
         # no partitions yet
         list_result = metastore.list_stream_partitions(
             self.default_stream,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         partitions = list_result.all_items()
         assert len(partitions) == 0
@@ -1281,14 +1281,14 @@ class TestStream:
             namespace="test_stream_ns",
             table_name="mystreamtable",
             table_version="v.1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # When we try to get the last committed stream
         stream = metastore.get_stream(
             namespace="test_stream_ns",
             table_name="mystreamtable",
             table_version="v.1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # Expect nothing to be returned
         assert stream is None
@@ -1301,7 +1301,7 @@ class TestStream:
                 table_version="v.1",
             ),
             stream_id=self.default_stream.id,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # Expect nothing to be returned
         assert stream is None
@@ -1314,7 +1314,7 @@ class TestStream:
                 table_name="mystreamtable",
                 table_version="v.1",
                 stream_format=StreamFormat.ICEBERG,
-                catalog_properties=self.catalog,
+                catalog=self.catalog,
             )
 
     def test_delete_stream_bad_parent_locator(self):
@@ -1328,7 +1328,7 @@ class TestStream:
             kwargs_copy[key] = "i_dont_exist"
             with pytest.raises(ValueError):
                 metastore.delete_stream(
-                    catalog_properties=self.catalog,
+                    catalog=self.catalog,
                     **kwargs_copy,
                 )
 
@@ -1338,7 +1338,7 @@ class TestStream:
             namespace="test_stream_ns",
             table_name="mystreamtable",
             table_version="v.1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # When that staged stream is retrieved by ID
         fetched_stream = metastore.get_stream_by_id(
@@ -1348,7 +1348,7 @@ class TestStream:
                 table_version="v.1",
             ),
             stream_id=staged_stream.stream_id,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # Ensure that it is equivalent to the stream we staged
         assert fetched_stream.id == staged_stream.id == fetched_stream.stream_id
@@ -1359,21 +1359,21 @@ class TestStream:
             namespace="test_stream_ns",
             table_name="mystreamtable",
             table_version="v.1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         assert fetched_stream.id == self.default_stream.id == fetched_stream.stream_id
         assert fetched_stream.equivalent_to(self.default_stream)
         # Given a committed stream that replaces the default stream
         committed_stream = metastore.commit_stream(
             stream=staged_stream,
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # When the last committed stream is retrieved
         fetched_stream = metastore.get_stream(
             namespace="test_stream_ns",
             table_name="mystreamtable",
             table_version="v.1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         # Ensure that it is equivalent to the stream we committed
         assert fetched_stream.id == committed_stream.id == fetched_stream.stream_id
@@ -1382,7 +1382,7 @@ class TestStream:
             "test_stream_ns",
             "mystreamtable",
             "v.1",
-            catalog_properties=self.catalog,
+            catalog=self.catalog,
         )
         streams = list_result.all_items()
         # This will list the default stream and the newly committed stream

--- a/deltacat/tests/storage/model/test_metafile_io.py
+++ b/deltacat/tests/storage/model/test_metafile_io.py
@@ -603,10 +603,7 @@ class TestMetafileIO:
             with pytest.raises(ValueError):
                 transaction.commit(temp_dir)
 
-    def test_replace_partition(self, keep_temp_dir):
-        os.environ["METAFILE_FORMAT"] = "json"
-        temp_dir = keep_temp_dir
-        print(f"DeltaCAT Catalog Root Dir: {temp_dir}")
+    def test_replace_partition(self, temp_dir):
         commit_results = _commit_single_delta_table(temp_dir)
         for expected, actual, _ in commit_results:
             assert expected.equivalent_to(actual)

--- a/deltacat/tests/storage/model/test_metafile_io.py
+++ b/deltacat/tests/storage/model/test_metafile_io.py
@@ -603,7 +603,10 @@ class TestMetafileIO:
             with pytest.raises(ValueError):
                 transaction.commit(temp_dir)
 
-    def test_replace_partition(self, temp_dir):
+    def test_replace_partition(self, keep_temp_dir):
+        os.environ["METAFILE_FORMAT"] = "json"
+        temp_dir = keep_temp_dir
+        print(f"DeltaCAT Catalog Root Dir: {temp_dir}")
         commit_results = _commit_single_delta_table(temp_dir)
         for expected, actual, _ in commit_results:
             assert expected.equivalent_to(actual)

--- a/deltacat/tests/test_deltacat.py
+++ b/deltacat/tests/test_deltacat.py
@@ -1,0 +1,56 @@
+import shutil
+import tempfile
+import deltacat as dc
+
+from deltacat.env import create_ray_runtime_environment
+
+
+class TestDeltaCAT:
+    @classmethod
+    def setup_class(cls):
+        cls.temp_dir_1 = tempfile.mkdtemp()
+        cls.temp_dir_2 = tempfile.mkdtemp()
+        # Initialize DeltaCAT with two local catalogs.
+        dc.init(
+            catalogs={
+                "test_catalog_1": dc.Catalog(root=cls.temp_dir_1),
+                "test_catalog_2": dc.Catalog(root=cls.temp_dir_2),
+            },
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        shutil.rmtree(cls.temp_dir_1)
+        shutil.rmtree(cls.temp_dir_2)
+
+    def test_cross_catalog_namespace_copy(self):
+        # Given two empty DeltaCAT catalogs.
+        # When the same namespace is created in both catalogs.
+        namespace_src = dc.create_namespace(
+            namespace="test_namespace",
+            catalog="test_catalog_1",
+        )
+        namespace_dst = dc.create_namespace(
+            namespace=namespace_src.namespace,
+            properties=namespace_src.properties,
+            catalog="test_catalog_2",
+        )
+
+        # Expect the catalog namespace created in each catalog
+        # method to be equivalent and equal to the source namespace.
+        assert namespace_src.equivalent_to(namespace_dst)
+        assert namespace_src == namespace_dst
+
+        # When each catalog namespace is fetched explicitly
+        # Expect them to be equivalent but not equal
+        # (due to different metafile IDs).
+        actual_namespace_src = dc.get_namespace(
+            namespace=namespace_src.namespace,
+            catalog="test_catalog_1",
+        )
+        actual_namespace_dst = dc.get_namespace(
+            namespace=namespace_dst.namespace,
+            catalog="test_catalog_2",
+        )
+        assert actual_namespace_src.equivalent_to(actual_namespace_dst)
+        assert not actual_namespace_src == actual_namespace_dst

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ pyarrow == 17.0.0
 #pyiceberg[glue] @ git+https://github.com/apache/iceberg-python
 pyiceberg[glue] >= 0.6.0
 pymemcache == 4.0.0
-pyspark == 3.5.3
 ray[default] >= 2.20.0,<2.31.0
 redis == 4.6.0
 s3fs == 2024.5.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setuptools.setup(
         "typing-extensions == 4.6.1",
         "redis == 4.6.0",
         "schedule == 1.2.0",
-        "pyspark == 3.5.3",
     ],
     setup_requires=["wheel"],
     package_data={


### PR DESCRIPTION
## Summary

Initial WIP draft of DeltaCAT FS API w/ limited functionality for creating/getting/copying catalogs and namespaces (see `test_deltacat_api.py` for an example). Also adds bug fixes and refactoring of catalog properties to support multi-process-safe named catalog registration in local or distributed Ray apps/clusters.



## Checklist

- [X] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed
