### PR TITLE
Remove ray namespace support in Catalogs & minor test refactors

### DIFF
--- a/deltacat/api.py
+++ b/deltacat/api.py
@@ -2,6 +2,7 @@ from typing import Any
 
 
 import deltacat as dc
+from deltacat.catalog import Catalog
 
 
 def copy(source, destination):
@@ -115,7 +116,9 @@ def put(path, *args, **kwargs) -> Any:
         #  disk so that users don't need to re-initialize them every time.
         # register the given catalog
         catalog_name = parts[0]
-        return dc.put_catalog(catalog_name, *args, **kwargs)
+        # Initialize default catalog using kwargs
+        catalog = Catalog(**kwargs)
+        return dc.put_catalog(catalog_name, catalog)
     elif len(parts) == 2:
         # register the given namespace
         catalog_name = parts[0]

--- a/deltacat/catalog/model/catalog.py
+++ b/deltacat/catalog/model/catalog.py
@@ -257,7 +257,6 @@ def put_catalog(
     Args:
         name: name of catalog
         catalog: catalog instance to use, if provided
-        impl: catalog module to initialize. Only used if `catalog` param not provided
         default:  Make this the default catalog if multiple catalogs are available.
             ignored if this is the only catalog available, since it will always be the default catalog.
         ray_init_args: ray initialization args (used only if ray not already initialized)
@@ -288,7 +287,7 @@ def put_catalog(
             pass
         if catalog_already_exists:
             raise ValueError(
-                f"Failed to put catalog {name} because it already exists and fail_if_exists=True"
+                f"Failed to put catalog {name} because it already exists and fail_if_exists={fail_if_exists}"
             )
 
     # Add the catalog (which may overwrite existing if fail_if_exists=False)

--- a/deltacat/catalog/model/catalog.py
+++ b/deltacat/catalog/model/catalog.py
@@ -136,9 +136,7 @@ class Catalogs:
     def names(self) -> List[str]:
         return list(self.catalogs.keys())
 
-    def put(self, name: str,
-            catalog: Catalog,
-            set_default: bool = False) -> None:
+    def put(self, name: str, catalog: Catalog, set_default: bool = False) -> None:
         self.catalogs[name] = catalog
         if set_default:
             self.default_catalog = catalog
@@ -202,6 +200,7 @@ def init(
         catalogs=catalogs, default_catalog_name=default_catalog_name
     )
 
+
 def get_catalog(name: Optional[str] = None, **kwargs) -> Catalog:
     """
     Get a catalog by name, or the default catalog if no name is provided.
@@ -226,7 +225,8 @@ def get_catalog(name: Optional[str] = None, **kwargs) -> Catalog:
         if not catalog:
             available_catalogs = ray.get(all_catalogs.all.remote()).values()
             raise ValueError(
-                f"Catalog '{name}' not found. Available catalogs: " f"{available_catalogs}."
+                f"Catalog '{name}' not found. Available catalogs: "
+                f"{available_catalogs}."
             )
         return catalog
 
@@ -235,9 +235,11 @@ def get_catalog(name: Optional[str] = None, **kwargs) -> Catalog:
         if not catalog:
             available_catalogs = ray.get(all_catalogs.all.remote()).values()
             raise ValueError(
-                f"Call to get_catalog without name set failed because there is no default Catalog set. Available catalogs: " f"{available_catalogs}."
+                f"Call to get_catalog without name set failed because there is no default Catalog set. Available catalogs: "
+                f"{available_catalogs}."
             )
         return catalog
+
 
 def put_catalog(
     name: str,
@@ -275,9 +277,10 @@ def put_catalog(
     else:
         # NOTE - since we are initializing with a single catalog, it will be set to the default
         if not set_as_default:
-            logger.warning(f"Calling put_catalog with set_as_default=False, "
-                           f"but still setting Catalog {catalog} as default since it is the only catalog.")
+            logger.warning(
+                f"Calling put_catalog with set_as_default=False, "
+                f"but still setting Catalog {catalog} as default since it is the only catalog."
+            )
         init({name: catalog}, ray_init_args=ray_init_args, **kwargs)
 
     return catalog
-

--- a/deltacat/tests/catalog/iceberg/test_iceberg_catalog.py
+++ b/deltacat/tests/catalog/iceberg/test_iceberg_catalog.py
@@ -1,7 +1,6 @@
 import tempfile
 import shutil
 import uuid
-import ray
 import deltacat
 import pytest
 from deltacat import Field, Schema
@@ -54,7 +53,7 @@ class TestIcebergCatalogInitialization:
             catalog_name,
             impl=deltacat.IcebergCatalog,
             **{"config": config},
-            ray_init_args={"ignore_reinit_error": True}
+            ray_init_args={"ignore_reinit_error": True},
         )
 
         table_def = deltacat.create_table(

--- a/deltacat/tests/catalog/iceberg/test_iceberg_catalog.py
+++ b/deltacat/tests/catalog/iceberg/test_iceberg_catalog.py
@@ -1,7 +1,7 @@
 import tempfile
 import shutil
 import uuid
-
+import ray
 import deltacat
 import pytest
 from deltacat import Field, Schema
@@ -42,9 +42,6 @@ class TestIcebergCatalogInitialization:
         catalog_name = str(uuid.uuid4())
 
         config = IcebergCatalogConfig(
-            type=CatalogType.SQL, properties={"warehouse": self.temp_dir}
-        )
-        config = IcebergCatalogConfig(
             type=CatalogType.SQL,
             properties={
                 "warehouse": self.temp_dir,
@@ -54,7 +51,10 @@ class TestIcebergCatalogInitialization:
 
         # Initialize with the PyIceberg catalog
         deltacat.put_catalog(
-            catalog_name, impl=deltacat.IcebergCatalog, **{"config": config}
+            catalog_name,
+            impl=deltacat.IcebergCatalog,
+            **{"config": config},
+            ray_init_args={"ignore_reinit_error": True}
         )
 
         table_def = deltacat.create_table(

--- a/deltacat/tests/catalog/iceberg/test_iceberg_catalog.py
+++ b/deltacat/tests/catalog/iceberg/test_iceberg_catalog.py
@@ -3,7 +3,7 @@ import shutil
 import uuid
 import deltacat
 import pytest
-from deltacat import Field, Schema
+from deltacat import Field, Schema, Catalog
 from pyiceberg.catalog import CatalogType
 
 import pyarrow as pa
@@ -49,10 +49,10 @@ class TestIcebergCatalogInitialization:
         )
 
         # Initialize with the PyIceberg catalog
+        catalog = Catalog(impl=deltacat.IcebergCatalog, **{"config": config})
         deltacat.put_catalog(
             catalog_name,
-            impl=deltacat.IcebergCatalog,
-            **{"config": config},
+            catalog,
             ray_init_args={"ignore_reinit_error": True},
         )
 

--- a/deltacat/tests/catalog/test_catalogs.py
+++ b/deltacat/tests/catalog/test_catalogs.py
@@ -29,6 +29,37 @@ class MockCatalogImpl:
         # Return some state that the catalog would normally maintain
         return {"initialized": True, "args": args, "kwargs": kwargs}
 
+@pytest.fixture(scope="function")
+def reset_catalogs_ray_actor():
+    """
+    Setup and teardown for Ray environment for tests.
+
+    This will kill the actor all_catalogs, essentially wiping global state for catalogs
+
+    NOTE: tests using this fixture must be run serially. As of April 7 2025, the unit test suite had various
+      failures if run in parallel, in part because the state of all_catalogs in ray is shared across tests.
+
+    NOTE: when using this fixture, ensure you pass ray_init_args={"ignore_reinit_error": True} into all
+        functions which may re-initialize ray. This is because the production code checks the all_catalogs actor
+        in order to determine whether it needs to initialize Ray
+    """
+    # Reset the global catalog_actor state before each test
+    import deltacat.catalog.model.catalog as catalog_module
+
+    # Initialize Ray if not already initialized
+    if not ray.is_initialized():
+        ray.init(ignore_reinit_error=True)
+    yield
+
+    # Clean up the actor if it exists
+    if catalog_module.all_catalogs is not None:
+        try:
+            ray.kill(catalog_module.all_catalogs)
+        except Exception:
+            pass
+        finally:
+            catalog_module.all_catalogs = None
+
 
 class TestCatalog(unittest.TestCase):
     """Tests for the Catalog class itself, without Ray initialization."""
@@ -63,65 +94,46 @@ class TestCatalog(unittest.TestCase):
             # Check that the inner state is set to the output of initialize
             self.assertEqual(catalog.inner, {"iceberg": True})
 
+class TestCatalogsIntegration:
+    """Integration tests for Default catalog functionality."""
 
-@pytest.fixture(scope="function")
-def isolated_ray_env(request):
-    """
-    Setup and teardown an isolated Ray environment for tests.
+    temp_dir = None
 
-    In order to use this fixture, Ray must be re-initialize providing the namespace and ignoring re-initialization errors
-
-    Re-initialize ray like:
-    init(catalog,
-        ray_init_args={"namespace": namespace, "ignore_reinit_error": True},
-        **{"force_reinitialize": True})
-    """
-
-    namespace = f"test_catalogs_{uuid.uuid4().hex}"
-
-    # Reset the global all_catalogs state before each test
-    global all_catalogs
-    all_catalogs = None
-
-    yield namespace
-
-    # Clean up the actor in this namespace if it exists
-    if all_catalogs is not None and isinstance(all_catalogs, ray.actor.ActorHandle):
-        try:
-            ray.kill(all_catalogs)
-            ray.shutdown()
-        except Exception:
-            pass
-
-    # Reset all_catalogs to None
-    all_catalogs = None
-
-
-class TestCatalogsWithRay:
-    """
-    Tests for Catalogs and global catalog state which require Ray initialization.
-    """
-
-    def test_init_single_catalog(self, isolated_ray_env):
-        """Test initializing a single catalog."""
-        # Create a catalog
+    @classmethod
+    def setup_class(cls):
+        cls.temp_dir = tempfile.mkdtemp()
+        # Other tests are going to have initialized ray catalog. Initialize here to ensure
+        # that when this test class is run individuall it mimicks running with other tests
         catalog = Catalog(impl=MockCatalogImpl)
-
-        # Initialize with a single catalog and Ray init args including the namespace
-        init(
-            catalog,
-            ray_init_args={"namespace": isolated_ray_env, "ignore_reinit_error": True},
+        init(catalog,
+            ray_init_args={"ignore_reinit_error": True},
             **{"force_reinitialize": True},
         )
 
-        assert is_initialized(**{"namespace": isolated_ray_env})
+    @classmethod
+    def teardown_class(cls):
+        if cls.temp_dir and os.path.exists(cls.temp_dir):
+            shutil.rmtree(cls.temp_dir)
+
+    def test_init_single_catalog(self, reset_catalogs_ray_actor):
+        """Test initializing a single catalog."""
+
+        catalog = Catalog(impl=MockCatalogImpl)
+
+        # Initialize with a single catalog and Ray init args including the namespace
+        init(catalog,
+            ray_init_args={"ignore_reinit_error": True},
+            **{"force_reinitialize": True},
+        )
+
+        assert is_initialized()
 
         # Get the default catalog and check it's the same one we initialized with
-        retrieved_catalog = get_catalog(**{"namespace": isolated_ray_env})
+        retrieved_catalog = get_catalog()
         assert retrieved_catalog.impl == MockCatalogImpl
         assert retrieved_catalog.inner["initialized"]
 
-    def test_init_multiple_catalogs(self, isolated_ray_env):
+    def test_init_multiple_catalogs(self, reset_catalogs_ray_actor):
         """Test initializing multiple catalogs."""
         # Create catalogs
         catalog1 = Catalog(impl=MockCatalogImpl, id=1)
@@ -131,22 +143,22 @@ class TestCatalogsWithRay:
         catalogs_dict = {"catalog1": catalog1, "catalog2": catalog2}
         init(
             catalogs_dict,
-            ray_init_args={"namespace": isolated_ray_env, "ignore_reinit_error": True},
+            ray_init_args={"ignore_reinit_error": True},
             **{"force_reinitialize": True},
         )
 
-        assert is_initialized(**{"namespace": isolated_ray_env})
+        assert is_initialized()
 
         # Get catalogs by name and check they're the same ones we initialized with
-        retrieved_catalog1 = get_catalog("catalog1", **{"namespace": isolated_ray_env})
+        retrieved_catalog1 = get_catalog("catalog1")
         assert retrieved_catalog1.impl == MockCatalogImpl
         assert retrieved_catalog1.inner["kwargs"]["id"] == 1
 
-        retrieved_catalog2 = get_catalog("catalog2", **{"namespace": isolated_ray_env})
+        retrieved_catalog2 = get_catalog("catalog2")
         assert retrieved_catalog2.impl == MockCatalogImpl
         assert retrieved_catalog2.inner["kwargs"]["id"] == 2
 
-    def test_init_with_default_catalog_name(self, isolated_ray_env):
+    def test_init_with_default_catalog_name(self, reset_catalogs_ray_actor):
         """Test initializing with a specified default catalog name."""
         # Create catalogs
         catalog1 = Catalog(impl=MockCatalogImpl, id=1)
@@ -157,139 +169,85 @@ class TestCatalogsWithRay:
         init(
             catalogs_dict,
             default_catalog_name="catalog2",
-            ray_init_args={"namespace": isolated_ray_env, "ignore_reinit_error": True},
+            ray_init_args={"ignore_reinit_error": True},
             **{"force_reinitialize": True},
         )
 
         # Get the default catalog and check it's catalog2
-        default_catalog = get_catalog(**{"namespace": isolated_ray_env})
+        default_catalog = get_catalog()
         assert default_catalog.impl == MockCatalogImpl
         assert default_catalog.inner["kwargs"]["id"] == 2
 
-    def test_put_catalog(self, isolated_ray_env):
+    def test_put_catalog(self, reset_catalogs_ray_actor):
         """Test adding a catalog after initialization."""
         # Initialize with a single catalog
         catalog1 = Catalog(impl=MockCatalogImpl, id=1)
         init(
             {"catalog1": catalog1},
-            ray_init_args={"namespace": isolated_ray_env, "ignore_reinit_error": True},
+            ray_init_args={"ignore_reinit_error": True},
             **{"force_reinitialize": True},
         )
 
         # Add a second catalog
         put_catalog(
-            "catalog2", impl=MockCatalogImpl, id=2, **{"namespace": isolated_ray_env}
-        )
+            "catalog2", impl=MockCatalogImpl, id=2)
 
         # Check both catalogs are available
-        retrieved_catalog1 = get_catalog("catalog1", **{"namespace": isolated_ray_env})
+        retrieved_catalog1 = get_catalog("catalog1")
         assert retrieved_catalog1.inner["kwargs"]["id"] == 1
 
-        retrieved_catalog2 = get_catalog("catalog2", **{"namespace": isolated_ray_env})
+        retrieved_catalog2 = get_catalog("catalog2")
         assert retrieved_catalog2.inner["kwargs"]["id"] == 2
 
-    def test_put_catalog_that_already_exists(self, isolated_ray_env):
-        """Test that trying to add a catalog with a name that already exists raises an error."""
-        # Initialize with a catalog
-        catalog = Catalog(impl=MockCatalogImpl, id=1)
-        init(
-            {"test_catalog": catalog},
-            ray_init_args={"namespace": isolated_ray_env, "ignore_reinit_error": True},
-            **{"force_reinitialize": True},
+    def test_put_catalog_that_already_exists(self, reset_catalogs_ray_actor):
+        put_catalog(
+            "test_catalog",
+            impl=MockCatalogImpl,
+            id=1,
+            ray_init_args={"ignore_reinit_error": True}
         )
 
-        # Try to add another catalog with the same name
-        with pytest.raises(ValueError, match="Catalog test_catalog already exists."):
-            put_catalog(
-                "test_catalog",
-                impl=MockCatalogImpl,
-                id=2,
-                **{"namespace": isolated_ray_env},
-            )
+        # Try to add another catalog with the same name. Should not error
+        put_catalog(
+            "test_catalog",
+            impl=MockCatalogImpl,
+            id=2,
+            ray_init_args={"ignore_reinit_error": True}
+        )
 
-    def test_get_catalog_nonexistent(self, isolated_ray_env):
+        retrieved_catalog = get_catalog("test_catalog")
+        assert retrieved_catalog.inner["kwargs"]["id"] == 2
+
+    def test_get_catalog_nonexistent(self, reset_catalogs_ray_actor):
         """Test that trying to get a nonexistent catalog raises an error."""
         # Initialize with a catalog
         catalog = Catalog(impl=MockCatalogImpl)
         init(
             {"test_catalog": catalog},
-            ray_init_args={"namespace": isolated_ray_env, "ignore_reinit_error": True},
+            ray_init_args={"ignore_reinit_error": True},
             **{"force_reinitialize": True},
         )
 
         # Try to get a nonexistent catalog
-        with pytest.raises(KeyError, match="Catalog 'nonexistent' not found"):
-            get_catalog("nonexistent", **{"namespace": isolated_ray_env})
+        with pytest.raises(ValueError):
+            get_catalog("nonexistent")
 
-    def test_get_catalog_no_default(self, isolated_ray_env):
+    def test_get_catalog_no_default(self, reset_catalogs_ray_actor):
         """Test that trying to get the default catalog when none is set raises an error."""
         # Initialize with multiple catalogs but no default
         catalog1 = Catalog(impl=MockCatalogImpl, id=1)
         catalog2 = Catalog(impl=MockCatalogImpl, id=2)
         init(
             {"catalog1": catalog1, "catalog2": catalog2},
-            ray_init_args={"namespace": isolated_ray_env, "ignore_reinit_error": True},
+            ray_init_args={"ignore_reinit_error": True},
             **{"force_reinitialize": True},
         )
 
         # Try to get the default catalog
-        with pytest.raises(KeyError):
-            get_catalog(**{"namespace": isolated_ray_env})
+        with pytest.raises(ValueError):
+            get_catalog()
 
-
-class TestIcebergCatalogIntegration:
-    """Integration tests for Iceberg catalog functionality."""
-
-    temp_dir = None
-
-    @classmethod
-    def setup_class(cls):
-        cls.temp_dir = tempfile.mkdtemp()
-
-    @classmethod
-    def teardown_class(cls):
-        if cls.temp_dir and os.path.exists(cls.temp_dir):
-            shutil.rmtree(cls.temp_dir)
-
-    def test_iceberg_catalog_initialization(self, isolated_ray_env):
-        """Test that an Iceberg catalog can be initialized and accessed."""
-        catalog_name = str(uuid.uuid4())
-
-        # Create the Iceberg catalog config
-        config = IcebergCatalogConfig(
-            type=CatalogType.IN_MEMORY, properties={"warehouse": self.temp_dir}
-        )
-
-        # Create the catalog using the factory method
-        catalog = Catalog.iceberg(config)
-
-        # Initialize DeltaCAT with this catalog
-        init(
-            {catalog_name: catalog},
-            ray_init_args={"namespace": isolated_ray_env, "ignore_reinit_error": True},
-        )
-
-        # Retrieve the catalog and verify it's the same one
-        retrieved_catalog = get_catalog(catalog_name, **{"namespace": isolated_ray_env})
-        assert retrieved_catalog.impl.__name__ == "deltacat.catalog.iceberg.impl"
-        assert isinstance(retrieved_catalog.inner, IcebergCatalog)
-
-
-class TestDefaultCatalogIntegration:
-    """Integration tests for Default catalog functionality."""
-
-    temp_dir = None
-
-    @classmethod
-    def setup_class(cls):
-        cls.temp_dir = tempfile.mkdtemp()
-
-    @classmethod
-    def teardown_class(cls):
-        if cls.temp_dir and os.path.exists(cls.temp_dir):
-            shutil.rmtree(cls.temp_dir)
-
-    def test_default_catalog_initialization(self, isolated_ray_env):
+    def test_default_catalog_initialization(self, reset_catalogs_ray_actor):
         """Test that a Default catalog can be initialized and accessed using the factory method."""
         from deltacat.catalog.model.properties import CatalogProperties
 
@@ -304,30 +262,47 @@ class TestDefaultCatalogIntegration:
         # Initialize DeltaCAT with this catalog
         init(
             {catalog_name: catalog},
-            ray_init_args={"namespace": isolated_ray_env, "ignore_reinit_error": True},
+            ray_init_args={"ignore_reinit_error": True},
             **{"force_reinitialize": True},
         )
 
         # Retrieve the catalog and verify it's the same one
-        retrieved_catalog = get_catalog(catalog_name, **{"namespace": isolated_ray_env})
+        retrieved_catalog = get_catalog(catalog_name)
         assert retrieved_catalog.impl.__name__ == "deltacat.catalog.main.impl"
         assert isinstance(retrieved_catalog.inner, CatalogProperties)
         assert retrieved_catalog.inner.root == self.temp_dir
 
-    def test_default_catalog_initialization_from_kwargs(self, isolated_ray_env):
+    def test_default_catalog_initialization_from_kwargs(self, reset_catalogs_ray_actor):
 
         catalog_name = str(uuid.uuid4())
         # Initialize DeltaCAT with this catalog
         from deltacat.catalog.main import impl as DeltacatCatalog
 
-        init(
-            {catalog_name: Catalog(DeltacatCatalog, **{"root": "test_root"})},
-            ray_init_args={"namespace": isolated_ray_env, "ignore_reinit_error": True},
-            **{"force_reinitialization": True},
-        )
+        put_catalog(catalog_name,
+                    Catalog(DeltacatCatalog, **{"root": "test_root"}),
+                    ray_init_args={"ignore_reinit_error": True})
 
         # Retrieve the catalog and verify it's the same one
-        retrieved_catalog = get_catalog(catalog_name, **{"namespace": isolated_ray_env})
+        retrieved_catalog = get_catalog(catalog_name)
         assert retrieved_catalog.impl.__name__ == "deltacat.catalog.main.impl"
         assert isinstance(retrieved_catalog.inner, CatalogProperties)
         assert retrieved_catalog.inner.root == "test_root"
+
+    def test_iceberg_catalog_initialization(self, reset_catalogs_ray_actor):
+        """Test that an Iceberg catalog can be initialized and accessed."""
+        catalog_name = str(uuid.uuid4())
+
+        # Create the Iceberg catalog config
+        config = IcebergCatalogConfig(
+            type=CatalogType.IN_MEMORY, properties={"warehouse": self.temp_dir}
+        )
+
+        # Create the catalog using the factory method
+        catalog = Catalog.iceberg(config)
+
+        put_catalog(catalog_name, catalog, ray_init_args={"ignore_reinit_error": True})
+
+        # Retrieve the catalog and verify it's the same one
+        retrieved_catalog = get_catalog(catalog_name)
+        assert retrieved_catalog.impl.__name__ == "deltacat.catalog.iceberg.impl"
+        assert isinstance(retrieved_catalog.inner, IcebergCatalog)

--- a/deltacat/tests/catalog/test_catalogs.py
+++ b/deltacat/tests/catalog/test_catalogs.py
@@ -29,6 +29,7 @@ class MockCatalogImpl:
         # Return some state that the catalog would normally maintain
         return {"initialized": True, "args": args, "kwargs": kwargs}
 
+
 @pytest.fixture(scope="function")
 def reset_catalogs_ray_actor():
     """
@@ -94,6 +95,7 @@ class TestCatalog(unittest.TestCase):
             # Check that the inner state is set to the output of initialize
             self.assertEqual(catalog.inner, {"iceberg": True})
 
+
 class TestCatalogsIntegration:
     """Integration tests for Default catalog functionality."""
 
@@ -105,7 +107,8 @@ class TestCatalogsIntegration:
         # Other tests are going to have initialized ray catalog. Initialize here to ensure
         # that when this test class is run individuall it mimicks running with other tests
         catalog = Catalog(impl=MockCatalogImpl)
-        init(catalog,
+        init(
+            catalog,
             ray_init_args={"ignore_reinit_error": True},
             **{"force_reinitialize": True},
         )
@@ -121,7 +124,8 @@ class TestCatalogsIntegration:
         catalog = Catalog(impl=MockCatalogImpl)
 
         # Initialize with a single catalog and Ray init args including the namespace
-        init(catalog,
+        init(
+            catalog,
             ray_init_args={"ignore_reinit_error": True},
             **{"force_reinitialize": True},
         )
@@ -189,8 +193,7 @@ class TestCatalogsIntegration:
         )
 
         # Add a second catalog
-        put_catalog(
-            "catalog2", impl=MockCatalogImpl, id=2)
+        put_catalog("catalog2", impl=MockCatalogImpl, id=2)
 
         # Check both catalogs are available
         retrieved_catalog1 = get_catalog("catalog1")
@@ -204,7 +207,7 @@ class TestCatalogsIntegration:
             "test_catalog",
             impl=MockCatalogImpl,
             id=1,
-            ray_init_args={"ignore_reinit_error": True}
+            ray_init_args={"ignore_reinit_error": True},
         )
 
         # Try to add another catalog with the same name. Should not error
@@ -212,7 +215,7 @@ class TestCatalogsIntegration:
             "test_catalog",
             impl=MockCatalogImpl,
             id=2,
-            ray_init_args={"ignore_reinit_error": True}
+            ray_init_args={"ignore_reinit_error": True},
         )
 
         retrieved_catalog = get_catalog("test_catalog")
@@ -278,9 +281,11 @@ class TestCatalogsIntegration:
         # Initialize DeltaCAT with this catalog
         from deltacat.catalog.main import impl as DeltacatCatalog
 
-        put_catalog(catalog_name,
-                    Catalog(DeltacatCatalog, **{"root": "test_root"}),
-                    ray_init_args={"ignore_reinit_error": True})
+        put_catalog(
+            catalog_name,
+            Catalog(DeltacatCatalog, **{"root": "test_root"}),
+            ray_init_args={"ignore_reinit_error": True},
+        )
 
         # Retrieve the catalog and verify it's the same one
         retrieved_catalog = get_catalog(catalog_name)

--- a/deltacat/tests/compute/compactor/utils/test_io.py
+++ b/deltacat/tests/compute/compactor/utils/test_io.py
@@ -1,8 +1,12 @@
 import unittest
 from unittest import mock
 
-from compute.conftest import create_local_deltacat_storage_file, clean_up_local_deltacat_storage_file
+from compute.conftest import (
+    create_local_deltacat_storage_file,
+    clean_up_local_deltacat_storage_file,
+)
 from deltacat.tests.test_utils.constants import TEST_UPSERT_DELTA
+
 
 class TestFitInputDeltas(unittest.TestCase):
     @classmethod

--- a/deltacat/tests/compute/compactor/utils/test_io.py
+++ b/deltacat/tests/compute/compactor/utils/test_io.py
@@ -1,8 +1,8 @@
 import unittest
 from unittest import mock
-from deltacat.tests.test_utils.constants import TEST_UPSERT_DELTA
-from typing import Any, Dict
 
+from compute.conftest import create_local_deltacat_storage_file, clean_up_local_deltacat_storage_file
+from deltacat.tests.test_utils.constants import TEST_UPSERT_DELTA
 
 class TestFitInputDeltas(unittest.TestCase):
     @classmethod
@@ -14,9 +14,7 @@ class TestFitInputDeltas(unittest.TestCase):
             CompactionSessionAuditInfo,
         )
 
