### PR TITLE
feat: implement catalog table functions

### DIFF
--- a/README-development.md
+++ b/README-development.md
@@ -82,12 +82,12 @@ make test
 Runs all unit tests.
 
 > [!NOTE]
-> To run an individual unit test where `my_deltacat_test` exists in either the test file, class, 
+> To run an individual unit test where `my_deltacat_test` exists in either the test file, class,
 > or function/method name, run a command of the form:
 > ```shell
 > python -m pytest -k "my_deltacat_test" -s -vv
 > ```
-> Note that the `-s` flag disables output capturing so that you can see stdout from `print` 
+> Note that the `-s` flag disables output capturing so that you can see stdout from `print`
 > and other statements in real time, and `-vv` let's you see each test version and its input
 > parameters to ease debugging.
 

--- a/deltacat/catalog/v2/catalog_impl.py
+++ b/deltacat/catalog/v2/catalog_impl.py
@@ -1,21 +1,25 @@
 from typing import Any, Dict, List, Optional, Union
 
-from deltacat.catalog.catalog_properties import (
-    CatalogProperties,
+from deltacat.exceptions import (
+    NamespaceAlreadyExistsError,
+    StreamNotFoundError,
+    TableAlreadyExistsError,
+    TableVersionNotFoundError,
 )
-
 from deltacat.storage.model.partition import PartitionScheme
 from deltacat.catalog.model.table_definition import TableDefinition
 from deltacat.storage.model.sort_key import SortScheme
 from deltacat.storage.model.list_result import ListResult
 from deltacat.storage.model.namespace import Namespace, NamespaceProperties
 from deltacat.storage.model.schema import Schema
-from deltacat.storage.model.table import TableProperties
+from deltacat.storage.model.table import Table, TableProperties
+from deltacat.storage.model.table_version import TableVersion
 from deltacat.storage.model.types import (
     DistributedDataset,
     LifecycleState,
     LocalDataset,
     LocalTable,
+    StreamFormat,
 )
 from deltacat.types.media import ContentType
 from deltacat.types.tables import TableWriteMode
@@ -25,27 +29,48 @@ from deltacat.constants import (
 )
 
 
-# table functions
 def write_to_table(
     data: Union[LocalTable, LocalDataset, DistributedDataset],
     table: str,
+    *args,
     namespace: Optional[str] = None,
     mode: TableWriteMode = TableWriteMode.AUTO,
     content_type: ContentType = ContentType.PARQUET,
-    *args,
     **kwargs,
 ) -> None:
+    """Write data to a DeltaCat table.
+
+    Args:
+        data: Data to write to the table. Can be a LocalTable, LocalDataset, or DistributedDataset.
+        table: Name of the table to write to.
+        namespace: Optional namespace of the table. Uses default namespace if not specified.
+        mode: Write mode to use when writing to the table.
+        content_type: Content type of the data being written.
+
+    Returns:
+        None
+    """
     raise NotImplementedError("Not implemented")
 
 
 def read_table(
-    table: str, namespace: Optional[str] = None, *args, **kwargs
+    table: str, *args, namespace: Optional[str] = None, **kwargs
 ) -> DistributedDataset:
+    """Read data from a DeltaCat table.
+
+    Args:
+        table: Name of the table to read from.
+        namespace: Optional namespace of the table. Uses default namespace if not specified.
+
+    Returns:
+        A Deltacat DistributedDataset containing the table data.
+    """
     raise NotImplementedError("Not implemented")
 
 
 def alter_table(
     table: str,
+    *args,
     namespace: Optional[str] = None,
     lifecycle_state: Optional[LifecycleState] = None,
     schema_updates: Optional[Dict[str, Any]] = None,
@@ -53,15 +78,57 @@ def alter_table(
     sort_keys: Optional[SortScheme] = None,
     description: Optional[str] = None,
     properties: Optional[TableProperties] = None,
-    *args,
     **kwargs,
 ) -> None:
-    """Alter table definition."""
-    raise NotImplementedError("alter_table not implemented")
+    """Alter deltacat table/table_version definition.
+
+    Modifies various aspects of a table's metadata including lifecycle state,
+    schema, partitioning, sort keys, description, and properties.
+
+    Args:
+        table: Name of the table to alter.
+        namespace: Optional namespace of the table. Uses default namespace if not specified.
+        lifecycle_state: New lifecycle state for the table.
+        schema_updates: Map of schema updates to apply.
+        partition_updates: Map of partition scheme updates to apply.
+        sort_keys: New sort keys scheme.
+        description: New description for the table.
+        properties: New table properties.
+
+    Returns:
+        None
+
+    Raises:
+        TableNotFoundError: If the table does not already exist.
+    """
+    namespace = namespace or default_namespace()
+
+    storage_impl.update_table(
+        *args,
+        namespace=namespace,
+        table_name=table,
+        description=description,
+        properties=properties,
+        lifecycle_state=lifecycle_state,
+        **kwargs,
+    )
+
+    table_version = storage_impl.get_latest_table_version(namespace, table, **kwargs)
+    storage_impl.update_table_version(
+        *args,
+        namespace=namespace,
+        table_name=table,
+        table_version=table_version.id,
+        description=description,
+        schema_updates=schema_updates,
+        partition_updates=partition_updates,
+        sort_keys=sort_keys,
+        **kwargs,
+    )
 
 
 def create_table(
-    table: str,
+    name: str,
     *args,
     namespace: Optional[str] = None,
     version: Optional[str] = None,
@@ -76,129 +143,360 @@ def create_table(
     fail_if_exists: bool = True,
     **kwargs,
 ) -> TableDefinition:
+    """Create an empty table in the catalog.
+
+    If a namespace isn't provided, the table will be created within the default deltacat namespace.
+    Additionally if the provided namespace does not exist, it will be created for you.
+
+
+    Args:
+        name: Name of the table to create.
+        namespace: Optional namespace for the table. Uses default namespace if not specified.
+        version: Optional version identifier for the table.
+        lifecycle_state: Lifecycle state of the new table. Defaults to ACTIVE.
+        schema: Schema definition for the table.
+        partition_scheme: Optional partitioning scheme for the table.
+        sort_keys: Optional sort keys for the table.
+        description: Optional description of the table.
+        table_properties: Optional properties for the table.
+        namespace_properties: Optional properties for the namespace if it needs to be created.
+        content_types: Optional list of allowed content types for the table.
+        fail_if_exists: If True, raises an error if table already exists. If False, returns existing table.
+
+    Returns:
+        TableDefinition object for the created or existing table.
+
+    Raises:
+        TableAlreadyExistsError: If the table already exists and fail_if_exists is True.
+        NamespaceNotFoundError: If the provided namespace does not exist.
     """
-    Create an empty table. Raises an error if the table already exists and
-    `fail_if_exists` is True (default behavior).
-    """
-    raise NotImplementedError()
+    namespace = namespace or default_namespace()
+
+    table = get_table(*args, name, namespace=namespace, table_version=version, **kwargs)
+    if table is not None:
+        if fail_if_exists:
+            raise TableAlreadyExistsError(f"Table {namespace}.{name} already exists")
+        return table
+
+    if not namespace_exists(*args, namespace, **kwargs):
+        create_namespace(
+            *args, namespace=namespace, properties=namespace_properties, **kwargs
+        )
+
+    (table, table_version, stream) = storage_impl.create_table_version(
+        *args,
+        namespace=namespace,
+        table_name=name,
+        table_version=version,
+        schema=schema,
+        partition_scheme=partition_scheme,
+        sort_keys=sort_keys,
+        table_version_description=description,
+        table_description=description,
+        table_properties=table_properties,
+        lifecycle_state=lifecycle_state or LifecycleState.ACTIVE,
+        supported_content_types=content_types,
+        **kwargs,
+    )
+
+    return TableDefinition.of(
+        table=table,
+        table_version=table_version,
+        stream=stream,
+    )
 
 
 def drop_table(
-    table: str, namespace: Optional[str] = None, purge: bool = False, *args, **kwargs
+    name: str,
+    *args,
+    namespace: Optional[str] = None,
+    table_version: Optional[str] = None,
+    purge: bool = False,
+    **kwargs,
 ) -> None:
-    """Drop a table from the catalog and optionally purge it. Raises an error
-    if the table does not exist."""
-    raise NotImplementedError("drop_table not implemented")
+    """Drop a table from the catalog and optionally purges underlying data.
+
+    Args:
+        name: Name of the table to drop.
+        namespace: Optional namespace of the table. Uses default namespace if not specified.
+        purge: If True, permanently delete the table data. If False, only remove from catalog.
+
+    Returns:
+        None
+
+    Raises:
+        TableNotFoundError: If the table does not exist.
+
+    TODO: Honor purge once garbage collection is implemented.
+    TODO: Drop table version if specified, possibly create a delete_table_version api.
+    """
+    if purge:
+        raise NotImplementedError("Purge flag is not currently supported.")
+
+    namespace = namespace or default_namespace()
+    storage_impl.delete_table(
+        *args, namespace=namespace, name=name, purge=purge, **kwargs
+    )
 
 
-def refresh_table(table: str, namespace: Optional[str] = None, *args, **kwargs) -> None:
-    """Refresh metadata cached on the Ray cluster for the given table."""
+def refresh_table(table: str, *args, namespace: Optional[str] = None, **kwargs) -> None:
+    """Refresh metadata cached on the Ray cluster for the given table.
+
+    Args:
+        table: Name of the table to refresh.
+        namespace: Optional namespace of the table. Uses default namespace if not specified.
+
+    Returns:
+        None
+    """
     raise NotImplementedError("refresh_table not implemented")
 
 
 def list_tables(
-    namespace: Optional[str] = None, *args, **kwargs
+    *args, namespace: Optional[str] = None, **kwargs
 ) -> ListResult[TableDefinition]:
-    """List a page of table definitions. Raises an error if the given namespace
-    does not exist."""
-    raise NotImplementedError()
+    """List a page of table definitions.
+
+    Args:
+        namespace: Optional namespace to list tables from. Uses default namespace if not specified.
+
+    Returns:
+        ListResult containing TableDefinition objects for tables in the namespace.
+    """
+    namespace = namespace or default_namespace()
+    tables = storage_impl.list_tables(*args, namespace=namespace, **kwargs)
+    table_definitions = [
+        get_table(*args, table.table_name, namespace, **kwargs)
+        for table in tables.all_items()
+    ]
+
+    return ListResult(items=table_definitions)
 
 
 def get_table(
-    table: str, namespace: Optional[str] = None, *args, **kwargs
+    name: str,
+    *args,
+    namespace: Optional[str] = None,
+    table_version: Optional[str] = None,
+    stream_format: StreamFormat = StreamFormat.DELTACAT,
+    **kwargs,
 ) -> Optional[TableDefinition]:
-    """
-    Get table definition metadata. Returns None if the given table does not exist.
+    """Get table definition metadata.
 
+    Args:
+        name: Name of the table to retrieve.
+        namespace: Optional namespace of the table. Uses default namespace if not specified.
+        table_version: Optional specific version of the table to retrieve.
+            If not specified, the latest version is used.
+        stream_format: Optional stream format to retrieve. Uses the default Deltacat stream
+            format if not specified.
+
+    Returns:
+        Deltacat TableDefinition if the table exists, None otherwise.
+
+    Raises:
+        TableVersionNotFoundError: If the table version does not exist.
+        StreamNotFoundError: If the stream does not exist.
     """
-    raise NotImplementedError()
+    namespace = namespace or default_namespace()
+    table: Optional[Table] = storage_impl.get_table(
+        *args, table_name=name, namespace=namespace, **kwargs
+    )
+
+    if table is None:
+        return None
+
+    table_version: Optional[TableVersion] = storage_impl.get_table_version(
+        *args, namespace, name, table_version or table.latest_table_version, **kwargs
+    )
+
+    if table_version is None:
+        raise TableVersionNotFoundError(
+            f"TableVersion {namespace}.{name}.{table_version} does not exist."
+        )
+
+    stream = storage_impl.get_stream(
+        *args,
+        namespace=namespace,
+        table_name=name,
+        table_version=table_version.id,
+        stream_format=stream_format,
+        **kwargs,
+    )
+
+    if stream is None:
+        raise StreamNotFoundError(
+            f"Stream {namespace}.{table}.{table_version}.{stream} does not exist."
+        )
+
+    return TableDefinition.of(
+        table=table,
+        table_version=table_version,
+        stream=stream,
+    )
 
 
 def truncate_table(
-    table: str, namespace: Optional[str] = None, *args, **kwargs
+    table: str, *args, namespace: Optional[str] = None, **kwargs
 ) -> None:
-    """Truncate table data. Raises an error if the table does not exist."""
+    """Truncate table data.
+
+    Args:
+        table: Name of the table to truncate.
+        namespace: Optional namespace of the table. Uses default namespace if not specified.
+
+    Returns:
+        None
+    """
     raise NotImplementedError("truncate_table not implemented")
 
 
 def rename_table(
-    table: str, new_name: str, namespace: Optional[str] = None, *args, **kwargs
+    table: str, new_name: str, *args, namespace: Optional[str] = None, **kwargs
 ) -> None:
-    """Rename a table."""
-    raise NotImplementedError("rename_table not implemented")
+    """Rename an existing table.
 
+    Args:
+        table: Current name of the table.
+        new_name: New name for the table.
+        namespace: Optional namespace of the table. Uses default namespace if not specified.
 
-def table_exists(table: str, namespace: Optional[str] = None, *args, **kwargs) -> bool:
-    """Returns True if the given table exists, False if not."""
-    catalog = kwargs.get("catalog")
-    if not isinstance(catalog, CatalogProperties):
-        raise ValueError("Catalog must be a CatalogProperties instance")
+    Returns:
+        None
 
+    Raises:
+        TableNotFoundError: If the table does not exist.
+    """
     namespace = namespace or default_namespace()
-
-    return storage_impl.table_exists(
-        table_name=table, namespace=namespace, catalog=catalog
+    storage_impl.update_table(
+        *args, table_name=table, new_table_name=new_name, namespace=namespace, **kwargs
     )
 
 
-# namespace functions
-def list_namespaces(*args, **kwargs) -> ListResult[Namespace]:
-    """List a page of table namespaces."""
-    catalog = kwargs.get("catalog")
-    if not isinstance(catalog, CatalogProperties):
-        raise ValueError("Catalog must be a CatalogProperties instance")
+def table_exists(table: str, *args, namespace: Optional[str] = None, **kwargs) -> bool:
+    """Check if a table exists in the catalog.
 
-    return storage_impl.list_namespaces(catalog=catalog)
+    Args:
+        table: Name of the table to check.
+        namespace: Optional namespace of the table. Uses default namespace if not specified.
+
+    Returns:
+        True if the table exists, False otherwise.
+    """
+    namespace = namespace or default_namespace()
+    return storage_impl.table_exists(
+        *args, table_name=table, namespace=namespace, **kwargs
+    )
+
+
+def list_namespaces(*args, **kwargs) -> ListResult[Namespace]:
+    """List a page of table namespaces.
+
+    Args:
+        catalog: Catalog properties instance.
+
+    Returns:
+        ListResult containing Namespace objects.
+    """
+    return storage_impl.list_namespaces(*args, **kwargs)
 
 
 def get_namespace(namespace: str, *args, **kwargs) -> Optional[Namespace]:
-    """Gets table namespace metadata for the specified table namespace.
-    Returns None if the given namespace does not exist.
+    """Get metadata for a specific table namespace.
+
+    Args:
+        namespace: Name of the namespace to retrieve.
+
+    Returns:
+        Namespace object if the namespace exists, None otherwise.
     """
-    return storage_impl.get_namespace(namespace=namespace, **kwargs)
+    return storage_impl.get_namespace(*args, namespace=namespace, **kwargs)
 
 
 def namespace_exists(namespace: str, *args, **kwargs) -> bool:
-    """Returns True if the given table namespace exists, False if not."""
+    """Check if a namespace exists.
 
-    return storage_impl.namespace_exists(namespace=namespace, **kwargs)
+    Args:
+        namespace: Name of the namespace to check.
+
+    Returns:
+        True if the namespace exists, False otherwise.
+    """
+    return storage_impl.namespace_exists(*args, namespace=namespace, **kwargs)
 
 
 def create_namespace(
-    namespace: str, properties: Optional[NamespaceProperties], *args, **kwargs
+    namespace: str, *args, properties: Optional[NamespaceProperties] = None, **kwargs
 ) -> Namespace:
-    """Creates a table namespace with the given name and properties. Returns
-    the created namespace.
+    """Create a new namespace.
 
-    :raises ValueError if the namespace already exists.
+    Args:
+        namespace: Name of the namespace to create.
+        properties: Optional properties for the namespace.
+
+    Returns:
+        Created Namespace object.
+
+    Raises:
+        NamespaceAlreadyExistsError: If the namespace already exists.
     """
-    # Check if namespace already exists
     if namespace_exists(namespace):
-        raise ValueError(f"Namespace {namespace} already exists")
+        raise NamespaceAlreadyExistsError(f"Namespace {namespace} already exists")
 
-    # Create namespace through storage layer
     return storage_impl.create_namespace(
-        namespace=namespace, properties=properties, **kwargs
+        *args, namespace=namespace, properties=properties, **kwargs
     )
 
 
 def alter_namespace(
     namespace: str,
+    *args,
     properties: Optional[NamespaceProperties] = None,
     new_namespace: Optional[str] = None,
-    *args,
     **kwargs,
 ) -> None:
-    """Alter table namespace definition."""
-    raise NotImplementedError("alter_namespace not implemented")
+    """Alter a namespace definition.
+
+    Args:
+        namespace: Name of the namespace to alter.
+        properties: Optional new properties for the namespace.
+        new_namespace: Optional new name for the namespace.
+
+    Returns:
+        None
+    """
+    storage_impl.update_namespace(
+        *args,
+        namespace=namespace,
+        properties=properties,
+        new_namespace=new_namespace,
+        **kwargs,
+    )
 
 
-def drop_namespace(namespace: str, purge: bool = False, *args, **kwargs) -> None:
-    """Drop the given namespace and all of its tables from the catalog,
-    optionally purging them."""
-    raise NotImplementedError("drop_namespace not implemented")
+def drop_namespace(namespace: str, *args, purge: bool = False, **kwargs) -> None:
+    """Drop a namespace and all of its tables from the catalog.
+
+    Args:
+        namespace: Name of the namespace to drop.
+        purge: If True, permanently delete all tables in the namespace.
+            If False, only remove from catalog.
+
+    Returns:
+        None
+
+    TODO: Honor purge once garbage collection is implemented.
+    """
+    if purge:
+        raise NotImplementedError("Purge flag is not currently supported.")
+
+    storage_impl.delete_namespace(*args, namespace=namespace, purge=purge, **kwargs)
 
 
 def default_namespace(*args, **kwargs) -> str:
-    """Returns the default namespace for the catalog."""
-    return DEFAULT_NAMESPACE
+    """Return the default namespace for the catalog.
+
+    Returns:
+        String name of the default namespace.
+    """
+    return DEFAULT_NAMESPACE  # table functions

--- a/deltacat/exceptions.py
+++ b/deltacat/exceptions.py
@@ -70,6 +70,7 @@ class DeltaCatErrorNames(str, Enum):
     STREAM_NOT_FOUND_ERROR = "StreamNotFoundError"
     DELTA_NOT_FOUND_ERROR = "DeltaNotFoundError"
     TABLE_ALREADY_EXISTS_ERROR = "TableAlreadyExistsError"
+    NAMESPACE_ALREADY_EXISTS_ERROR = "NamespaceAlreadyExistsError"
 
 
 class DeltaCatError(Exception):
@@ -234,6 +235,10 @@ class DeltaNotFoundError(NonRetryableError):
 
 
 class TableAlreadyExistsError(NonRetryableError):
+    error_name = DeltaCatErrorNames.TABLE_ALREADY_EXISTS_ERROR.value
+
+
+class NamespaceAlreadyExistsError(NonRetryableError):
     error_name = DeltaCatErrorNames.TABLE_ALREADY_EXISTS_ERROR.value
 
 

--- a/deltacat/storage/interface.py
+++ b/deltacat/storage/interface.py
@@ -289,8 +289,8 @@ def create_table_version(
     table_name: str,
     table_version: Optional[str] = None,
     schema: Optional[Schema] = None,
-    # TODO(pdames): rename to `sort_scheme`
     partition_scheme: Optional[PartitionScheme] = None,
+    # TODO(pdames): rename to `sort_scheme`
     sort_keys: Optional[SortScheme] = None,
     table_version_description: Optional[str] = None,
     table_version_properties: Optional[TableVersionProperties] = None,

--- a/deltacat/storage/interface.py
+++ b/deltacat/storage/interface.py
@@ -289,8 +289,8 @@ def create_table_version(
     table_name: str,
     table_version: Optional[str] = None,
     schema: Optional[Schema] = None,
-    partition_scheme: Optional[PartitionScheme] = None,
     # TODO(pdames): rename to `sort_scheme`
+    partition_scheme: Optional[PartitionScheme] = None,
     sort_keys: Optional[SortScheme] = None,
     table_version_description: Optional[str] = None,
     table_version_properties: Optional[TableVersionProperties] = None,
@@ -408,6 +408,36 @@ def delete_stream(
     raise NotImplementedError("delete_stream not implemented")
 
 
+def delete_table(
+    namespace: str,
+    name: str,
+    purge: bool = False,
+    *args,
+    **kwargs,
+) -> None:
+    """
+    Drops the given table and all its contents (table versions, streams, partitions,
+    and deltas). If purge is True, also removes all data files associated with the table.
+    Raises an error if the given table does not exist.
+    """
+    raise NotImplementedError("delete_table not implemented")
+
+
+def delete_namespace(
+    namespace: str,
+    purge: bool = False,
+    *args,
+    **kwargs,
+) -> None:
+    """
+    Drops a table namespace and all its contents. If purge is True, then all
+    tables, table versions, and deltas will be deleted. Otherwise, the namespace
+    will be dropped only if it is empty. Raises an error if the given namespace
+    does not exist.
+    """
+    raise NotImplementedError("drop_namespace not implemented")
+
+
 def get_stream_by_id(
     table_version_locator: TableVersionLocator,
     stream_id: str,
@@ -439,8 +469,29 @@ def get_stream(
     raise NotImplementedError("get_stream not implemented")
 
 
+def stream_exists(
+    namespace: str,
+    table_name: str,
+    table_version: Optional[str] = None,
+    stream_format: StreamFormat = StreamFormat.DELTACAT,
+    *args,
+    **kwargs,
+) -> bool:
+    """
+    Returns True if the given Stream exists, False if not.
+    Resolves to the latest active table version if no table version is given.
+    Resolves to the DeltaCAT stream format if no stream format is given.
+    Returns None if the table version or stream format does not exist.
+    """
+    raise NotImplementedError("stream_exists not implemented")
+
+
 def stage_partition(
-    stream: Stream, partition_values: Optional[PartitionValues] = None, *args, **kwargs
+    stream: Stream,
+    partition_values: Optional[PartitionValues] = None,
+    partition_scheme_id: Optional[str] = None,
+    *args,
+    **kwargs,
 ) -> Partition:
     """
     Stages a new partition for the given stream and partition values. Returns
@@ -513,6 +564,7 @@ def get_partition_by_id(
 def get_partition(
     stream_locator: StreamLocator,
     partition_values: Optional[PartitionValues] = None,
+    partition_scheme_id: Optional[str] = None,
     *args,
     **kwargs,
 ) -> Optional[Partition]:

--- a/deltacat/storage/main/impl.py
+++ b/deltacat/storage/main/impl.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Union, Tuple
 
 from deltacat.catalog import get_catalog_properties
 from deltacat.constants import DEFAULT_TABLE_VERSION
+from deltacat.exceptions import TableNotFoundError
 from deltacat.storage.model.manifest import (
     EntryParams,
     ManifestAuthor,
@@ -64,6 +65,7 @@ from deltacat.storage.model.metafile import (
 from deltacat.storage.model.transaction import (
     TransactionOperation,
     Transaction,
+    TransactionOperationList,
 )
 from deltacat.storage.model.manifest import Manifest
 from deltacat.types.media import (
@@ -899,7 +901,7 @@ def update_table(
         **kwargs,
     )
     if not old_table:
-        raise ValueError(f"Table `{namespace}.{table_name}` does not exist.")
+        raise TableNotFoundError(f"Table `{namespace}.{table_name}` does not exist.")
     new_table: Table = Metafile.update_for(old_table)
     new_table.description = description or old_table.description
     new_table.properties = properties or old_table.properties
@@ -1305,6 +1307,84 @@ def delete_stream(
             TransactionOperation.of(
                 operation_type=TransactionOperationType.DELETE,
                 dest_metafile=stream_to_delete,
+            )
+        ],
+    )
+    catalog_properties = get_catalog_properties(**kwargs)
+    transaction.commit(
+        catalog_root_dir=catalog_properties.root,
+        filesystem=catalog_properties.filesystem,
+    )
+
+
+def delete_table(
+    namespace: str,
+    name: str,
+    purge: bool = False,
+    *args,
+    **kwargs,
+) -> None:
+    """
+    Drops the given table and all its contents (table versions, streams, partitions,
+    and deltas). If purge is True, also removes all data files associated with the table.
+    Raises an error if the given table does not exist.
+
+    TODO: Honor purge once garbage collection is implemented.
+    """
+    table: Optional[Table] = get_table(
+        *args,
+        namespace=namespace,
+        table_name=name,
+        **kwargs,
+    )
+
+    if not table:
+        raise TableNotFoundError(f"Table `{namespace}.{name}` does not exist.")
+
+    transaction = Transaction.of(
+        txn_type=TransactionType.DELETE,
+        txn_operations=TransactionOperationList.of(
+            [
+                TransactionOperation.of(
+                    operation_type=TransactionOperationType.DELETE,
+                    dest_metafile=table,
+                )
+            ]
+        ),
+    )
+
+    catalog_properties = get_catalog_properties(**kwargs)
+    transaction.commit(
+        catalog_root_dir=catalog_properties.root,
+        filesystem=catalog_properties.filesystem,
+    )
+
+
+def delete_namespace(
+    namespace: str,
+    purge: bool = False,
+    *args,
+    **kwargs,
+) -> None:
+    """
+    Drops the given table namespace and all its contents. Raises an error if the
+    given namespace does not exist.
+    """
+    namespace: Optional[Namespace] = get_namespace(
+        *args,
+        namespace=namespace,
+        **kwargs,
+    )
+
+    if not namespace:
+        raise ValueError(f"Namespace `{namespace}` does not exist.")
+
+    transaction = Transaction.of(
+        txn_type=TransactionType.DELETE,
+        txn_operations=[
+            TransactionOperation.of(
+                operation_type=TransactionOperationType.DELETE,
+                dest_metafile=namespace,
             )
         ],
     )

--- a/deltacat/storage/model/namespace.py
+++ b/deltacat/storage/model/namespace.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, List
 from deltacat.storage.model.metafile import Metafile
 from deltacat.storage.model.locator import Locator, LocatorName
 
-NamespaceProperties = Dict[str, Any]
+NamespaceProperties = dict[str, Any]
 
 
 class Namespace(Metafile):

--- a/deltacat/storage/model/table.py
+++ b/deltacat/storage/model/table.py
@@ -14,7 +14,7 @@ from deltacat.storage.model.namespace import (
 from deltacat.storage.model.metafile import Metafile, MetafileRevisionInfo
 from deltacat.constants import TXN_DIR_NAME
 
-TableProperties = Dict[str, Any]
+TableProperties = dict[str, Any]
 
 
 class Table(Metafile):
@@ -119,6 +119,12 @@ class Table(Metafile):
         if table_locator:
             return table_locator.table_name
         return None
+
+    @table_name.setter
+    def table_name(self, table_name: Optional[str]) -> None:
+        table_locator = self.locator
+        if table_locator:
+            table_locator.table_name = table_name
 
     def to_serializable(self) -> Table:
         serializable = self

--- a/deltacat/tests/catalog/main/test_catalog_impl_namespace_operations.py
+++ b/deltacat/tests/catalog/main/test_catalog_impl_namespace_operations.py
@@ -1,4 +1,6 @@
 import shutil
+from deltacat.exceptions import NamespaceAlreadyExistsError
+import pytest
 import tempfile
 import deltacat.catalog.v2.catalog_impl as catalog
 from deltacat.catalog.catalog_properties import initialize_properties
@@ -87,12 +89,26 @@ class TestCatalogNamespaceOperations:
         assert catalog.namespace_exists(namespace, catalog=catalog)
 
         # Try to create the same namespace again, should raise ValueError
-        import pytest
-
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(NamespaceAlreadyExistsError, match=namespace):
             catalog.create_namespace(
                 namespace=namespace, properties=properties, catalog=catalog
             )
 
-        # Verify the error message
-        assert f"Namespace {namespace} already exists" in str(excinfo.value)
+    def test_drop_namespace(self):
+        """Test dropping a namespace"""
+        namespace = "test_drop_namespace"
+        properties = {"description": "Test Namespace", "owner": "test-user"}
+
+        # Create namespace
+        catalog.create_namespace(
+            namespace=namespace, properties=properties, catalog=catalog
+        )
+
+        # Verify namespace exists
+        assert catalog.namespace_exists(namespace, catalog=catalog)
+
+        # Drop namespace
+        catalog.drop_namespace(namespace, catalog=catalog)
+
+        # Verify namespace does not exist
+        assert not catalog.namespace_exists(namespace, catalog=catalog)

--- a/deltacat/tests/catalog/main/test_catalog_impl_table_operations.py
+++ b/deltacat/tests/catalog/main/test_catalog_impl_table_operations.py
@@ -1,0 +1,436 @@
+import shutil
+import tempfile
+import pytest
+import pyarrow as pa
+
+import deltacat.catalog.v2.catalog_impl as catalog
+from deltacat.catalog.catalog_properties import initialize_properties
+from deltacat.storage.model.schema import Schema
+from deltacat.storage.model.sort_key import SortKey, SortScheme, SortOrder, NullOrder
+from deltacat.storage.model.table import TableProperties
+from deltacat.storage.model.namespace import NamespaceProperties
+from deltacat.storage.model.types import LifecycleState
+from deltacat.exceptions import (
+    TableAlreadyExistsError,
+    TableNotFoundError,
+)
+
+
+@pytest.fixture(scope="class")
+def catalog_setup():
+    """Setup and teardown for the catalog test environment."""
+    temp_dir = tempfile.mkdtemp()
+    catalog_properties = initialize_properties(root=temp_dir)
+
+    yield temp_dir, catalog_properties
+
+    # Teardown
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture(scope="function")
+def test_namespace(catalog_setup):
+    """Create a test namespace for each test."""
+    _, catalog_properties = catalog_setup
+    namespace_name = "test_table_namespace"
+
+    if not catalog.namespace_exists(namespace_name, catalog=catalog_properties):
+        catalog.create_namespace(
+            namespace=namespace_name,
+            properties={"description": "Test Table Namespace"},
+            catalog=catalog_properties,
+        )
+
+    return namespace_name, catalog_properties
+
+
+@pytest.fixture
+def sample_arrow_schema():
+    """Create a sample PyArrow schema for testing."""
+    return pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("name", pa.string()),
+            pa.field("value", pa.float64()),
+        ]
+    )
+
+
+@pytest.fixture
+def sample_sort_keys():
+    """Create a sample sort scheme for testing."""
+    return SortScheme(
+        keys=[
+            SortKey.of(
+                key=["id"], sort_order=SortOrder.ASCENDING, null_order=NullOrder.AT_END
+            ),
+        ]
+    )
+
+
+class TestCatalogTableOperations:
+    def test_create_table(self, test_namespace, sample_arrow_schema, sample_sort_keys):
+        """Test creating a table with schema and properties"""
+        namespace_name, catalog_properties = test_namespace
+        table_name = "test_create_table"
+
+        # Create a schema
+        schema = Schema(arrow=sample_arrow_schema)
+
+        # Create table properties
+        table_properties = TableProperties(
+            {"owner": "test-user", "department": "engineering"}
+        )
+
+        # Create namespace properties
+        namespace_properties = NamespaceProperties({"description": "Test Namespace"})
+
+        # Create the table
+        table_definition = catalog.create_table(
+            name=table_name,
+            namespace=namespace_name,
+            schema=schema,
+            sort_keys=sample_sort_keys,
+            description="Test table for unit tests",
+            table_properties=table_properties,
+            namespace_properties=namespace_properties,
+            catalog=catalog_properties,
+        )
+
+        # Verify table was created
+        assert catalog.table_exists(
+            table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        table = table_definition.table
+        table_version = table_definition.table_version
+
+        # Verify table definition properties
+        assert table_version.table_name == table_name
+        assert table_version.namespace == namespace_name
+        assert table_version.description == "Test table for unit tests"
+        assert table_version.state == LifecycleState.CREATED
+        assert table.properties.get("owner") == "test-user"
+        assert table.properties.get("department") == "engineering"
+        assert table_version.schema.arrow.names == sample_arrow_schema.names
+        assert len(table_version.sort_scheme.keys) == 1
+        sort_key_paths = [key[0][0] for key in table_version.sort_scheme.keys]
+        assert "id" in sort_key_paths
+
+    def test_create_table_already_exists(self, test_namespace):
+        namespace_name, catalog_properties = test_namespace
+        table_name = "test_table_exists"
+
+        # Create the table
+        catalog.create_table(
+            name=table_name,
+            namespace=namespace_name,
+            description="First creation",
+            catalog=catalog_properties,
+        )
+
+        # Verify table exists
+        assert catalog.table_exists(
+            table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Try to create the same table again, should raise TableAlreadyExistsError
+        with pytest.raises(
+            TableAlreadyExistsError,
+            match=f"Table {namespace_name}.{table_name} already exists",
+        ):
+            catalog.create_table(
+                name=table_name,
+                namespace=namespace_name,
+                description="Second creation attempt",
+                catalog=catalog_properties,
+            )
+
+    def test_create_table_already_exists_no_fail(self, test_namespace):
+        """Test creating a table that already exists with fail_if_exists=False"""
+        namespace_name, catalog_properties = test_namespace
+        table_name = "test_table_exists_no_fail"
+
+        # Create the table with original description
+        catalog.create_table(
+            name=table_name,
+            namespace=namespace_name,
+            description="Original description",
+            catalog=catalog_properties,
+        )
+
+        assert catalog.table_exists(
+            table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Create the same table with fail_if_exists=False
+        table_definition = catalog.create_table(
+            name=table_name,
+            namespace=namespace_name,
+            description="Updated description",
+            fail_if_exists=False,
+            catalog=catalog_properties,
+        )
+
+        table = table_definition.table
+
+        assert table.table_name == table_name
+        assert table.namespace == namespace_name
+        # Ensure description is unchanged
+        assert table.description == "Original description"
+
+    def test_drop_table(self, test_namespace):
+        namespace_name, catalog_properties = test_namespace
+        table_name = "test_drop_table"
+
+        # Create the table
+        catalog.create_table(
+            name=table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Verify table exists
+        assert catalog.table_exists(
+            table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Drop the table
+        catalog.drop_table(
+            name=table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Verify table no longer exists
+        assert not catalog.table_exists(
+            table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+    def test_drop_table_not_exists(self, test_namespace):
+        namespace_name, catalog_properties = test_namespace
+        table_name = "nonexistent_table"
+
+        # Verify table doesn't exist
+        assert not catalog.table_exists(
+            table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Try to drop the table, should raise TableNotFoundError
+        with pytest.raises(TableNotFoundError, match=table_name):
+            catalog.drop_table(
+                name=table_name, namespace=namespace_name, catalog=catalog_properties
+            )
+
+    def test_rename_table(self, test_namespace):
+        namespace_name, catalog_properties = test_namespace
+        original_name = "test_original_table"
+        new_name = "test_renamed_table"
+
+        # Create the table with original name
+        catalog.create_table(
+            name=original_name,
+            namespace=namespace_name,
+            description="Table to be renamed",
+            catalog=catalog_properties,
+        )
+
+        # Verify original table exists
+        assert catalog.table_exists(
+            original_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Rename the table
+        catalog.rename_table(
+            table=original_name,
+            new_name=new_name,
+            namespace=namespace_name,
+            catalog=catalog_properties,
+        )
+
+        # Verify new table exists and old table doesn't
+        assert catalog.table_exists(
+            new_name, namespace=namespace_name, catalog=catalog_properties
+        )
+        assert not catalog.table_exists(
+            original_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+    def test_rename_table_not_exists(self, test_namespace):
+        namespace_name, catalog_properties = test_namespace
+        original_name = "nonexistent_table"
+        new_name = "test_renamed_nonexistent"
+
+        # Verify table doesn't exist
+        assert not catalog.table_exists(
+            original_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Try to rename the table, should raise TableNotFoundError
+        with pytest.raises(TableNotFoundError, match=original_name):
+            catalog.rename_table(
+                table=original_name,
+                new_name=new_name,
+                namespace=namespace_name,
+                catalog=catalog_properties,
+            )
+
+    def test_table_exists(self, test_namespace):
+        namespace_name, catalog_properties = test_namespace
+        existing_table = "test_table_exists_check"
+        non_existing_table = "nonexistent_table"
+
+        # Create a table
+        catalog.create_table(
+            name=existing_table, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Check existing table
+        assert catalog.table_exists(
+            existing_table, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Check non-existing table
+        assert not catalog.table_exists(
+            non_existing_table, namespace=namespace_name, catalog=catalog_properties
+        )
+
+    def test_create_table_with_default_namespace(self, catalog_setup):
+        _, catalog_properties = catalog_setup
+        table_name = "test_default_namespace_table"
+
+        # Create table with default namespace
+        table_definition = catalog.create_table(
+            name=table_name, catalog=catalog_properties
+        )
+
+        table = table_definition.table
+        # Verify table was created in default namespace
+        default_ns = catalog.default_namespace()
+        assert table.namespace == default_ns
+        assert catalog.table_exists(
+            table_name, namespace=default_ns, catalog=catalog_properties
+        )
+
+    def test_create_table_with_missing_namespace(self, catalog_setup):
+        _, catalog_properties = catalog_setup
+        table_name = "test_namespace_not_found_table"
+        new_namespace = "nonexistent_namespace"
+
+        # Verify namespace doesn't exist yet
+        assert not catalog.namespace_exists(new_namespace, catalog=catalog_properties)
+
+        # Try to create table with non-existent namespace
+        catalog.create_table(
+            name=table_name, namespace=new_namespace, catalog=catalog_properties
+        )
+
+        assert catalog.table_exists(
+            table_name, namespace=new_namespace, catalog=catalog_properties
+        )
+        assert catalog.namespace_exists(new_namespace, catalog=catalog_properties)
+
+    def test_alter_table(self, test_namespace, sample_arrow_schema, sample_sort_keys):
+        namespace_name, catalog_properties = test_namespace
+        table_name = "test_alter_table"
+
+        # Create initial schema and properties
+        schema = Schema.of(schema=sample_arrow_schema)
+        initial_properties = TableProperties(
+            {"owner": "original-user", "department": "engineering"}
+        )
+
+        # Create the table with initial properties
+        table = catalog.create_table(
+            name=table_name,
+            namespace=namespace_name,
+            schema=schema,
+            sort_keys=sample_sort_keys,
+            description="Initial description",
+            table_properties=initial_properties,
+            catalog=catalog_properties,
+        )
+        old_schema = table.table_version.schema
+
+        # Verify table was created with initial properties
+        assert catalog.table_exists(
+            table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Create updated schema
+        updated_arrow_schema = pa.schema(
+            [
+                pa.field("count", pa.float64()),  # Added field
+            ]
+        )
+
+        new_schema = old_schema.add_subschema(
+            name="updated_schema",
+            schema=updated_arrow_schema,
+        )
+
+        # Create updated properties
+        updated_properties = TableProperties(
+            {"owner": "new-user", "department": "data-science", "priority": "high"}
+        )
+
+        # Alter the table with new properties
+        catalog.alter_table(
+            table=table_name,
+            namespace=namespace_name,
+            schema_updates=new_schema,
+            description="Updated description",
+            properties=updated_properties,
+            catalog=catalog_properties,
+        )
+
+        # Get the updated table definition
+        updated_table_def = catalog.get_table(
+            table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        updated_table = updated_table_def.table
+        updated_table_version = updated_table_def.table_version
+
+        # Verify table properties were updated
+        assert updated_table_version.description == "Updated description"
+        assert updated_table_version.state == LifecycleState.CREATED
+        assert updated_table.properties.get("owner") == "new-user"
+        assert updated_table.properties.get("department") == "data-science"
+        assert updated_table.properties.get("priority") == "high"
+
+    def test_alter_table_not_exists(self, test_namespace):
+        """Test altering a table that doesn't exist"""
+        namespace_name, catalog_properties = test_namespace
+        nonexistent_table = "nonexistent_alter_table"
+
+        # Verify table doesn't exist
+        assert not catalog.table_exists(
+            nonexistent_table, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Try to alter the nonexistent table, should raise TableNotFoundError
+        with pytest.raises(TableNotFoundError, match=nonexistent_table):
+            catalog.alter_table(
+                table=nonexistent_table,
+                namespace=namespace_name,
+                description="Updated description",
+                catalog=catalog_properties,
+            )
+
+    def test_drop_with_purge_validation(self, test_namespace):
+        """Test that using purge flag raises ValidationError"""
+        namespace_name, catalog_properties = test_namespace
+        table_name = "test_drop_with_purge"
+
+        # Create the table
+        catalog.create_table(
+            name=table_name, namespace=namespace_name, catalog=catalog_properties
+        )
+
+        # Try to drop with purge=True, should raise ValidationError
+        with pytest.raises(
+            NotImplementedError, match="Purge flag is not currently supported"
+        ):
+            catalog.drop_table(
+                name=table_name,
+                namespace=namespace_name,
+                purge=True,
+                catalog=catalog_properties,
+            )


### PR DESCRIPTION
## Summary

This PR continues work on the catalog interface layer for Deltacat. It primarily focuses on implementing table related functions.

Functions Implemented:
- alter_table
- create_table
- drop_table
- list_tables
- get_table
- rename_table

Also includes minor bugfixes and better exception handling in the storage interface layer.

## Testing

- ran existing tests using `make test`
- added new tests for catalog table functions

## Checklist

- [x] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

There are some follow up tasks that have been added as TODO's.