### PR TITLE
Patch version bump to 1.1.34

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.33"
+__version__ = "1.1.34"
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Patch version bump to 1.1.34

## Rationale
Release new changes. 

## Changes
- https://github.com/ray-project/deltacat/pull/522

## Impact
The change is backward compatible and fixes an audit logging bug.

## Testing

See testing section: https://github.com/ray-project/deltacat/pull/506

## Regression Risk

The new changes only affect reads that were failing before. So, the risk is very low.  

## Checklist

- [x] Unit tests covering the changes have been added
  - [x] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
