### PR TITLE
Patch version bump to 1.1.32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
                   python -m pytest --benchmark-json output.json
             # Download previous benchmark result from cache (if exists)
             - name: Download previous benchmark data
-              uses: actions/cache@v1
+              uses: actions/cache@v4
               with:
                   path: ./cache
                   key: ${{ runner.os }}-benchmark

--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.31"
+__version__ = "1.1.32"
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Patch version bump to 1.1.32

## Rationale

Release new changes. 

## Changes
- https://github.com/ray-project/deltacat/pull/506

## Impact

The changes are backward compatible. They fix several high severity tickets at our side. 

## Testing

See testing section: https://github.com/ray-project/deltacat/pull/506

## Regression Risk

The new changes only affect reads that were failing before. So, the risk is very low.  

## Checklist

- [x] Unit tests covering the changes have been added
  - [x] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