-        cls.kwargs_for_local_deltacat_storage: Dict[str, Any] = {
-            DATABASE_FILE_PATH_KEY: DATABASE_FILE_PATH_VALUE,
-        }
+        cls.kwargs_for_local_deltacat_storage = create_local_deltacat_storage_file()
 
         cls.COMPACTION_AUDIT = CompactionSessionAuditInfo("1.0", "2.3", "test")
 
@@ -25,6 +23,7 @@ class TestFitInputDeltas(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         cls.module_patcher.stop()
+        clean_up_local_deltacat_storage_file(cls.kwargs_for_local_deltacat_storage)
 
     def test_sanity(self):
         from deltacat.compute.compactor.utils import io

--- a/deltacat/tests/compute/compactor/utils/test_io.py
+++ b/deltacat/tests/compute/compactor/utils/test_io.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 
-from compute.conftest import (
+from deltacat.tests.compute.conftest import (
     create_local_deltacat_storage_file,
     clean_up_local_deltacat_storage_file,
 )

--- a/deltacat/tests/compute/compactor/utils/test_io.py
+++ b/deltacat/tests/compute/compactor/utils/test_io.py
@@ -3,11 +3,6 @@ from unittest import mock
 from deltacat.tests.test_utils.constants import TEST_UPSERT_DELTA
 from typing import Any, Dict
 
-DATABASE_FILE_PATH_KEY, DATABASE_FILE_PATH_VALUE = (
-    "db_file_path",
-    "deltacat/tests/local_deltacat_storage/db_test.sqlite",
-)
-
 
 class TestFitInputDeltas(unittest.TestCase):
     @classmethod

--- a/deltacat/tests/compute/compactor_v2/deletes/test_delete_utils.py
+++ b/deltacat/tests/compute/compactor_v2/deletes/test_delete_utils.py
@@ -20,13 +20,13 @@ from deltacat.tests.compute.test_util_common import (
 
 from dataclasses import dataclass, fields
 import ray
-import os
 from typing import Any, Dict, List, Optional, Tuple
 import deltacat.tests.local_deltacat_storage as ds
 from deltacat.compute.compactor.model.compact_partition_params import (
     CompactPartitionParams,
 )
 import pyarrow as pa
+
 
 @dataclass(frozen=True)
 class PrepareDeleteTestCaseParams:

--- a/deltacat/tests/compute/compactor_v2/deletes/test_delete_utils.py
+++ b/deltacat/tests/compute/compactor_v2/deletes/test_delete_utils.py
@@ -28,12 +28,6 @@ from deltacat.compute.compactor.model.compact_partition_params import (
 )
 import pyarrow as pa
 
-DATABASE_FILE_PATH_KEY, DATABASE_FILE_PATH_VALUE = (
-    "db_file_path",
-    "deltacat/tests/local_deltacat_storage/db_test.sqlite",
-)
-
-
 @dataclass(frozen=True)
 class PrepareDeleteTestCaseParams:
     """
@@ -56,17 +50,6 @@ def setup_ray_cluster():
     ray.init(local_mode=True, ignore_reinit_error=True)
     yield
     ray.shutdown()
-
-
-@pytest.fixture(scope="function")
-def local_deltacat_storage_kwargs(request: pytest.FixtureRequest):
-    # see deltacat/tests/local_deltacat_storage/README.md for documentation
-    kwargs_for_local_deltacat_storage: Dict[str, Any] = {
-        DATABASE_FILE_PATH_KEY: DATABASE_FILE_PATH_VALUE,
-    }
-    yield kwargs_for_local_deltacat_storage
-    if os.path.exists(DATABASE_FILE_PATH_VALUE):
-        os.remove(DATABASE_FILE_PATH_VALUE)
 
 
 TEST_CASES_PREPARE_DELETE = {

--- a/deltacat/tests/compute/compactor_v2/test_compaction_session.py
+++ b/deltacat/tests/compute/compactor_v2/test_compaction_session.py
@@ -28,11 +28,6 @@ from deltacat.tests.test_utils.pyarrow import (
 )
 from moto import mock_s3
 
-DATABASE_FILE_PATH_KEY, DATABASE_FILE_PATH_VALUE = (
-    "db_file_path",
-    "deltacat/tests/local_deltacat_storage/db_test.sqlite",
-)
-
 
 @pytest.fixture(autouse=True, scope="module")
 def setup_ray_cluster():
@@ -64,16 +59,6 @@ def setup_compaction_artifacts_s3_bucket(s3_resource: ServiceResource):
         Bucket=TEST_S3_RCF_BUCKET_NAME,
     )
     yield
-
-
-@pytest.fixture(scope="function")
-def local_deltacat_storage_kwargs(request: pytest.FixtureRequest):
-    kwargs_for_local_deltacat_storage: Dict[str, Any] = {
-        DATABASE_FILE_PATH_KEY: DATABASE_FILE_PATH_VALUE,
-    }
-    yield kwargs_for_local_deltacat_storage
-    if os.path.exists(DATABASE_FILE_PATH_VALUE):
-        os.remove(DATABASE_FILE_PATH_VALUE)
 
 
 class TestCompactionSession:

--- a/deltacat/tests/compute/compactor_v2/test_compaction_session.py
+++ b/deltacat/tests/compute/compactor_v2/test_compaction_session.py
@@ -1,4 +1,3 @@
-from typing import Dict, Any
 import ray
 import os
 import pytest

--- a/deltacat/tests/compute/conftest.py
+++ b/deltacat/tests/compute/conftest.py
@@ -29,20 +29,21 @@ def local_deltacat_storage_kwargs(temp_dir):
     """
     Fixture that creates a temporary database file for each test function
     and returns storage kwargs dictionary.
-    
+
     Returns:
         dict: A dictionary with db_file_path key pointing to a temporary database file
     """
     # Create a unique database file in the temporary directory
     db_file_path = os.path.join(temp_dir, "db_test.sqlite")
-    
+
     # Return kwargs dictionary ready to use
     kwargs = {"db_file_path": db_file_path}
     yield kwargs
-    
+
     # Cleanup: remove the database file if it exists
     if os.path.exists(db_file_path):
         os.remove(db_file_path)
+
 
 def create_local_deltacat_storage_file() -> Dict[str, str]:
     """
@@ -72,5 +73,3 @@ def clean_up_local_deltacat_storage_file(local_storage_kwargs: Dict[str, str]):
     # Remove the temporary directory if it exists
     if os.path.exists(dir_path):
         shutil.rmtree(dir_path)
-
-

--- a/deltacat/tests/compute/conftest.py
+++ b/deltacat/tests/compute/conftest.py
@@ -1,0 +1,43 @@
+import os
+import tempfile
+import shutil
+import pytest
+
+
+@pytest.fixture
+def temp_dir():
+    """
+    Fixture that creates a temporary directory for tests and cleans it up afterwards.
+
+    Returns:
+        str: Path to the temporary directory
+    """
+    # Create a temporary directory
+    dir_path = tempfile.mkdtemp()
+
+    # Provide the directory path to the test
+    yield dir_path
+
+    # Cleanup: remove the directory after the test is done
+    shutil.rmtree(dir_path)
+
+
+@pytest.fixture(scope="function")
+def local_deltacat_storage_kwargs(temp_dir):
+    """
+    Fixture that creates a temporary database file for each test function
+    and returns storage kwargs dictionary.
+    
+    Returns:
+        dict: A dictionary with db_file_path key pointing to a temporary database file
+    """
+    # Create a unique database file in the temporary directory
+    db_file_path = os.path.join(temp_dir, "db_test.sqlite")
+    
+    # Return kwargs dictionary ready to use
+    kwargs = {"db_file_path": db_file_path}
+    yield kwargs
+    
+    # Cleanup: remove the database file if it exists
+    if os.path.exists(db_file_path):
+        os.remove(db_file_path)

--- a/deltacat/tests/compute/conftest.py
+++ b/deltacat/tests/compute/conftest.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 import shutil
+from typing import Dict
+
 import pytest
 
 
@@ -41,3 +43,34 @@ def local_deltacat_storage_kwargs(temp_dir):
     # Cleanup: remove the database file if it exists
     if os.path.exists(db_file_path):
         os.remove(db_file_path)
+
+def create_local_deltacat_storage_file() -> Dict[str, str]:
+    """
+    Helper function to create a local deltacat storage file
+
+    Essentially uses the same approach as local_deltacat_storage_kwargs, but more flexible
+    if the consumer does not want to use a function scoped fixture
+
+    Returns: kwargs to use for local deltacat storage, i.e. {"db_file_path": $db_file}
+    """
+    temp_dir = tempfile.mkdtemp()
+    db_file_path = os.path.join(temp_dir, "db_test.sqlite")
+    return {"db_file_path": db_file_path}
+
+
+def clean_up_local_deltacat_storage_file(local_storage_kwargs: Dict[str, str]):
+    """
+    Cleans up local file and directory created by create_local_deltacat_storage_file
+    """
+    db_file = local_storage_kwargs["db_file_path"]
+    dir_path = os.path.dirname(db_file)
+
+    # Remove the database file if it exists
+    if os.path.exists(db_file):
+        os.remove(db_file)
+
+    # Remove the temporary directory if it exists
+    if os.path.exists(dir_path):
+        shutil.rmtree(dir_path)
+
+

--- a/deltacat/tests/compute/resource_estimation/test_delta.py
+++ b/deltacat/tests/compute/resource_estimation/test_delta.py
@@ -22,21 +22,6 @@ Function scoped fixtures
 
 
 @pytest.fixture(scope="function")
-def local_deltacat_storage_kwargs():
-    DATABASE_FILE_PATH_KEY, DATABASE_FILE_PATH_VALUE = (
-        "db_file_path",
-        "deltacat/tests/local_deltacat_storage/db_test.sqlite",
-    )
-    # see deltacat/tests/local_deltacat_storage/README.md for documentation
-    kwargs_for_local_deltacat_storage = {
-        DATABASE_FILE_PATH_KEY: DATABASE_FILE_PATH_VALUE,
-    }
-    yield kwargs_for_local_deltacat_storage
-    if os.path.exists(DATABASE_FILE_PATH_VALUE):
-        os.remove(DATABASE_FILE_PATH_VALUE)
-
-
-@pytest.fixture(scope="function")
 def parquet_delta_with_manifest(local_deltacat_storage_kwargs):
     """
     These fixtures are function scoped as functions can modify the delta.

--- a/deltacat/tests/compute/resource_estimation/test_delta.py
+++ b/deltacat/tests/compute/resource_estimation/test_delta.py
@@ -1,6 +1,5 @@
 import deltacat.tests.local_deltacat_storage as ds
 from deltacat.types.media import ContentType
-import os
 import pytest
 from deltacat.storage import Delta
 from deltacat.compute.resource_estimation.delta import (

--- a/deltacat/tests/compute/test_compact_partition_incremental.py
+++ b/deltacat/tests/compute/test_compact_partition_incremental.py
@@ -94,6 +94,7 @@ def setup_compaction_artifacts_s3_bucket(s3_resource: ServiceResource):
 FUNCTION scoped fixtures
 """
 
+
 @pytest.mark.parametrize(
     [
         "test_name",

--- a/deltacat/tests/compute/test_compact_partition_multiple_rounds.py
+++ b/deltacat/tests/compute/test_compact_partition_multiple_rounds.py
@@ -48,12 +48,6 @@ from deltacat.utils.placement import (
     PlacementGroupManager,
 )
 
-DATABASE_FILE_PATH_KEY, DATABASE_FILE_PATH_VALUE = (
-    "db_file_path",
-    "deltacat/tests/local_deltacat_storage/db_test.sqlite",
-)
-
-
 """
 MODULE scoped fixtures
 """
@@ -76,13 +70,6 @@ def mock_aws_credential():
     yield
 
 
-@pytest.fixture(autouse=True, scope="module")
-def cleanup_the_database_file_after_all_compaction_session_package_tests_complete():
-    # make sure the database file is deleted after all the compactor package tests are completed
-    if os.path.exists(DATABASE_FILE_PATH_VALUE):
-        os.remove(DATABASE_FILE_PATH_VALUE)
-
-
 @pytest.fixture(scope="module")
 def s3_resource(mock_aws_credential):
     with mock_s3():
@@ -96,22 +83,6 @@ def setup_compaction_artifacts_s3_bucket(s3_resource: ServiceResource):
         Bucket=TEST_S3_RCF_BUCKET_NAME,
     )
     yield
-
-
-"""
-FUNCTION scoped fixtures
-"""
-
-
-@pytest.fixture(scope="function")
-def local_deltacat_storage_kwargs(request: pytest.FixtureRequest):
-    # see deltacat/tests/local_deltacat_storage/README.md for documentation
-    kwargs_for_local_deltacat_storage: Dict[str, Any] = {
-        DATABASE_FILE_PATH_KEY: DATABASE_FILE_PATH_VALUE,
-    }
-    yield kwargs_for_local_deltacat_storage
-    if os.path.exists(DATABASE_FILE_PATH_VALUE):
-        os.remove(DATABASE_FILE_PATH_VALUE)
 
 
 @pytest.mark.parametrize(

--- a/deltacat/tests/compute/test_compact_partition_rebase.py
+++ b/deltacat/tests/compute/test_compact_partition_rebase.py
@@ -48,12 +48,6 @@ from deltacat.utils.placement import (
     PlacementGroupManager,
 )
 
-DATABASE_FILE_PATH_KEY, DATABASE_FILE_PATH_VALUE = (
-    "db_file_path",
-    "deltacat/tests/local_deltacat_storage/db_test.sqlite",
-)
-
-
 """
 MODULE scoped fixtures
 """
@@ -76,13 +70,6 @@ def mock_aws_credential():
     yield
 
 
-@pytest.fixture(autouse=True, scope="module")
-def cleanup_the_database_file_after_all_compaction_session_package_tests_complete():
-    # make sure the database file is deleted after all the compactor package tests are completed
-    if os.path.exists(DATABASE_FILE_PATH_VALUE):
-        os.remove(DATABASE_FILE_PATH_VALUE)
-
-
 @pytest.fixture(scope="module")
 def s3_resource(mock_aws_credential):
     with mock_s3():
@@ -96,22 +83,6 @@ def setup_compaction_artifacts_s3_bucket(s3_resource: ServiceResource):
         Bucket=TEST_S3_RCF_BUCKET_NAME,
     )
     yield
-
-
-"""
-FUNCTION scoped fixtures
-"""
-
-
-@pytest.fixture(scope="function")
-def local_deltacat_storage_kwargs(request: pytest.FixtureRequest):
-    # see deltacat/tests/local_deltacat_storage/README.md for documentation
-    kwargs_for_local_deltacat_storage: Dict[str, Any] = {
-        DATABASE_FILE_PATH_KEY: DATABASE_FILE_PATH_VALUE,
-    }
-    yield kwargs_for_local_deltacat_storage
-    if os.path.exists(DATABASE_FILE_PATH_VALUE):
-        os.remove(DATABASE_FILE_PATH_VALUE)
 
 
 @pytest.mark.parametrize(

--- a/deltacat/tests/compute/test_compact_partition_rebase_then_incremental.py
+++ b/deltacat/tests/compute/test_compact_partition_rebase_then_incremental.py
@@ -52,12 +52,6 @@ from deltacat.compute.compactor.model.compaction_session_audit_info import (
     CompactionSessionAuditInfo,
 )
 
-DATABASE_FILE_PATH_KEY, DATABASE_FILE_PATH_VALUE = (
-    "db_file_path",
-    "deltacat/tests/local_deltacat_storage/db_test.sqlite",
-)
-
-
 """
 MODULE scoped fixtures
 """
@@ -80,13 +74,6 @@ def mock_aws_credential():
     yield
 
 
-@pytest.fixture(autouse=True, scope="module")
-def cleanup_the_database_file_after_all_compaction_session_package_tests_complete():
-    # make sure the database file is deleted after all the compactor package tests are completed
-    if os.path.exists(DATABASE_FILE_PATH_VALUE):
-        os.remove(DATABASE_FILE_PATH_VALUE)
-
-
 @pytest.fixture(scope="module")
 def s3_resource(mock_aws_credential):
     with mock_s3():
@@ -100,22 +87,6 @@ def setup_compaction_artifacts_s3_bucket(s3_resource: ServiceResource):
         Bucket=TEST_S3_RCF_BUCKET_NAME,
     )
     yield
-
-
-"""
-FUNCTION scoped fixtures
-"""
-
-
-@pytest.fixture(scope="function")
-def local_deltacat_storage_kwargs(request: pytest.FixtureRequest):
-    # see deltacat/tests/local_deltacat_storage/README.md for documentation
-    kwargs_for_local_deltacat_storage: Dict[str, Any] = {
-        DATABASE_FILE_PATH_KEY: DATABASE_FILE_PATH_VALUE,
-    }
-    yield kwargs_for_local_deltacat_storage
-    if os.path.exists(DATABASE_FILE_PATH_VALUE):
-        os.remove(DATABASE_FILE_PATH_VALUE)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Follow on from PR https://github.com/ray-project/deltacat/pull/517

Remove Namespace support in Catalogs. Also refactor compute tests to use a sqlite DB in a temporary directory, since the tests were not properly cleaning up the sqlite file that previously used the test directory