### PR TITLE
Add enforce_primary_key_uniqueness support to converter

### DIFF
--- a/deltacat/compute/converter/model/convert_input.py
+++ b/deltacat/compute/converter/model/convert_input.py
@@ -1,26 +1,29 @@
 from __future__ import annotations
 from typing import Dict, List
+from deltacat.compute.converter.model.convert_input_files import ConvertInputFiles
 
 
 class ConvertInput(Dict):
     @staticmethod
     def of(
-        files_for_each_bucket,
+        convert_input_files,
         convert_task_index,
         iceberg_table_warehouse_prefix,
         identifier_fields,
         compact_small_files,
+        enforce_primary_key_uniqueness,
         position_delete_for_multiple_data_files,
         max_parallel_data_file_download,
         s3_file_system,
     ) -> ConvertInput:
 
         result = ConvertInput()
-        result["files_for_each_bucket"] = files_for_each_bucket
+        result["convert_input_files"] = convert_input_files
         result["convert_task_index"] = convert_task_index
         result["identifier_fields"] = identifier_fields
         result["iceberg_table_warehouse_prefix"] = iceberg_table_warehouse_prefix
         result["compact_small_files"] = compact_small_files
+        result["enforce_primary_key_uniqueness"] = enforce_primary_key_uniqueness
         result[
             "position_delete_for_multiple_data_files"
         ] = position_delete_for_multiple_data_files
@@ -30,8 +33,8 @@ class ConvertInput(Dict):
         return result
 
     @property
-    def files_for_each_bucket(self) -> tuple:
-        return self["files_for_each_bucket"]
+    def convert_input_files(self) -> ConvertInputFiles:
+        return self["convert_input_files"]
 
     @property
     def identifier_fields(self) -> List[str]:
@@ -48,6 +51,10 @@ class ConvertInput(Dict):
     @property
     def compact_small_files(self) -> bool:
         return self["compact_small_files"]
+
+    @property
+    def enforce_primary_key_uniqueness(self) -> bool:
+        return self["enforce_primary_key_uniqueness"]
 
     @property
     def position_delete_for_multiple_data_files(self) -> bool:

--- a/deltacat/compute/converter/model/convert_input_files.py
+++ b/deltacat/compute/converter/model/convert_input_files.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from typing import Dict
+
+
+class ConvertInputFiles(Dict):
+    @staticmethod
+    def of(
+        partition_value,
+        all_data_files_for_dedupe=None,
+        applicable_data_files=None,
+        applicable_equality_delete_files=None,
+        existing_position_delete_files=None,
+    ) -> ConvertInputFiles:
+
+        result = ConvertInputFiles()
+        result["partition_value"] = partition_value
+        result["all_data_files_for_dedupe"] = all_data_files_for_dedupe
+        result["applicable_data_files"] = applicable_data_files
+        result["applicable_equality_delete_files"] = applicable_equality_delete_files
+        result["existing_position_delete_files"] = existing_position_delete_files
+        return result
+
+    @property
+    def partition_value(self):
+        return self["partition_value"]
+
+    @property
+    def all_data_files_for_dedupe(self):
+        return self["all_data_files_for_dedupe"]
+
+    @property
+    def applicable_data_files(self):
+        return self["applicable_data_files"]
+
+    @property
+    def applicable_equality_delete_files(self):
+        return self["applicable_equality_delete_files"]
+
+    @property
+    def existing_position_delete_files(self):
+        return self["existing_position_delete_files"]
+
+    @partition_value.setter
+    def partition_value(self, partition_value):
+        self["partition_value"] = partition_value
+
+    @all_data_files_for_dedupe.setter
+    def all_data_files_for_dedupe(self, all_data_files_for_dedupe):
+        self["all_data_files_for_dedupe"] = all_data_files_for_dedupe
+
+    @applicable_data_files.setter
+    def applicable_data_files(self, applicable_data_files):
+        self["applicable_data_files"] = applicable_data_files
+
+    @applicable_equality_delete_files.setter
+    def applicable_equality_delete_files(self, applicable_equality_delete_files):
+        self["applicable_equality_delete_files"] = applicable_equality_delete_files
+
+    @existing_position_delete_files.setter
+    def existing_position_delete_files(self, existing_position_delete_files):
+        self["existing_position_delete_files"] = existing_position_delete_files

