### PR TITLE
chore: add Manifest.from_json() method

### DIFF
--- a/deltacat/storage/model/manifest.py
+++ b/deltacat/storage/model/manifest.py
@@ -11,6 +11,8 @@ from deltacat import logs
 
 from deltacat.storage.model.schema import FieldLocator
 
+import json
+
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
@@ -193,6 +195,20 @@ class Manifest(dict):
         return manifest
 
     @staticmethod
+    def from_json(json_string: str) -> Manifest:
+        parsed_dict = json.loads(json_string)
+        return Manifest.of(
+            entries=ManifestEntryList.of(
+                [
+                    ManifestEntry.from_dict(entry)
+                    for entry in parsed_dict.get("entries", [])
+                ]
+            ),
+            author=ManifestAuthor.from_dict(parsed_dict.get("author", {})),
+            uuid=parsed_dict.get("id"),
+        )
+
+    @staticmethod
     def merge_manifests(
         manifests: List[Manifest], author: Optional[ManifestAuthor] = None
     ) -> Manifest:
@@ -263,6 +279,21 @@ class ManifestMeta(dict):
         if entry_params is not None:
             manifest_meta["entry_params"] = entry_params
         return manifest_meta
+
+    @staticmethod
+    def from_dict(obj: dict) -> ManifestMeta:
+
+        return ManifestMeta.of(
+            record_count=obj.get("record_count"),
+            content_length=obj.get("content_length"),
+            content_type=obj.get("content_type"),
+            content_encoding=obj.get("content_encoding"),
+            source_content_length=obj.get("source_content_length"),
+            credentials=obj.get("credentials"),
+            content_type_parameters=obj.get("content_type_parameters"),
+            entry_type=obj.get("entry_type"),
+            entry_params=obj.get("entry_params"),
+        )
 
     @property
     def record_count(self) -> Optional[int]:
@@ -358,6 +389,16 @@ class ManifestEntry(dict):
         manifest_entry = ManifestEntry.of(url, manifest_entry_meta)
         return manifest_entry
 
+    @staticmethod
+    def from_dict(obj: dict) -> ManifestEntry:
+        return ManifestEntry.of(
+            url=obj.get("url"),
+            uri=obj.get("uri"),
+            meta=ManifestMeta.from_dict(obj.get("meta", {})),
+            mandatory=obj.get("mandatory", True),
+            uuid=obj.get("id"),
+        )
+
     @property
     def uri(self) -> Optional[str]:
         return self.get("uri")
@@ -391,6 +432,10 @@ class ManifestAuthor(dict):
         if version is not None:
             manifest_author["version"] = version
         return manifest_author
+
+    @staticmethod
+    def from_dict(obj: dict) -> ManifestAuthor:
+        return ManifestAuthor.of(obj.get("name"), obj.get("version"))
 
     @property
     def name(self) -> Optional[str]:

--- a/deltacat/storage/model/manifest.py
+++ b/deltacat/storage/model/manifest.py
@@ -204,7 +204,7 @@ class Manifest(dict):
                     for entry in parsed_dict.get("entries", [])
                 ]
             ),
-            author=ManifestAuthor.from_dict(parsed_dict.get("author", {})),
+            author=ManifestAuthor.from_dict(parsed_dict.get("author")),
             uuid=parsed_dict.get("id"),
         )
 
@@ -281,7 +281,9 @@ class ManifestMeta(dict):
         return manifest_meta
 
     @staticmethod
