### PR TITLE
[Converter] Add location provider override to allow customized file location; Override reserved columns stats populating logic

### DIFF
--- a/deltacat/compute/converter/constants.py
+++ b/deltacat/compute/converter/constants.py
@@ -2,3 +2,5 @@ DEFAULT_CONVERTER_TASK_MAX_PARALLELISM = 4096
 
 # Safe limit ONLY considering CPU limit, typically 32 for a 8x-large worker
 DEFAULT_MAX_PARALLEL_DATA_FILE_DOWNLOAD = 30
+
+DEFAULT_ICEBERG_NAMESPACE = "default"

--- a/deltacat/compute/converter/model/convert_input.py
+++ b/deltacat/compute/converter/model/convert_input.py
@@ -15,6 +15,7 @@ class ConvertInput(Dict):
         position_delete_for_multiple_data_files,
         max_parallel_data_file_download,
         s3_file_system,
+        s3_client_kwargs,
     ) -> ConvertInput:
 
         result = ConvertInput()
@@ -29,6 +30,7 @@ class ConvertInput(Dict):
         ] = position_delete_for_multiple_data_files
         result["max_parallel_data_file_download"] = max_parallel_data_file_download
         result["s3_file_system"] = s3_file_system
+        result["s3_client_kwargs"] = s3_client_kwargs
 
         return result
 
@@ -67,3 +69,7 @@ class ConvertInput(Dict):
     @property
     def s3_file_system(self):
         return self["s3_file_system"]
+
+    @property
+    def s3_client_kwargs(self):
+        return self["s3_client_kwargs"]

--- a/deltacat/compute/converter/model/converter_session_params.py
+++ b/deltacat/compute/converter/model/converter_session_params.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 from typing import Optional, Dict
-from deltacat.compute.converter.constants import DEFAULT_CONVERTER_TASK_MAX_PARALLELISM
+from deltacat.compute.converter.constants import (
+    DEFAULT_CONVERTER_TASK_MAX_PARALLELISM,
+    DEFAULT_ICEBERG_NAMESPACE,
+)
+from fsspec import AbstractFileSystem
 
 
 class ConverterSessionParams(dict):
@@ -18,11 +22,11 @@ class ConverterSessionParams(dict):
         assert (
             params.get("iceberg_warehouse_bucket_name") is not None
         ), "iceberg_warehouse_bucket_name is a required arg"
-        assert (
-            params.get("iceberg_namespace") is not None
-        ), "iceberg_namespace is a required arg"
         result = ConverterSessionParams(params)
 
+        result.iceberg_namespace = params.get(
+            "iceberg_namespace", DEFAULT_ICEBERG_NAMESPACE
+        )
         result.enforce_primary_key_uniqueness = params.get(
             "enforce_primary_key_uniqueness", False
         )
@@ -36,6 +40,10 @@ class ConverterSessionParams(dict):
             "task_max_parallelism", DEFAULT_CONVERTER_TASK_MAX_PARALLELISM
         )
         result.merge_keys = params.get("merge_keys", None)
+        result.s3_client_kwargs = params.get("s3_client_kwargs", {})
+        result.s3_file_system = params.get("s3_file_system", None)
+        result.s3_prefix_override = params.get("s3_prefix_override", None)
+
         return result
 
     @property
@@ -53,6 +61,10 @@ class ConverterSessionParams(dict):
     @property
     def iceberg_namespace(self) -> str:
         return self["iceberg_namespace"]
+
+    @iceberg_namespace.setter
+    def iceberg_namespace(self, iceberg_namespace) -> None:
+        self["iceberg_namespace"] = iceberg_namespace
 
     @property
     def enforce_primary_key_uniqueness(self) -> bool:
@@ -97,3 +109,29 @@ class ConverterSessionParams(dict):
     @merge_keys.setter
     def merge_keys(self, merge_keys) -> None:
         self["merge_keys"] = merge_keys
+
+    @property
+    def s3_client_kwargs(self) -> Dict:
+        return self["s3_client_kwargs"]
+
+    @s3_client_kwargs.setter
+    def s3_client_kwargs(self, s3_client_kwargs) -> None:
+        self["s3_client_kwargs"] = s3_client_kwargs
+
+    @property
+    def s3_file_system(self) -> AbstractFileSystem:
+        return self["s3_file_system"]
+
+    @s3_file_system.setter
+    def s3_file_system(self, s3_file_system) -> None:
+        self["s3_file_system"] = s3_file_system
+
+    @property
+    def location_provider_prefix_override(self) -> str:
+        return self["location_provider_prefix_override"]
+
+    @location_provider_prefix_override.setter
+    def location_provider_prefix_override(
+        self, location_provider_prefix_override
+    ) -> None:
+        self["location_provider_prefix_override"] = location_provider_prefix_override

