### PR TITLE
fix: remove IcebergCatalog import from required imports

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -67,7 +67,7 @@ if importlib.util.find_spec("pyiceberg") is not None:
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "2.0.0b2"
+__version__ = "2.0.0b3"
 
 
 __all__ = [
@@ -104,7 +104,6 @@ __all__ = [
     "Dataset",
     "Datatype",
     "Field",
-    "IcebergCatalog",
     "LifecycleState",
     "ListResult",
     "LocalDataset",

--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -59,7 +59,7 @@ from deltacat.types.tables import TableWriteMode
 
 __iceberg__ = []
 if importlib.util.find_spec("pyiceberg") is not None:
-    from deltacat.catalog.iceberg import impl as IcebergCatalog
+    from deltacat.catalog.iceberg import impl as IcebergCatalog  # noqa: F401
 
     __iceberg__ = [
         "IcebergCatalog",


### PR DESCRIPTION
## Summary

Removed `IcebergCatalog` import from required imports. Line 65 adds this import if the `pyiceberg` dependency is installed. This prevents new installations from failing if `pyiceberg` is not installed.

## Checklist

- [ ] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