-    def from_dict(obj: dict) -> ManifestMeta:
+    def from_dict(obj: dict) -> Optional[ManifestMeta]:
+        if obj is None:
+            return None
 
         return ManifestMeta.of(
             record_count=obj.get("record_count"),
@@ -394,7 +396,7 @@ class ManifestEntry(dict):
         return ManifestEntry.of(
             url=obj.get("url"),
             uri=obj.get("uri"),
-            meta=ManifestMeta.from_dict(obj.get("meta", {})),
+            meta=ManifestMeta.from_dict(obj.get("meta")),
             mandatory=obj.get("mandatory", True),
             uuid=obj.get("id"),
         )
@@ -434,7 +436,9 @@ class ManifestAuthor(dict):
         return manifest_author
 
     @staticmethod
-    def from_dict(obj: dict) -> ManifestAuthor:
+    def from_dict(obj: dict) -> Optional[ManifestAuthor]:
+        if obj is None:
+            return None
         return ManifestAuthor.of(obj.get("name"), obj.get("version"))
 
     @property

--- a/deltacat/tests/storage/model/test_manifest.py
+++ b/deltacat/tests/storage/model/test_manifest.py
@@ -5,7 +5,7 @@ from deltacat.storage.model.manifest import Manifest
 
 @pytest.fixture
 def manifest_a():
-    return '''
+    return """
         {
           "entries":[
             {
@@ -29,7 +29,7 @@ def manifest_a():
                 "content_type":"application/x-amzn-unescaped-tsv",
                 "content_encoding":"gzip"
               }
-            }	
+            }
           ],
           "meta":{
             "record_count":0,
@@ -44,14 +44,15 @@ def manifest_a():
             "version":"1.0"
           }
         }
-           '''
+           """
+
 
 def test_manifest_from_json(manifest_a):
     manifest = Manifest.from_json(manifest_a)
 
     assert manifest.entries is not None
     assert len(manifest.entries) == 2
-    assert manifest.entries[0].uri == 's3://test_bucket/file1.tsv.gz'
+    assert manifest.entries[0].uri == "s3://test_bucket/file1.tsv.gz"
     assert manifest.entries[0].meta.record_count == 0
     assert manifest.meta.content_length == 579
-    assert manifest.author.name == 'Dave'
+    assert manifest.author.name == "Dave"

--- a/deltacat/tests/storage/model/test_manifest.py
+++ b/deltacat/tests/storage/model/test_manifest.py
@@ -1,0 +1,57 @@
+import pytest
+
+from deltacat.storage.model.manifest import Manifest
+
+
+@pytest.fixture
+def manifest_a():
+    return '''
+        {
+          "entries":[
+            {
+              "uri":"s3://test_bucket/file1.tsv.gz",
+              "mandatory":true,
+              "meta":{
+                "record_count":0,
+                "content_length":123,
+                "source_content_length":0,
+                "content_type":"application/x-amzn-unescaped-tsv",
+                "content_encoding":"gzip"
+              }
+            },
+            {
+              "uri":"s3://test_bucket/file2.tsv.gz",
+              "mandatory":true,
+              "meta":{
+                "record_count":0,
+                "content_length":456,
+                "source_content_length":0,
+                "content_type":"application/x-amzn-unescaped-tsv",
+                "content_encoding":"gzip"
+              }
+            }	
+          ],
+          "meta":{
+            "record_count":0,
+            "content_length":579,
+            "source_content_length":0,
+            "content_type":"application/x-amzn-unescaped-tsv",
+            "content_encoding":"gzip"
+          },
+          "id":"052f62c0-5082-4935-9937-18a705156123",
+          "author":{
+            "name":"Dave",
+            "version":"1.0"
+          }
+        }
+           '''
+
+def test_manifest_from_json(manifest_a):
+    manifest = Manifest.from_json(manifest_a)
+
+    assert manifest.entries is not None
+    assert len(manifest.entries) == 2
+    assert manifest.entries[0].uri == 's3://test_bucket/file1.tsv.gz'
+    assert manifest.entries[0].meta.record_count == 0
+    assert manifest.meta.content_length == 579
+    assert manifest.author.name == 'Dave'

--- a/deltacat/tests/storage/model/test_manifest.py
+++ b/deltacat/tests/storage/model/test_manifest.py
@@ -1,6 +1,8 @@
+import json
+
 import pytest
 
-from deltacat.storage.model.manifest import Manifest
+from deltacat.storage.model.manifest import Manifest, ManifestEntry
 
 
 @pytest.fixture
@@ -47,6 +49,56 @@ def manifest_a():
            """
 
 
+@pytest.fixture
+def manifest_no_author():
+    return """
+        {
+          "entries":[
+            {
+              "uri":"s3://test_bucket/file1.tsv.gz",
+              "mandatory":true,
+              "meta":{
+                "record_count":0,
+                "content_length":123,
+                "source_content_length":0,
+                "content_type":"application/x-amzn-unescaped-tsv",
+                "content_encoding":"gzip"
+              }
+            },
+            {
+              "uri":"s3://test_bucket/file2.tsv.gz",
+              "mandatory":true,
+              "meta":{
+                "record_count":0,
+                "content_length":456,
+                "source_content_length":0,
+                "content_type":"application/x-amzn-unescaped-tsv",
+                "content_encoding":"gzip"
+              }
+            }
+          ],
+          "meta":{
+            "record_count":0,
+            "content_length":579,
+            "source_content_length":0,
+            "content_type":"application/x-amzn-unescaped-tsv",
+            "content_encoding":"gzip"
+          },
+          "id":"052f62c0-5082-4935-9937-18a705156123"
+        }
+           """
+
+
+@pytest.fixture()
+def manifest_entry_no_meta():
+    return """
+            {
+              "uri":"s3://test_bucket/file1.tsv.gz",
+              "mandatory":true
+            }
+           """
+
+
 def test_manifest_from_json(manifest_a):
     manifest = Manifest.from_json(manifest_a)
 
@@ -56,3 +108,22 @@ def test_manifest_from_json(manifest_a):
     assert manifest.entries[0].meta.record_count == 0
     assert manifest.meta.content_length == 579
     assert manifest.author.name == "Dave"
+
+
+def test_manifest_from_json_no_author(manifest_no_author):
+    manifest = Manifest.from_json(manifest_no_author)
+
+    assert manifest.entries is not None
+    assert len(manifest.entries) == 2
+    assert manifest.entries[0].uri == "s3://test_bucket/file1.tsv.gz"
+    assert manifest.entries[0].meta is not None
+    assert manifest.author is None
+
+
+def test_manifest_entry_from_dict_no_meta(manifest_entry_no_meta):
+    entry = ManifestEntry.from_dict(json.loads(manifest_entry_no_meta))
+
+    assert entry is not None
+    assert entry.meta is None
+    assert entry.uri == "s3://test_bucket/file1.tsv.gz"
+    assert entry.mandatory is True


### PR DESCRIPTION
## Summary

Implementing `Manifest.from_json()` method to support deserialization from Manifest json string.

## Rationale

This is needed to support parsing Manifest that is returned from Glue partition.

## Testing
- Added unit test and passed

