### PR TITLE
chore: upgrade pydantic to 2.x

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 
 import deltacat.logs  # noqa: F401
@@ -35,7 +36,6 @@ from deltacat.catalog.model.catalog import (  # noqa: F401
     get_catalog,
     put_catalog,
 )
-from deltacat.catalog.iceberg import impl as IcebergCatalog
 from deltacat.catalog.model.table_definition import TableDefinition
 from deltacat.storage import (
     DistributedDataset,
@@ -57,6 +57,14 @@ from deltacat.storage import (
 from deltacat.storage.rivulet import Dataset, Datatype
 from deltacat.types.media import ContentEncoding, ContentType, TableType
 from deltacat.types.tables import TableWriteMode
+
+__iceberg__ = []
+if importlib.util.find_spec("pyiceberg") is not None:
+    from deltacat.catalog.iceberg import impl as IcebergCatalog
+
+    __iceberg__ = [
+        "IcebergCatalog",
+    ]
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
@@ -116,3 +124,5 @@ __all__ = [
     "TableType",
     "TableWriteMode",
 ]
+
+__all__ += __iceberg__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,20 @@
-# setup.py install_requires
-# any changes here should also be reflected in setup.py "install_requires"
+# These are mirrored in setup.py as install_requires,
+# which is what the users of the Deltacat package will install. The rest of this file
+# sets up all the packages necessary for a /developer/ of Deltacat.
+#
+# In short, if you change it here, PLEASE also change it in setup.py.
 aws-embedded-metrics == 3.2.0
 boto3 ~= 1.34
 getdaft == 0.3.6
 intervaltree == 3.1.0
 msgpack ~= 1.0.7
-numpy == 1.22.4
+numpy == 1.21.5
 pandas == 1.3.5
 # upgrade to pyarrow 18.0.0 causes test
 # TestCompactionSession::test_compact_partition_when_incremental_then_rcf_stats_accurate to fail
 # due to input_inflation exceeding 1e-5
 pyarrow == 17.0.0
+pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3
 
 # setup.py extras_require
 # any changes here should also be reflected in setup.py "extras_require"

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
         # TestCompactionSession::test_compact_partition_when_incremental_then_rcf_stats_accurate to fail
         # due to input_inflation exceeding 1e-5
         "pyarrow == 17.0.0",
-        "pydantic == 1.10.4",
+        "pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3",
         "pymemcache == 4.0.0",
         "ray >= 2.20.0",
         "s3fs == 2024.5.0",


### PR DESCRIPTION
## Summary
Upgrade pydantic to a constrained version that matches ray.
`pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3`
