### PR TITLE
Adding incremental validation to assert consensus of hash bucket value

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.35"
+__version__ = "1.1.36"
 
 
 __all__ = [

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -69,14 +69,17 @@ def compact_partition(params: CompactPartitionParams, **kwargs) -> Optional[str]
     assert (
         params.hash_bucket_count is not None and params.hash_bucket_count >= 1
     ), "hash_bucket_count is a required arg for compactor v2"
+    assert type(params.hash_bucket_count) is int, "Hash bucket count must be an integer"
     if params.num_rounds > 1:
         assert (
             not params.drop_duplicates
         ), "num_rounds > 1, drop_duplicates must be False but is True"
 
-    with memray.Tracker(
-        "compaction_partition.bin"
-    ) if params.enable_profiler else nullcontext():
+    with (
+        memray.Tracker("compaction_partition.bin")
+        if params.enable_profiler
+        else nullcontext()
+    ):
         execute_compaction_result: ExecutionCompactionResult = _execute_compaction(
             params,
             **kwargs,

--- a/deltacat/compute/compactor_v2/model/merge_input.py
+++ b/deltacat/compute/compactor_v2/model/merge_input.py
@@ -48,6 +48,7 @@ class MergeInput(Dict):
         deltacat_storage_kwargs: Optional[Dict[str, Any]] = None,
         memory_logs_enabled: Optional[bool] = None,
         disable_copy_by_reference: Optional[bool] = None,
+        hash_bucket_count: Optional[int] = None,
     ) -> MergeInput:
 
         result = MergeInput()
@@ -71,6 +72,7 @@ class MergeInput(Dict):
         result["deltacat_storage_kwargs"] = deltacat_storage_kwargs or {}
         result["memory_logs_enabled"] = memory_logs_enabled
         result["disable_copy_by_reference"] = disable_copy_by_reference
+        result["hash_bucket_count"] = hash_bucket_count
         return result
 
     @property
@@ -154,3 +156,7 @@ class MergeInput(Dict):
     @property
     def disable_copy_by_reference(self) -> bool:
         return self["disable_copy_by_reference"]
+
+    @property
+    def hash_bucket_count(self) -> int:
+        return self["hash_bucket_count"]

--- a/deltacat/compute/compactor_v2/private/compaction_utils.py
+++ b/deltacat/compute/compactor_v2/private/compaction_utils.py
@@ -438,6 +438,7 @@ def _merge(
                 delete_file_envelopes=delete_file_envelopes,
                 memory_logs_enabled=params.memory_logs_enabled,
                 disable_copy_by_reference=params.disable_copy_by_reference,
+                hash_bucket_count=params.hash_bucket_count,
             )
         }
 

--- a/deltacat/compute/compactor_v2/utils/merge.py
+++ b/deltacat/compute/compactor_v2/utils/merge.py
@@ -133,4 +133,5 @@ def generate_local_merge_input(
         delete_strategy=delete_strategy,
         delete_file_envelopes=delete_file_envelopes,
         disable_copy_by_reference=params.disable_copy_by_reference,
+        hash_bucket_count=params.hash_bucket_count,
     )


### PR DESCRIPTION
## Summary

This change checks for hash bucket value computed by the nodes running hash bucketing tasks and produces INFO log if it's non-compliant with bucketing spec. 

## Rationale

Checking for consensus can help us catch this issue at scale during runtime as all our efforts to reproduce this bug in test environment have failed. 

## Changes

Adds validation of bucketing spec on incremental table as well for added cost. 

## Impact

No impact to existing runs. A log message will be produced on every non-compliance. 

## Testing

Functional tests exists for checking happy case and failure cases. 

## Regression Risk

None

## Checklist

- [x] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