--- a/deltacat/compute/converter/model/converter_session_params.py
+++ b/deltacat/compute/converter/model/converter_session_params.py
@@ -23,6 +23,9 @@ class ConverterSessionParams(dict):
         ), "iceberg_namespace is a required arg"
         result = ConverterSessionParams(params)
 
+        result.enforce_primary_key_uniqueness = params.get(
+            "enforce_primary_key_uniqueness", False
+        )
         result.compact_small_files = params.get("compact_small_files", False)
 
         # For Iceberg v3 spec, option to produce delete vector that can establish 1:1 mapping with data files.
@@ -50,6 +53,14 @@ class ConverterSessionParams(dict):
     @property
     def iceberg_namespace(self) -> str:
         return self["iceberg_namespace"]
+
+    @property
+    def enforce_primary_key_uniqueness(self) -> bool:
+        return self["enforce_primary_key_uniqueness"]
+
+    @enforce_primary_key_uniqueness.setter
+    def enforce_primary_key_uniqueness(self, enforce_primary_key_uniqueness) -> None:
+        self["compact_small_files"] = enforce_primary_key_uniqueness
 
     @property
     def compact_small_files(self) -> bool:

--- a/deltacat/compute/converter/steps/convert.py
+++ b/deltacat/compute/converter/steps/convert.py
@@ -1,15 +1,16 @@
 import pyarrow.compute as pc
+
 import deltacat.compute.converter.utils.iceberg_columns as sc
 import pyarrow as pa
-import numpy as np
-import daft
+
 from collections import defaultdict
 import ray
 import logging
 from deltacat.compute.converter.model.convert_input import ConvertInput
+from deltacat.compute.converter.steps.dedupe import dedupe_data_files
 from deltacat.compute.converter.utils.s3u import upload_table_with_retry
