### PR TITLE
Fix DQ issue due to inconsistent grouping of bucketed records

### DIFF
--- a/deltacat/compute/compactor_v2/utils/primary_key_index.py
+++ b/deltacat/compute/compactor_v2/utils/primary_key_index.py
@@ -79,7 +79,6 @@ def _append_table_by_hash_bucket(
     )
 
     hb_pk_grouped_by = hb_pk_grouped_by.sort_by(sc._HASH_BUCKET_IDX_COLUMN_NAME)
-
     group_count_array = hb_pk_grouped_by[f"{sc._HASH_BUCKET_IDX_COLUMN_NAME}_count"]
     hb_group_array = hb_pk_grouped_by[sc._HASH_BUCKET_IDX_COLUMN_NAME]
 
@@ -92,7 +91,9 @@ def _append_table_by_hash_bucket(
             pyarrow_table
         ), f"Group count {group_count_py} not equal to {len(pyarrow_table)}"
         all_buckets = pc.unique(pyarrow_table[sc._HASH_BUCKET_IDX_COLUMN_NAME])
-        assert len(all_buckets) == 1, "Only one hash bucket is "
+        assert (
+            len(all_buckets) == 1
+        ), f"Only one hash bucket is allowed by found {len(all_buckets)}"
         assert (
             all_buckets[0].as_py() == hb_idx
         ), f"Hash bucket not equal, {all_buckets[0]} and {hb_idx}"

--- a/deltacat/compute/compactor_v2/utils/primary_key_index.py
+++ b/deltacat/compute/compactor_v2/utils/primary_key_index.py
@@ -78,13 +78,24 @@ def _append_table_by_hash_bucket(
         f"Grouping a pki table of length {len(pki_table)} took {groupby_latency}s"
     )
 
+    hb_pk_grouped_by = hb_pk_grouped_by.sort_by(sc._HASH_BUCKET_IDX_COLUMN_NAME)
+
     group_count_array = hb_pk_grouped_by[f"{sc._HASH_BUCKET_IDX_COLUMN_NAME}_count"]
     hb_group_array = hb_pk_grouped_by[sc._HASH_BUCKET_IDX_COLUMN_NAME]
 
     result_len = 0
     for i, group_count in enumerate(group_count_array):
         hb_idx = hb_group_array[i].as_py()
-        pyarrow_table = hb_pk_table.slice(offset=result_len, length=group_count.as_py())
+        group_count_py = group_count.as_py()
+        pyarrow_table = hb_pk_table.slice(offset=result_len, length=group_count_py)
+        assert group_count_py == len(
+            pyarrow_table
+        ), f"Group count {group_count_py} not equal to {len(pyarrow_table)}"
+        all_buckets = pc.unique(pyarrow_table[sc._HASH_BUCKET_IDX_COLUMN_NAME])
+        assert len(all_buckets) == 1, "Only one hash bucket is "
+        assert (
+            all_buckets[0].as_py() == hb_idx
+        ), f"Hash bucket not equal, {all_buckets[0]} and {hb_idx}"
         pyarrow_table = pyarrow_table.drop(
             [sc._HASH_BUCKET_IDX_COLUMN_NAME, sc._PK_HASH_STRING_COLUMN_NAME]
         )
@@ -141,6 +152,7 @@ def _optimized_group_record_batches_by_hash_bucket(
         record_batches.append(record_batch)
 
     if record_batches:
+        print(f"{len(record_batches)} -- END")
         appended_len, append_latency = timed_invocation(
             _append_table_by_hash_bucket,
             pa.Table.from_batches(record_batches),


### PR DESCRIPTION
## Summary

This change fixes a DQ issue that was caused due to inconsistent grouping of bucketed records. The pyarrow `groupby` method *almost* always returns the keys (on which the records were grouped) in the same order as they appear in the input. Algorithm relied on this invariant for correctness. However, we missed adding an assertion for the same. In rare scenarios, the order of the keys changed which led to incorrect assignment of hash buckets to respective record groups and caused DQ issue in the tables.

The ordering of keys in the output will be consistent with the input if pyarrow uses `exactly one thread` to execute the `groupby` operation. However, in some `unknown` scenarios, pyarrow could be using multi-threading to speed up the grouping operation which has resulted in inconsistent order of the keys on which the records were grouped by.  

## Rationale

This change helps stop the further bleeding by ensuring the data is written correctly from now on. 

## Changes

This change ensures that invariant is true by explicitly sorting the output of pyarrow groupby operation. This comes at an added cost which is necessary for correctness. 

## Impact

Fixes the DQ issue. 

## Testing

I downloaded a specific file from our internal catalog on which this issue occurs consistently. Then, tested it by running compaction against real tables to verify the fix. An attempt to reproduce this issue on hand-crafted files did not trigger pyarrow fallback to `multi-threading`. Hence, we will be adding an integration test case using one of the file on which this issue occurred in production.  

## Regression Risk

None

## Checklist

- [ ] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
