### PR TITLE
Bugfix: Final parameter of `MergeResult` is using peak_memory_usage_bytes instead of time.time() (task_completed_at)

### DIFF
--- a/deltacat/compute/compactor_v2/steps/merge.py
+++ b/deltacat/compute/compactor_v2/steps/merge.py
@@ -627,5 +627,5 @@ def merge(input: MergeInput) -> MergeResult:
             merge_result[3],
             merge_result[4],
             np.double(emit_metrics_time),
-            merge_result[4],
+            merge_result[6],
         )


### PR DESCRIPTION
## Summary
- [Final parameter](https://github.com/ray-project/deltacat/blob/9a0a624f91e6de6708626a3d457649348dcd8b82/deltacat/compute/compactor_v2/steps/merge.py#L630) of [`MergeResult`](https://github.com/ray-project/deltacat/blob/f2d11b21c8f5c2421d70fcf9b3fa4769d7f6c9e8/deltacat/compute/compactor_v2/model/merge_result.py#L7) is using [`peak_memory_usage_bytes`](https://github.com/ray-project/deltacat/blob/f2d11b21c8f5c2421d70fcf9b3fa4769d7f6c9e8/deltacat/compute/compactor_v2/model/merge_result.py#L12), which is already returned as the [fourth parameter](https://github.com/ray-project/deltacat/blob/f2d11b21c8f5c2421d70fcf9b3fa4769d7f6c9e8/deltacat/compute/compactor_v2/steps/merge.py#L566) instead of `time.time()` as an argument

## Rationale
- Root-cause of a bug in  the `task_completed_at` calculation

## Changes
- Final parameter of [`MergeResult`](https://github.com/ray-project/deltacat/blob/9a0a624f91e6de6708626a3d457649348dcd8b82/deltacat/compute/compactor_v2/steps/merge.py#L623) is using `peak_memory_usage_bytes`, which is already returned as the fourth parameter instead of `time.time()` 

## Impact
- Fixes calculation of `last_task_completed_at` in [compaction audit module](https://github.com/ray-project/deltacat/blob/f2d11b21c8f5c2421d70fcf9b3fa4769d7f6c9e8/deltacat/compute/compactor/model/compaction_session_audit_info.py#L830). Previously, 

## Testing
- No additional testing added

## Regression Risk

If this is a bugfix, assess the risk of regression caused by this fix and steps taken to mitigate it.

## Checklist

- [ ] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