--- a/deltacat/compute/converter/pyiceberg/overrides.py
+++ b/deltacat/compute/converter/pyiceberg/overrides.py
@@ -1,24 +1,165 @@
 from collections import defaultdict
 import logging
 from deltacat import logs
+import pyarrow
 import pyarrow.parquet as pq
+from pyiceberg.io.pyarrow import (
+    parquet_path_to_id_mapping,
+    StatisticsCollector,
+    MetricModeTypes,
+    DataFileStatistics,
+    MetricsMode,
+    StatsAggregator,
+)
+from typing import Dict, List, Set
+from deltacat.compute.converter.utils.iceberg_columns import (
+    ICEBERG_RESERVED_FIELD_ID_FOR_FILE_PATH_COLUMN,
+    ICEBERG_RESERVED_FIELD_ID_FOR_POS_COLUMN,
+)
+from pyiceberg.io.pyarrow import (
+    _check_pyarrow_schema_compatible,
+    compute_statistics_plan,
+)
+from pyiceberg.manifest import (
+    DataFile,
+    DataFileContent,
+    FileFormat,
+)
+from pyiceberg.expressions.visitors import _InclusiveMetricsEvaluator
+from pyiceberg.types import (
+    strtobool,
+)
+from pyiceberg.table import _min_sequence_number, _open_manifest
+from pyiceberg.utils.concurrent import ExecutorFactory
+from itertools import chain
+from pyiceberg.typedef import (
+    KeyDefaultDict,
+)
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
-def parquet_files_dict_to_iceberg_data_files(io, table_metadata, files_dict_list):
-    from pyiceberg.io.pyarrow import (
-        _check_pyarrow_schema_compatible,
-        data_file_statistics_from_parquet_metadata,
-        compute_statistics_plan,
-        parquet_path_to_id_mapping,
-    )
-    from pyiceberg.manifest import (
-        DataFile,
-        DataFileContent,
-        FileFormat,
+def parquet_path_to_id_mapping_override(schema):
+    res = parquet_path_to_id_mapping(schema)
+    # Override here to insert position delete reserved column field IDs
+    res["file_path"] = ICEBERG_RESERVED_FIELD_ID_FOR_FILE_PATH_COLUMN
+    res["pos"] = ICEBERG_RESERVED_FIELD_ID_FOR_POS_COLUMN
+    return res
+
+
+def data_file_statistics_from_parquet_metadata(
+    parquet_metadata: pq.FileMetaData,
+    stats_columns: Dict[int, StatisticsCollector],
+    parquet_column_mapping: Dict[str, int],
+) -> DataFileStatistics:
+    """
+    Overrides original Pyiceberg function: Compute and return DataFileStatistics that includes the following.
+
+    - record_count
+    - column_sizes
+    - value_counts
+    - null_value_counts
+    - nan_value_counts
+    - column_aggregates
+    - split_offsets
+
+    Args:
+        parquet_metadata (pyarrow.parquet.FileMetaData): A pyarrow metadata object.
+        stats_columns (Dict[int, StatisticsCollector]): The statistics gathering plan. It is required to
+            set the mode for column metrics collection
+        parquet_column_mapping (Dict[str, int]): The mapping of the parquet file name to the field ID
+    """
+    column_sizes: Dict[int, int] = {}
+    value_counts: Dict[int, int] = {}
+    split_offsets: List[int] = []
+
+    null_value_counts: Dict[int, int] = {}
+    nan_value_counts: Dict[int, int] = {}
+
+    col_aggs = {}
+
+    invalidate_col: Set[int] = set()
+    for r in range(parquet_metadata.num_row_groups):
+        # References:
+        # https://github.com/apache/iceberg/blob/fc381a81a1fdb8f51a0637ca27cd30673bd7aad3/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java#L232
+        # https://github.com/apache/parquet-mr/blob/ac29db4611f86a07cc6877b416aa4b183e09b353/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java#L184
+
+        row_group = parquet_metadata.row_group(r)
+
+        data_offset = row_group.column(0).data_page_offset
+        dictionary_offset = row_group.column(0).dictionary_page_offset
+
+        if row_group.column(0).has_dictionary_page and dictionary_offset < data_offset:
+            split_offsets.append(dictionary_offset)
+        else:
+            split_offsets.append(data_offset)
+
+        for pos in range(parquet_metadata.num_columns):
+            column = row_group.column(pos)
+            field_id = parquet_column_mapping[column.path_in_schema]
+            if field_id in stats_columns:
+                stats_col = stats_columns[field_id]
+
+                column_sizes.setdefault(field_id, 0)
+                column_sizes[field_id] += column.total_compressed_size
+
+                if stats_col.mode == MetricsMode(MetricModeTypes.NONE):
+                    continue
+
+                value_counts[field_id] = (
+                    value_counts.get(field_id, 0) + column.num_values
+                )
+
+                if column.is_stats_set:
+                    try:
+                        statistics = column.statistics
+
+                        if statistics.has_null_count:
+                            null_value_counts[field_id] = (
+                                null_value_counts.get(field_id, 0)
+                                + statistics.null_count
+                            )
+
+                        if stats_col.mode == MetricsMode(MetricModeTypes.COUNTS):
+                            continue
+
+                        if field_id not in col_aggs:
+                            col_aggs[field_id] = StatsAggregator(
+                                stats_col.iceberg_type,
+                                statistics.physical_type,
+                                stats_col.mode.length,
+                            )
+
+                        col_aggs[field_id].update_min(statistics.min)
+                        col_aggs[field_id].update_max(statistics.max)
+
+                    except pyarrow.lib.ArrowNotImplementedError as e:
+                        invalidate_col.add(field_id)
+                        logger.warning(e)
+            else:
+                # Note: Removed original adding columns without stats to invalid column logic here
+                logger.warning(
+                    "PyArrow statistics missing for column %d when writing file", pos
+                )
+
+    split_offsets.sort()
+
+    for field_id in invalidate_col:
+        del col_aggs[field_id]
+        del null_value_counts[field_id]
+
+    return DataFileStatistics(
+        record_count=parquet_metadata.num_rows,
+        column_sizes=column_sizes,
+        value_counts=value_counts,
+        null_value_counts=null_value_counts,
+        nan_value_counts=nan_value_counts,
+        column_aggregates=col_aggs,
+        split_offsets=split_offsets,
     )
 
+
+def parquet_files_dict_to_iceberg_data_files(io, table_metadata, files_dict_list):
     data_file_content_type = DataFileContent.POSITION_DELETES
     iceberg_files = []
     schema = table_metadata.schema()
@@ -37,7 +178,7 @@ def parquet_files_dict_to_iceberg_data_files(io, table_metadata, files_dict_list
                     stats_columns=compute_statistics_plan(
                         schema, table_metadata.properties
                     ),
-                    parquet_column_mapping=parquet_path_to_id_mapping(schema),
+                    parquet_column_mapping=parquet_path_to_id_mapping_override(schema),
                 )
 
                 data_file = DataFile(
@@ -45,7 +186,6 @@ def parquet_files_dict_to_iceberg_data_files(io, table_metadata, files_dict_list
                     file_path=file_path,
                     file_format=FileFormat.PARQUET,
                     partition=partition_value,
-                    # partition=Record(**{"pk": "111", "bucket": 2}),
                     file_size_in_bytes=len(input_file),
                     sort_order_id=None,
                     spec_id=table_metadata.default_spec_id,
@@ -60,9 +200,6 @@ def parquet_files_dict_to_iceberg_data_files(io, table_metadata, files_dict_list
 def fetch_all_bucket_files(table):
     # step 1: filter manifests using partition summaries
     # the filter depends on the partition spec used to write the manifest file, so create a cache of filters for each spec id
-    from pyiceberg.typedef import (
-        KeyDefaultDict,
-    )
 
     data_scan = table.scan()
     snapshot = data_scan.snapshot()
@@ -78,15 +215,6 @@ def fetch_all_bucket_files(table):
 
     # step 2: filter the data files in each manifest
     # this filter depends on the partition spec used to write the manifest file
-    from pyiceberg.expressions.visitors import _InclusiveMetricsEvaluator
-    from pyiceberg.types import (
-        strtobool,
-    )
-    from pyiceberg.table import _min_sequence_number, _open_manifest
-    from pyiceberg.utils.concurrent import ExecutorFactory
-    from itertools import chain
-    from pyiceberg.manifest import DataFileContent
-
     partition_evaluators = KeyDefaultDict(data_scan._build_partition_evaluator)
     metrics_evaluator = _InclusiveMetricsEvaluator(
         data_scan.table_metadata.schema(),

--- a/deltacat/compute/converter/steps/dedupe.py
+++ b/deltacat/compute/converter/steps/dedupe.py
@@ -11,6 +11,7 @@ def dedupe_data_files(
     identify_column_name_concatenated,
     identifier_columns,
     merge_sort_column,
+    s3_client_kwargs,
 ):
     data_file_table = []
 
@@ -27,6 +28,7 @@ def dedupe_data_files(
                 sc._ORDERED_RECORD_IDX_COLUMN_NAME,
             ],
             sequence_number=sequence_number,
+            s3_client_kwargs=s3_client_kwargs,
         )
         data_file_table.append(data_file_to_dedupe_table)
 

--- a/deltacat/compute/converter/utils/io.py
+++ b/deltacat/compute/converter/utils/io.py
@@ -1,13 +1,20 @@
 import deltacat.compute.converter.utils.iceberg_columns as sc
 import daft
+from deltacat.utils.daft import _get_s3_io_config
+from daft import TimeUnit
 
 
 def download_data_table_and_append_iceberg_columns(
-    file, columns_to_download, additional_columns_to_append, sequence_number
+    file,
+    columns_to_download,
+    additional_columns_to_append,
+    sequence_number,
+    s3_client_kwargs,
 ):
-    # TODO; add S3 client kwargs
     table = download_parquet_with_daft_hash_applied(
-        identify_columns=columns_to_download, file=file, s3_client_kwargs={}
+        identify_columns=columns_to_download,
+        file=file,
+        s3_client_kwargs=s3_client_kwargs,
     )
     if sc._FILE_PATH_COLUMN_NAME in additional_columns_to_append:
         table = sc.append_file_path_column(table, file.file_path)
@@ -20,7 +27,6 @@ def download_data_table_and_append_iceberg_columns(
 def download_parquet_with_daft_hash_applied(
     identify_columns, file, s3_client_kwargs, **kwargs
 ):
-    from daft import TimeUnit
 
     # TODO: Add correct read kwargs as in:
     #  https://github.com/ray-project/deltacat/blob/383855a4044e4dfe03cf36d7738359d512a517b4/deltacat/utils/daft.py#L97
@@ -28,8 +34,6 @@ def download_parquet_with_daft_hash_applied(
     coerce_int96_timestamp_unit = TimeUnit.from_str(
         kwargs.get("coerce_int96_timestamp_unit", "ms")
     )
-
-    from deltacat.utils.daft import _get_s3_io_config
 
     # TODO: Use Daft SHA1 hash instead to minimize probably of data corruption
     io_config = _get_s3_io_config(s3_client_kwargs=s3_client_kwargs)

--- a/deltacat/compute/converter/utils/s3u.py
+++ b/deltacat/compute/converter/utils/s3u.py
@@ -77,7 +77,7 @@ def upload_table_with_retry(
         s3_file_system = get_s3_file_system(content_type=content_type)
     capture_object = CapturedBlockWritePaths()
     block_write_path_provider = UuidBlockWritePathProvider(
-        capture_object=capture_object
+        capture_object=capture_object, base_path=s3_url_prefix
     )
     s3_table_writer_func = get_table_writer(table)
     table_record_count = get_table_length(table)

--- a/deltacat/tests/compute/converter/test_convert_session.py
+++ b/deltacat/tests/compute/converter/test_convert_session.py
@@ -249,6 +249,7 @@ def test_converter_drop_duplicates_success(
             position_delete_for_multiple_data_files=True,
             max_parallel_data_file_download=10,
             s3_file_system=s3_file_system,
+            s3_client_kwargs={},
         )
 
     number_partitioned_array_1 = pa.array([0, 0, 0], type=pa.int32())
@@ -418,6 +419,7 @@ def test_converter_pos_delete_read_by_spark_success(
             position_delete_for_multiple_data_files=True,
             max_parallel_data_file_download=10,
             s3_file_system=s3_file_system,
+            s3_client_kwargs={},
         )
 
     primary_key_array_1 = pa.array(["pk1", "pk2", "pk3"])


### PR DESCRIPTION
## Summary

This PR adds two additional features for customized converter job options, mainly:
1. File location override: Allow position delete produced to be written to customized location. 
Note this change does not directly override the Iceberg location provider implementation because currently DeltaCAT converter did not go through Iceberg write path. Instead, it rely on `UuidBlockWritePathProvider` for customized write path options.
2. `data_file_statistics_from_parquet_metadata()` method override: As an workaround for injecting reserved column stats instead of breaking the current logic of getting all columns from schema.

## Rationale

Explain the reasoning behind the changes and their benefits to the project.

## Changes

List the major changes made in this pull request.

## Impact

Discuss any potential impacts the changes may have on existing functionalities.

## Testing

Describe how the changes have been tested, including both automated and manual testing strategies.
If this is a bugfix, explain how the fix has been tested to ensure the bug is resolved without introducing new issues.

## Regression Risk

If this is a bugfix, assess the risk of regression caused by this fix and steps taken to mitigate it.

## Checklist

- [x] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
