### PR TITLE
fix: add missing -m flag to pytest command

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -28,7 +28,7 @@ jobs:
                   if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
             - name: Run unit tests
               run: >-
-                  python -m pytest "not integration"
+                  python -m pytest -m "not integration"
             - name: Echo release tag
               run: echo ${{ github.ref_name }}
             - name: Build a binary wheel and a source tarball


### PR DESCRIPTION
## Summary

Add missing flag to pytest command that was causing workflow to fail.

## Checklist

- [ ] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