-from deltacat.compute.converter.utils.converter_session_utils import (
-    partition_value_record_to_partition_value_string,
+from deltacat.compute.converter.utils.io import (
+    download_data_table_and_append_iceberg_columns,
 )
 from deltacat import logs
 
@@ -18,7 +19,7 @@ logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 @ray.remote
 def convert(convert_input: ConvertInput):
-    files_for_each_bucket = convert_input.files_for_each_bucket
+    convert_input_files = convert_input.convert_input_files
     convert_task_index = convert_input.convert_task_index
     iceberg_table_warehouse_prefix = convert_input.iceberg_table_warehouse_prefix
     identifier_fields = convert_input.identifier_fields
@@ -36,30 +37,73 @@ def convert(convert_input: ConvertInput):
         raise NotImplementedError(f"Compact previous position delete not supported yet")
 
     logger.info(f"Starting convert task index: {convert_task_index}")
-    data_files, equality_delete_files, position_delete_files = files_for_each_bucket[1]
-    partition_value_str = partition_value_record_to_partition_value_string(
-        files_for_each_bucket[0]
+
+    applicable_data_files = convert_input_files.applicable_data_files
+    applicable_equality_delete_files = (
+        convert_input_files.applicable_equality_delete_files
     )
-    partition_value = files_for_each_bucket[0]
+    all_data_files_for_this_bucket = convert_input_files.all_data_files_for_dedupe
+    # Get string representation of partition value out of Record[partition_value]
+    partition_value_str = (
+        convert_input_files.partition_value.__repr__().split("[", 1)[1].split("]")[0]
+    )
+    partition_value = convert_input_files.partition_value
     iceberg_table_warehouse_prefix_with_partition = (
         f"{iceberg_table_warehouse_prefix}/{partition_value_str}"
     )
-    (
-        to_be_deleted_files_list,
-        to_be_added_files_list,
-    ) = compute_pos_delete_with_limited_parallelism(
-        data_files_list=data_files,
-        identifier_columns=identifier_fields,
-        equality_delete_files_list=equality_delete_files,
-        iceberg_table_warehouse_prefix_with_partition=iceberg_table_warehouse_prefix_with_partition,
-        max_parallel_data_file_download=max_parallel_data_file_download,
+    enforce_primary_key_uniqueness = convert_input.enforce_primary_key_uniqueness
+    total_pos_delete_table = []
+    if applicable_equality_delete_files:
+        (
+            pos_delete_after_converting_equality_delete
+        ) = compute_pos_delete_with_limited_parallelism(
+            data_files_list=applicable_data_files,
+            identifier_columns=identifier_fields,
+            equality_delete_files_list=applicable_equality_delete_files,
+            iceberg_table_warehouse_prefix_with_partition=iceberg_table_warehouse_prefix_with_partition,
+            max_parallel_data_file_download=max_parallel_data_file_download,
+            s3_file_system=s3_file_system,
+        )
+        if pos_delete_after_converting_equality_delete:
+            total_pos_delete_table.append(pos_delete_after_converting_equality_delete)
+
+    if enforce_primary_key_uniqueness:
+        data_files_to_dedupe = get_additional_applicable_data_files(
+            all_data_files=all_data_files_for_this_bucket,
+            data_files_downloaded=applicable_data_files,
+        )
+        pos_delete_after_dedupe = dedupe_data_files(
+            data_file_to_dedupe=data_files_to_dedupe,
+            identify_column_name_concatenated=identifier_fields[0],
+            identifier_columns=identifier_fields,
+            merge_sort_column=sc._ORDERED_RECORD_IDX_COLUMN_NAME,
+        )
+        total_pos_delete_table.append(pos_delete_after_dedupe)
+
+    total_pos_delete = pa.concat_tables(total_pos_delete_table)
+    to_be_added_files_list = upload_table_with_retry(
+        table=total_pos_delete,
+        s3_url_prefix=iceberg_table_warehouse_prefix_with_partition,
+        s3_table_writer_kwargs={},
         s3_file_system=s3_file_system,
     )
+
     to_be_delete_files_dict = defaultdict()
-    to_be_delete_files_dict[partition_value] = to_be_deleted_files_list
+    if applicable_equality_delete_files:
+        to_be_delete_files_dict[partition_value] = [
+            equality_delete_file[1]
+            for equality_delete_file in applicable_equality_delete_files
+        ]
     to_be_added_files_dict = defaultdict()
     to_be_added_files_dict[partition_value] = to_be_added_files_list
     return (to_be_delete_files_dict, to_be_added_files_dict)
+
+
+def get_additional_applicable_data_files(all_data_files, data_files_downloaded):
+    data_file_to_dedupe = all_data_files
+    if data_files_downloaded:
+        data_file_to_dedupe = list(set(all_data_files) - set(data_files_downloaded))
+    return data_file_to_dedupe
 
 
 def filter_rows_to_be_deleted(
@@ -71,43 +115,34 @@ def filter_rows_to_be_deleted(
             data_file_table[identifier_column],
             equality_delete_table[identifier_column],
         )
-        positional_delete_table = data_file_table.filter(equality_deletes)
-        logger.info(f"positional_delete_table:{positional_delete_table.to_pydict()}")
+        position_delete_table = data_file_table.filter(equality_deletes)
+        logger.info(f"positional_delete_table:{position_delete_table.to_pydict()}")
         logger.info(f"data_file_table:{data_file_table.to_pydict()}")
         logger.info(
-            f"length_pos_delete_table, {len(positional_delete_table)}, length_data_table:{len(data_file_table)}"
+            f"length_pos_delete_table, {len(position_delete_table)}, length_data_table:{len(data_file_table)}"
         )
-    if positional_delete_table:
-        # TODO: Add support for multiple identify columns
-        identifier_column = identifier_columns[0]
-        positional_delete_table = positional_delete_table.drop([identifier_column])
-    if len(positional_delete_table) == len(data_file_table):
-        return True, None
-    return False, positional_delete_table
+    return position_delete_table
 
 
-def compute_pos_delete(
+def compute_pos_delete_converting_equality_deletes(
     equality_delete_table,
     data_file_table,
     identifier_columns,
     iceberg_table_warehouse_prefix_with_partition,
     s3_file_system,
 ):
-    delete_whole_file, new_position_delete_table = filter_rows_to_be_deleted(
+    new_position_delete_table = filter_rows_to_be_deleted(
         data_file_table=data_file_table,
         equality_delete_table=equality_delete_table,
         identifier_columns=identifier_columns,
     )
     if new_position_delete_table:
-        logger.info(f"compute_pos_delete_table:{new_position_delete_table.to_pydict()}")
-    if new_position_delete_table:
-        new_pos_delete_s3_link = upload_table_with_retry(
-            table=new_position_delete_table,
-            s3_url_prefix=iceberg_table_warehouse_prefix_with_partition,
-            s3_table_writer_kwargs={},
-            s3_file_system=s3_file_system,
+        logger.info(
+            f"Length of position delete table after converting from equality deletes:{len(new_position_delete_table)}"
         )
-    return delete_whole_file, new_pos_delete_s3_link
+    else:
+        return None
+    return new_position_delete_table
 
 
 def download_bucketed_table(data_files, equality_delete_files):
@@ -122,22 +157,6 @@ def download_bucketed_table(data_files, equality_delete_files):
     return compacted_table, equality_delete_table
 
 
-def download_data_table(data_files, columns):
-    data_tables = []
-    for file in data_files:
-        table = download_parquet_with_daft_hash_applied(
-            identify_columns=columns, file=file, s3_client_kwargs={}
-        )
-        table = table.append_column(
-            sc._FILE_PATH_COLUMN_FIELD,
-            pa.array(np.repeat(file.file_path, len(table)), sc._FILE_PATH_COLUMN_TYPE),
-        )
-        record_idx_iterator = iter(range(len(table)))
-        table = sc.append_record_idx_col(table, record_idx_iterator)
-        data_tables.append(table)
-    return pa.concat_tables(data_tables)
-
-
 def compute_pos_delete_with_limited_parallelism(
     data_files_list,
     identifier_columns,
@@ -146,60 +165,43 @@ def compute_pos_delete_with_limited_parallelism(
     max_parallel_data_file_download,
     s3_file_system,
 ):
-    to_be_deleted_file_list = []
-    to_be_added_pos_delete_file_list = []
-
     for data_files, equality_delete_files in zip(
         data_files_list, equality_delete_files_list
     ):
-        data_table = download_data_table(
-            data_files=data_files, columns=identifier_columns
-        )
-        equality_delete_table = download_data_table(
-            data_files=equality_delete_files, columns=identifier_columns
-        )
-        delete_whole_file, new_pos_delete_s3_link = compute_pos_delete(
-            equality_delete_table=equality_delete_table,
-            data_file_table=data_table,
-            iceberg_table_warehouse_prefix_with_partition=iceberg_table_warehouse_prefix_with_partition,
-            identifier_columns=identifier_columns,
-            s3_file_system=s3_file_system,
-        )
-        if delete_whole_file:
-            to_be_deleted_file_list.extend(data_files)
-        to_be_deleted_file_list.extend(equality_delete_files)
-        if new_pos_delete_s3_link:
-            to_be_added_pos_delete_file_list.extend(new_pos_delete_s3_link)
+        data_table_total = []
+        for data_file in data_files:
+            data_table = download_data_table_and_append_iceberg_columns(
+                data_files=data_file[1],
+                columns_to_download=identifier_columns,
+                additional_columns_to_append=[
+                    sc._FILE_PATH_COLUMN_NAME,
+                    sc._ORDERED_RECORD_IDX_COLUMN_NAME,
+                ],
+                sequence_number=data_file[0],
+            )
+            data_table_total.append(data_table)
+        data_table_total = pa.concat_tables(data_table_total)
 
-    to_be_deleted_file_list.extend(equality_delete_files)
-    logger.info(f"convert_to_be_deleted_file_list:{to_be_deleted_file_list}")
+        equality_delete_table_total = []
+        for equality_delete in equality_delete_files:
+            equality_delete_table = download_data_table_and_append_iceberg_columns(
+                data_files=equality_delete[1],
+                columns_to_download=identifier_columns,
+            )
+            equality_delete_table_total.append(equality_delete_table)
+        equality_delete_table_total = pa.concat_tables(equality_delete_table_total)
+
+    new_pos_delete_table = compute_pos_delete_converting_equality_deletes(
+        equality_delete_table=equality_delete_table_total,
+        data_file_table=data_table_total,
+        iceberg_table_warehouse_prefix_with_partition=iceberg_table_warehouse_prefix_with_partition,
+        identifier_columns=identifier_columns,
+        s3_file_system=s3_file_system,
+    )
+    if not new_pos_delete_table:
+        logger.info("No records deleted based on equality delete converstion")
+
     logger.info(
-        f"convert_to_be_added_pos_delete_file_list:{to_be_added_pos_delete_file_list}"
+        f"Number of records to delete based on equality delete convertion:{len(new_pos_delete_table)}"
     )
-    return to_be_deleted_file_list, to_be_added_pos_delete_file_list
-
-
-def download_parquet_with_daft_hash_applied(
-    identify_columns, file, s3_client_kwargs, **kwargs
-):
-    from daft import TimeUnit
-
-    # TODO: Add correct read kwargs as in:
-    #  https://github.com/ray-project/deltacat/blob/383855a4044e4dfe03cf36d7738359d512a517b4/deltacat/utils/daft.py#L97
-
-    coerce_int96_timestamp_unit = TimeUnit.from_str(
-        kwargs.get("coerce_int96_timestamp_unit", "ms")
-    )
-
-    from deltacat.utils.daft import _get_s3_io_config
-
-    # TODO: Use Daft SHA1 hash instead to minimize probably of data corruption
-    io_config = _get_s3_io_config(s3_client_kwargs=s3_client_kwargs)
-    df = daft.read_parquet(
-        path=file.file_path,
-        io_config=io_config,
-        coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,
-    )
-    df = df.select(daft.col(identify_columns[0]).hash())
-    arrow_table = df.to_arrow()
-    return arrow_table
+    return new_pos_delete_table

--- a/deltacat/compute/converter/steps/dedupe.py
+++ b/deltacat/compute/converter/steps/dedupe.py
@@ -1,0 +1,60 @@
+import pyarrow as pa
+import pyarrow.compute as pc
+import deltacat.compute.converter.utils.iceberg_columns as sc
+from deltacat.compute.converter.utils.io import (
+    download_data_table_and_append_iceberg_columns,
+)
+
+
+def dedupe_data_files(
+    data_file_to_dedupe,
+    identify_column_name_concatenated,
+    identifier_columns,
+    merge_sort_column,
+):
+    data_file_table = []
+
+    # Sort data files by file sequence number first
+    data_file_to_dedupe = sorted(data_file_to_dedupe, key=lambda f: f[0])
+    for file_tuple in data_file_to_dedupe:
+        sequence_number = file_tuple[0]
+        data_file = file_tuple[1]
+        data_file_to_dedupe_table = download_data_table_and_append_iceberg_columns(
+            file=data_file,
+            columns_to_download=identifier_columns,
+            additional_columns_to_append=[
+                sc._FILE_PATH_COLUMN_NAME,
+                sc._ORDERED_RECORD_IDX_COLUMN_NAME,
+            ],
+            sequence_number=sequence_number,
+        )
+        data_file_table.append(data_file_to_dedupe_table)
+
+    final_data_to_dedupe = pa.concat_tables(data_file_table)
+
+    record_idx_iterator = iter(range(len(final_data_to_dedupe)))
+
+    # Append global record index to used as aggregate column
+    final_data_to_dedupe = sc.append_global_record_idx_column(
+        final_data_to_dedupe, record_idx_iterator
+    )
+
+    final_data_table_indices = final_data_to_dedupe.group_by(
+        identify_column_name_concatenated, use_threads=False
+    ).aggregate([(sc._GLOBAL_RECORD_IDX_COLUMN_NAME, "max")])
+
+    pos_delete_indices = pc.invert(
+        pc.is_in(
+            final_data_to_dedupe[sc._GLOBAL_RECORD_IDX_COLUMN_NAME],
+            value_set=final_data_table_indices[
+                f"{sc._GLOBAL_RECORD_IDX_COLUMN_NAME}_max"
+            ],
+        )
+    )
+
+    final_data_table_to_delete = final_data_to_dedupe.filter(pos_delete_indices)
+
+    final_data_table_to_delete = final_data_table_to_delete.drop(
+        [identify_column_name_concatenated, sc._GLOBAL_RECORD_IDX_COLUMN_NAME]
+    )
+    return final_data_table_to_delete

--- a/deltacat/compute/converter/utils/converter_session_utils.py
+++ b/deltacat/compute/converter/utils/converter_session_utils.py
@@ -1,4 +1,13 @@
+from collections import defaultdict
+import logging
+from deltacat import logs
+from deltacat.compute.converter.model.convert_input_files import ConvertInputFiles
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
+
+
 def check_data_files_sequence_number(data_files_list, equality_delete_files_list):
+    # Sort by file sequence number
     data_files_list.sort(key=lambda file_tuple: file_tuple[0])
     equality_delete_files_list.sort(key=lambda file_tuple: file_tuple[0])
 
@@ -8,24 +17,19 @@ def check_data_files_sequence_number(data_files_list, equality_delete_files_list
     # Pointer for list data_file
     data_file_pointer = 0
 
-    debug_equality_delete_files = []
-
     # Loop through each value in equality_delete_file
     for equality_file_tuple in equality_delete_files_list:
         # Find all values in data_file that are smaller than val_equality
         valid_values = []
 
-        debug_valid_values = []
         # Move data_file_pointer to the first value in data_file that is smaller than val_equality
         while (
             data_file_pointer < len(data_files_list)
             and data_files_list[data_file_pointer][0] < equality_file_tuple[0]
         ):
-            valid_values.append(data_files_list[data_file_pointer][1])
-            debug_valid_values.append(data_files_list[data_file_pointer])
+            valid_values.append(data_files_list[data_file_pointer])
             data_file_pointer += 1
-            equality_delete_files.append(equality_file_tuple[1])
-            debug_equality_delete_files.append(equality_file_tuple)
+            equality_delete_files.append(equality_file_tuple)
 
         # Append the value from equality_delete_file and the corresponding valid values from data_file
         if valid_values:
@@ -56,7 +60,52 @@ def construct_iceberg_table_prefix(
     return f"{iceberg_warehouse_bucket_name}/{iceberg_namespace}/{table_name}/data"
 
 
-def partition_value_record_to_partition_value_string(partition):
-    # Get string representation of partition value out of Record[partition_value]
-    partition_value_str = partition.__repr__().split("[", 1)[1].split("]")[0]
-    return partition_value_str
+def group_all_files_to_each_bucket(
+    data_file_dict, equality_delete_dict, pos_delete_dict
+):
+    convert_input_files_for_all_buckets = []
+    files_for_each_bucket_for_deletes = defaultdict(tuple)
+    if equality_delete_dict:
+        # files_for_each_bucket contains the following files list:
+        # {partition_value: [(equality_delete_files_tuple_list, data_files_tuple_list, pos_delete_files_tuple_list)]
+        for k, v in data_file_dict.items():
+            logger.info(f"data_file: k, v:{k, v}")
+        for k, v in equality_delete_dict.items():
+            logger.info(f"equality_delete_file: k, v:{k, v}")
+        for partition_value, equality_delete_file_list in equality_delete_dict.items():
+            (
+                result_equality_delete_file,
+                result_data_file,
+            ) = check_data_files_sequence_number(
+                data_files_list=data_file_dict[partition_value],
+                equality_delete_files_list=equality_delete_dict[partition_value],
+            )
+            logger.info(f"result_data_file:{result_data_file}")
+            logger.info(f"result_equality_delete_file:{result_equality_delete_file}")
+            files_for_each_bucket_for_deletes[partition_value] = (
+                result_data_file,
+                result_equality_delete_file,
+                [],
+            )
+            if partition_value not in data_file_dict:
+                convert_input_file = ConvertInputFiles.of(
+                    partition_value=partition_value,
+                    applicable_data_files=result_data_file,
+                    applicable_equalitu_delete_files=result_equality_delete_file,
+                )
+                convert_input_files_for_all_buckets.append(convert_input_file)
+
+    for partition_value, all_data_files_for_each_bucket in data_file_dict.items():
+        convert_input_file = ConvertInputFiles.of(
+            partition_value=partition_value,
+            all_data_files_for_dedupe=all_data_files_for_each_bucket,
+        )
+        if partition_value in files_for_each_bucket_for_deletes:
+            convert_input_file.applicable_data_files = (
+                files_for_each_bucket_for_deletes[partition_value][0]
+            )
+            convert_input_file.applicable_delete_files = (
+                files_for_each_bucket_for_deletes[partition_value][1]
+            )
+        convert_input_files_for_all_buckets.append(convert_input_file)
+    return convert_input_files_for_all_buckets

--- a/deltacat/compute/converter/utils/iceberg_columns.py
+++ b/deltacat/compute/converter/utils/iceberg_columns.py
@@ -1,5 +1,6 @@
 import pyarrow as pa
 from typing import Union
+import numpy as np
 
 # Refer to: https://iceberg.apache.org/spec/#reserved-field-ids for reserved field ids
 ICEBERG_RESERVED_FIELD_ID_FOR_FILE_PATH_COLUMN = 2147483546
@@ -52,3 +53,30 @@ _FILE_PATH_COLUMN_FIELD = pa.field(
     metadata=_FILE_PATH_FIELD_METADATA,
     nullable=False,
 )
+
+
+def append_file_path_column(table: pa.Table, file_path: str):
+    table = table.append_column(
+        _FILE_PATH_COLUMN_FIELD,
+        pa.array(np.repeat(file_path, len(table)), _FILE_PATH_COLUMN_TYPE),
+    )
+    return table
+
+
+_GLOBAL_RECORD_IDX_COLUMN_NAME = _get_iceberg_col_name("global_record_index")
+_GLOBAL_RECORD_IDX_COLUMN_TYPE = pa.int64()
+_GLOBAL_RECORD_IDX_COLUMN_FIELD = pa.field(
+    _GLOBAL_RECORD_IDX_COLUMN_NAME,
+    _GLOBAL_RECORD_IDX_COLUMN_TYPE,
+)
+
+
+def append_global_record_idx_column(
+    table: pa.Table, ordered_record_indices
+) -> pa.Table:
+
+    table = table.append_column(
+        _GLOBAL_RECORD_IDX_COLUMN_NAME,
+        pa.array(ordered_record_indices, _GLOBAL_RECORD_IDX_COLUMN_TYPE),
+    )
+    return table

--- a/deltacat/compute/converter/utils/io.py
+++ b/deltacat/compute/converter/utils/io.py
@@ -1,0 +1,43 @@
+import deltacat.compute.converter.utils.iceberg_columns as sc
+import daft
+
+
+def download_data_table_and_append_iceberg_columns(
+    file, columns_to_download, additional_columns_to_append, sequence_number
+):
+    # TODO; add S3 client kwargs
+    table = download_parquet_with_daft_hash_applied(
+        identify_columns=columns_to_download, file=file, s3_client_kwargs={}
+    )
+    if sc._FILE_PATH_COLUMN_NAME in additional_columns_to_append:
+        table = sc.append_file_path_column(table, file.file_path)
+    if sc._ORDERED_RECORD_IDX_COLUMN_NAME in additional_columns_to_append:
+        record_idx_iterator = iter(range(len(table)))
+        table = sc.append_record_idx_col(table, record_idx_iterator)
+    return table
+
+
+def download_parquet_with_daft_hash_applied(
+    identify_columns, file, s3_client_kwargs, **kwargs
+):
+    from daft import TimeUnit
+
+    # TODO: Add correct read kwargs as in:
+    #  https://github.com/ray-project/deltacat/blob/383855a4044e4dfe03cf36d7738359d512a517b4/deltacat/utils/daft.py#L97
+
+    coerce_int96_timestamp_unit = TimeUnit.from_str(
+        kwargs.get("coerce_int96_timestamp_unit", "ms")
+    )
+
+    from deltacat.utils.daft import _get_s3_io_config
+
+    # TODO: Use Daft SHA1 hash instead to minimize probably of data corruption
+    io_config = _get_s3_io_config(s3_client_kwargs=s3_client_kwargs)
+    df = daft.read_parquet(
+        path=file.file_path,
+        io_config=io_config,
+        coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,
+    )
+    df = df.select(daft.col(identify_columns[0]).hash())
+    arrow_table = df.to_arrow()
+    return arrow_table

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyarrow == 17.0.0
 
 # deltacat[iceberg]
 #pyiceberg[glue] @ git+https://github.com/apache/iceberg-python
-pyiceberg[glue] >= 0.6.0
+pyiceberg[glue] == 0.8.0
 pymemcache == 4.0.0
 pyspark == 3.5.3
 ray[default] >= 2.20.0,<2.31.0


### PR DESCRIPTION
## Summary

Records with same primary key/identify fields will be deduped with this PR, the purpose is that we can enforce primary key uniqueness as well as finding primary keys to be deleted based on equality delete files within same operation(No need to download into memory same files again). All records meant to be either deduped or deleted will be output in form of position deletes.

## Rationale

Explain the reasoning behind the changes and their benefits to the project.

## Changes

List the major changes made in this pull request.

## Impact

Discuss any potential impacts the changes may have on existing functionalities.

## Testing

Describe how the changes have been tested, including both automated and manual testing strategies.
If this is a bugfix, explain how the fix has been tested to ensure the bug is resolved without introducing new issues.

## Regression Risk

If this is a bugfix, assess the risk of regression caused by this fix and steps taken to mitigate it.

## Checklist

- [x] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
