### PR TITLE
chore: bump version to 2.0.0b6

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -67,7 +67,7 @@ if importlib.util.find_spec("pyiceberg") is not None:
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "2.0.0b3"
+__version__ = "2.0.0b6"
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

bump package version to `2.0.0b6` to prepare for release.