### PR TITLE
Add a new resource estimation method to fallback to inflation

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.36"
+__version__ = "1.1.37"
 
 
 __all__ = [

--- a/deltacat/compute/resource_estimation/delta.py
+++ b/deltacat/compute/resource_estimation/delta.py
@@ -170,6 +170,10 @@ def _estimate_resources_required_to_process_delta_using_file_sampling(
         operation_type == OperationType.PYARROW_DOWNLOAD
     ), "Number of rows can only be estimated for PYARROW_DOWNLOAD operation"
 
+    if not estimate_resources_params.max_files_to_sample:
+        # we cannot calculate if we cannot sample
+        return None
+
     if not delta.manifest:
         delta.manifest = deltacat_storage.get_delta_manifest(
             delta.locator,
@@ -185,10 +189,6 @@ def _estimate_resources_required_to_process_delta_using_file_sampling(
                 on_disk_size_bytes=delta.meta.content_length,
             ),
         )
-
-    if not estimate_resources_params.max_files_to_sample:
-        # we cannot calculate if we cannot sample
-        return None
 
     sampled_in_memory_size = 0.0
     sampled_on_disk_size = 0.0
@@ -249,6 +249,10 @@ RESOURCE_ESTIMATION_METHOD_TO_DELTA_RESOURCE_ESTIMATION_FUNCTIONS = {
     ],
     ResourceEstimationMethod.DEFAULT_V2: [
         _estimate_resources_required_to_process_delta_using_type_params,
+        _estimate_resources_required_to_process_delta_using_file_sampling,
+        _estimate_resources_required_to_process_delta_using_previous_inflation,
+    ],
+    ResourceEstimationMethod.FILE_SAMPLING_WITH_PREVIOUS_INFLATION: [
         _estimate_resources_required_to_process_delta_using_file_sampling,
         _estimate_resources_required_to_process_delta_using_previous_inflation,
     ],

--- a/deltacat/compute/resource_estimation/model.py
+++ b/deltacat/compute/resource_estimation/model.py
@@ -24,6 +24,14 @@ class ResourceEstimationMethod(str, Enum):
     DEFAULT_V2 = "DEFAULT_V2"
 
     """
+    This approach combines file sampling estimation and inflation based methods
+    and runs them in the order specified below:
+    1. FILE_SAMPLING
+    2. PREVIOUS_INFLATION
+    """
+    FILE_SAMPLING_WITH_PREVIOUS_INFLATION = "FILE_SAMPLING_WITH_PREVIOUS_INFLATION"
+
+    """
     This approach strictly uses previous inflation and average record size to arrive
     at a resource estimate. It requires users to pass in previous inflation and average
     record sizes.

--- a/deltacat/tests/compute/resource_estimation/test_delta.py
+++ b/deltacat/tests/compute/resource_estimation/test_delta.py
@@ -416,11 +416,55 @@ class TestEstimateResourcesRequiredToProcessDelta:
             == delta_without_manifest.meta.content_length
         )
 
+    def test_empty_delta_sampled_when_file_sampling_with_previous_inflation(
+        self, local_deltacat_storage_kwargs, delta_without_manifest: Delta
+    ):
+        params = EstimateResourcesParams.of(
+            resource_estimation_method=ResourceEstimationMethod.FILE_SAMPLING_WITH_PREVIOUS_INFLATION,
+            max_files_to_sample=2,
+        )
+
+        result = estimate_resources_required_to_process_delta(
+            delta=delta_without_manifest,
+            operation_type=OperationType.PYARROW_DOWNLOAD,
+            deltacat_storage=ds,
+            deltacat_storage_kwargs=local_deltacat_storage_kwargs,
+            estimate_resources_params=params,
+        )
+
+        assert delta_without_manifest.manifest is not None
+        assert result.memory_bytes is not None
+        assert (
+            result.statistics.on_disk_size_bytes
+            == delta_without_manifest.meta.content_length
+        )
+
     def test_delta_manifest_parquet_when_file_sampling(
         self, local_deltacat_storage_kwargs, parquet_delta_with_manifest: Delta
     ):
         params = EstimateResourcesParams.of(
             resource_estimation_method=ResourceEstimationMethod.FILE_SAMPLING,
+            max_files_to_sample=2,
+        )
+
+        result = estimate_resources_required_to_process_delta(
+            delta=parquet_delta_with_manifest,
+            operation_type=OperationType.PYARROW_DOWNLOAD,
+            deltacat_storage=ds,
+            deltacat_storage_kwargs=local_deltacat_storage_kwargs,
+            estimate_resources_params=params,
+        )
+        assert result.memory_bytes is not None
+        assert (
+            result.statistics.on_disk_size_bytes
+            == parquet_delta_with_manifest.meta.content_length
+        )
+
+    def test_delta_manifest_parquet_when_file_sampling_with_previous_inflation(
+        self, local_deltacat_storage_kwargs, parquet_delta_with_manifest: Delta
+    ):
+        params = EstimateResourcesParams.of(
+            resource_estimation_method=ResourceEstimationMethod.FILE_SAMPLING_WITH_PREVIOUS_INFLATION,
             max_files_to_sample=2,
         )
 
@@ -511,6 +555,28 @@ class TestEstimateResourcesRequiredToProcessDelta:
             estimate_resources_params=params,
         )
         assert result is None
+
+    def test_delta_manifest_utsv_when_file_sampling_with_previous_inflation_zero_files_to_sample(
+        self, local_deltacat_storage_kwargs, utsv_delta_with_manifest: Delta
+    ):
+        previous_inflation = 7
+        params = EstimateResourcesParams.of(
+            resource_estimation_method=ResourceEstimationMethod.FILE_SAMPLING_WITH_PREVIOUS_INFLATION,
+            max_files_to_sample=None,
+            previous_inflation=previous_inflation,
+        )
+
+        result = estimate_resources_required_to_process_delta(
+            delta=utsv_delta_with_manifest,
+            operation_type=OperationType.PYARROW_DOWNLOAD,
+            deltacat_storage=ds,
+            deltacat_storage_kwargs=local_deltacat_storage_kwargs,
+            estimate_resources_params=params,
+        )
+        assert result is not None
+        assert result.memory_bytes == (
+            utsv_delta_with_manifest.meta.content_length * previous_inflation
+        )
 
     def test_empty_delta_when_default_v2(
         self, local_deltacat_storage_kwargs, delta_without_manifest: Delta


### PR DESCRIPTION
## Summary

This change adds a new resource estimation method which falls back to inflation after exhausting maximum files to sample. This allows us to use the same function in succession and use the inflation calculated from sampled files. 

## Rationale

Helps with better estimate memory during compaction. 

## Changes

Adds a new resource estimation method. 

## Impact

This change adds a new functionality. So, no impact on estimation methods.

## Testing

Functional tests have been added. 

## Regression Risk

No risk. 

## Checklist

- [x] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
