### PR TITLE
[Converter] Multiple pk support; Refactor parquet file to Iceberg data file conversion functions to be Ray distributed tasks.

### DIFF
--- a/deltacat/compute/converter/constants.py
+++ b/deltacat/compute/converter/constants.py
@@ -3,4 +3,7 @@ DEFAULT_CONVERTER_TASK_MAX_PARALLELISM = 4096
 # Safe limit ONLY considering CPU limit, typically 32 for a 8x-large worker
 DEFAULT_MAX_PARALLEL_DATA_FILE_DOWNLOAD = 30
 
-DEFAULT_ICEBERG_NAMESPACE = "default"
+
+# Unique identifier delimiter to ensure different primary key don't end up with same hash when concatenated.
+# e.g.: pk column a with value: 1, 12; pk column b with value: 12, 1; Without delimiter will both become "121".
+IDENTIFIER_FIELD_DELIMITER = "c303282d"

--- a/deltacat/compute/converter/converter_session.py
+++ b/deltacat/compute/converter/converter_session.py
@@ -19,7 +19,6 @@ from deltacat.compute.converter.steps.convert import convert
 from deltacat.compute.converter.model.convert_input import ConvertInput
 from deltacat.compute.converter.pyiceberg.overrides import (
     fetch_all_bucket_files,
-    parquet_files_dict_to_iceberg_data_files,
 )
 from deltacat.compute.converter.utils.converter_session_utils import (
     construct_iceberg_table_prefix,
@@ -62,6 +61,7 @@ def converter_session(params: ConverterSessionParams, **kwargs):
     data_file_dict, equality_delete_dict, pos_delete_dict = fetch_all_bucket_files(
         iceberg_table
     )
+
     convert_input_files_for_all_buckets = group_all_files_to_each_bucket(
         data_file_dict=data_file_dict,
         equality_delete_dict=equality_delete_dict,
@@ -83,10 +83,7 @@ def converter_session(params: ConverterSessionParams, **kwargs):
         identifier_fields = list(identifier_fields_set)
     else:
         identifier_fields = merge_keys
-    if len(identifier_fields) > 1:
-        raise NotImplementedError(
-            f"Multiple identifier fields lookup not supported yet."
-        )
+
     convert_options_provider = functools.partial(
         task_resource_options_provider,
         resource_amount_provider=convert_resource_options_provider,
@@ -107,6 +104,8 @@ def converter_session(params: ConverterSessionParams, **kwargs):
                 iceberg_table_warehouse_prefix=iceberg_table_warehouse_prefix,
                 identifier_fields=identifier_fields,
                 compact_small_files=compact_small_files,
+                table_io=iceberg_table.io,
+                table_metadata=iceberg_table.metadata,
                 enforce_primary_key_uniqueness=enforce_primary_key_uniqueness,
                 position_delete_for_multiple_data_files=position_delete_for_multiple_data_files,
                 max_parallel_data_file_download=max_parallel_data_file_download,
@@ -115,8 +114,8 @@ def converter_session(params: ConverterSessionParams, **kwargs):
             )
         }
 
+    logger.info((f"Getting remote convert tasks..."))
     # Ray remote task: convert
-    # Assuming that memory consume by each bucket doesn't exceed one node's memory limit.
     # TODO: Add split mechanism to split large buckets
     convert_tasks_pending = invoke_parallel(
         items=convert_input_files_for_all_buckets,
@@ -125,28 +124,27 @@ def converter_session(params: ConverterSessionParams, **kwargs):
         options_provider=convert_options_provider,
         kwargs_provider=convert_input_provider,
     )
+
     to_be_deleted_files_list = []
-    to_be_added_files_dict_list = []
+    logger.info(f"Finished invoking {len(convert_tasks_pending)} convert tasks.")
+
     convert_results = ray.get(convert_tasks_pending)
+    logger.info(f"Got {len(convert_tasks_pending)} convert tasks.")
+
+    to_be_added_files_list = []
     for convert_result in convert_results:
         to_be_deleted_files_list.extend(convert_result[0].values())
-        to_be_added_files_dict_list.append(convert_result[1])
-
-    new_position_delete_files = parquet_files_dict_to_iceberg_data_files(
-        io=iceberg_table.io,
-        table_metadata=iceberg_table.metadata,
-        files_dict_list=to_be_added_files_dict_list,
-    )
+        to_be_added_files_list.extend(convert_result[1])
 
     if not to_be_deleted_files_list:
         commit_append_snapshot(
             iceberg_table=iceberg_table,
-            new_position_delete_files=new_position_delete_files,
+            new_position_delete_files=to_be_added_files_list,
         )
     else:
         commit_replace_snapshot(
             iceberg_table=iceberg_table,
-            # equality_delete_files + data file that all rows are deleted
             to_be_deleted_files_list=to_be_deleted_files_list,
-            new_position_delete_files=new_position_delete_files,
+            new_position_delete_files=to_be_added_files_list,
         )
+    logger.info(f"Committed new Iceberg snapshot.")

--- a/deltacat/compute/converter/model/convert_input.py
+++ b/deltacat/compute/converter/model/convert_input.py
@@ -10,6 +10,8 @@ class ConvertInput(Dict):
         convert_task_index,
         iceberg_table_warehouse_prefix,
         identifier_fields,
+        table_io,
+        table_metadata,
         compact_small_files,
         enforce_primary_key_uniqueness,
         position_delete_for_multiple_data_files,
@@ -23,6 +25,8 @@ class ConvertInput(Dict):
         result["convert_task_index"] = convert_task_index
         result["identifier_fields"] = identifier_fields
         result["iceberg_table_warehouse_prefix"] = iceberg_table_warehouse_prefix
+        result["table_io"] = table_io
+        result["table_metadata"] = table_metadata
         result["compact_small_files"] = compact_small_files
         result["enforce_primary_key_uniqueness"] = enforce_primary_key_uniqueness
         result[
@@ -49,6 +53,14 @@ class ConvertInput(Dict):
     @property
     def iceberg_table_warehouse_prefix(self) -> str:
         return self["iceberg_table_warehouse_prefix"]
+
+    @property
+    def table_io(self):
+        return self["table_io"]
+
+    @property
+    def table_metadata(self):
+        return self["table_metadata"]
 
     @property
     def compact_small_files(self) -> bool:

--- a/deltacat/compute/converter/model/converter_session_params.py
+++ b/deltacat/compute/converter/model/converter_session_params.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 from typing import Optional, Dict
 from deltacat.compute.converter.constants import (
     DEFAULT_CONVERTER_TASK_MAX_PARALLELISM,
-    DEFAULT_ICEBERG_NAMESPACE,
 )
+from deltacat.constants import DEFAULT_NAMESPACE
 from fsspec import AbstractFileSystem
 
 
@@ -24,9 +24,7 @@ class ConverterSessionParams(dict):
         ), "iceberg_warehouse_bucket_name is a required arg"
         result = ConverterSessionParams(params)
 
-        result.iceberg_namespace = params.get(
-            "iceberg_namespace", DEFAULT_ICEBERG_NAMESPACE
-        )
+        result.iceberg_namespace = params.get("iceberg_namespace", DEFAULT_NAMESPACE)
         result.enforce_primary_key_uniqueness = params.get(
             "enforce_primary_key_uniqueness", False
         )

--- a/deltacat/compute/converter/pyiceberg/overrides.py
+++ b/deltacat/compute/converter/pyiceberg/overrides.py
@@ -17,7 +17,6 @@ from deltacat.compute.converter.utils.iceberg_columns import (
     ICEBERG_RESERVED_FIELD_ID_FOR_POS_COLUMN,
 )
 from pyiceberg.io.pyarrow import (
-    _check_pyarrow_schema_compatible,
     compute_statistics_plan,
 )
 from pyiceberg.manifest import (
@@ -25,16 +24,13 @@ from pyiceberg.manifest import (
     DataFileContent,
     FileFormat,
 )
-from pyiceberg.expressions.visitors import _InclusiveMetricsEvaluator
-from pyiceberg.types import (
-    strtobool,
-)
 from pyiceberg.table import _min_sequence_number, _open_manifest
 from pyiceberg.utils.concurrent import ExecutorFactory
 from itertools import chain
 from pyiceberg.typedef import (
     KeyDefaultDict,
 )
+
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
@@ -159,41 +155,39 @@ def data_file_statistics_from_parquet_metadata(
     )
 
 
-def parquet_files_dict_to_iceberg_data_files(io, table_metadata, files_dict_list):
+def parquet_files_dict_to_iceberg_data_files(io, table_metadata, files_dict):
     data_file_content_type = DataFileContent.POSITION_DELETES
     iceberg_files = []
     schema = table_metadata.schema()
-    for files_dict in files_dict_list:
-        for partition_value, file_paths in files_dict.items():
-            for file_path in file_paths:
-                input_file = io.new_input(file_path)
-                with input_file.open() as input_stream:
-                    parquet_metadata = pq.read_metadata(input_stream)
-                _check_pyarrow_schema_compatible(
-                    schema, parquet_metadata.schema.to_arrow_schema()
-                )
+    for partition_value, file_paths in files_dict.items():
+        for file_path in file_paths:
+            input_file = io.new_input(file_path)
+            with input_file.open() as input_stream:
+                parquet_metadata = pq.read_metadata(input_stream)
 
-                statistics = data_file_statistics_from_parquet_metadata(
-                    parquet_metadata=parquet_metadata,
-                    stats_columns=compute_statistics_plan(
-                        schema, table_metadata.properties
-                    ),
-                    parquet_column_mapping=parquet_path_to_id_mapping_override(schema),
-                )
+            # Removed _check_pyarrow_schema_compatible() here since reserved columns does not comply to all rules.
 
-                data_file = DataFile(
-                    content=data_file_content_type,
-                    file_path=file_path,
-                    file_format=FileFormat.PARQUET,
-                    partition=partition_value,
-                    file_size_in_bytes=len(input_file),
-                    sort_order_id=None,
-                    spec_id=table_metadata.default_spec_id,
-                    equality_ids=None,
-                    key_metadata=None,
-                    **statistics.to_serialized_dict(),
-                )
-                iceberg_files.append(data_file)
+            statistics = data_file_statistics_from_parquet_metadata(
+                parquet_metadata=parquet_metadata,
+                stats_columns=compute_statistics_plan(
+                    schema, table_metadata.properties
+                ),
+                parquet_column_mapping=parquet_path_to_id_mapping_override(schema),
+            )
+
+            data_file = DataFile(
+                content=data_file_content_type,
+                file_path=file_path,
+                file_format=FileFormat.PARQUET,
+                partition=partition_value,
+                file_size_in_bytes=len(input_file),
+                sort_order_id=None,
+                spec_id=table_metadata.default_spec_id,
+                equality_ids=None,
+                key_metadata=None,
+                **statistics.to_serialized_dict(),
+            )
+            iceberg_files.append(data_file)
     return iceberg_files
 
 
@@ -216,13 +210,7 @@ def fetch_all_bucket_files(table):
     # step 2: filter the data files in each manifest
     # this filter depends on the partition spec used to write the manifest file
     partition_evaluators = KeyDefaultDict(data_scan._build_partition_evaluator)
-    metrics_evaluator = _InclusiveMetricsEvaluator(
-        data_scan.table_metadata.schema(),
-        data_scan.row_filter,
-        data_scan.case_sensitive,
-        strtobool(data_scan.options.get("include_empty_files", "false")),
-    ).eval
-
+    residual_evaluators = KeyDefaultDict(data_scan._build_residual_evaluator)
     min_sequence_number = _min_sequence_number(manifests)
 
     # {"bucket_index": List[DataFile]}
@@ -239,7 +227,8 @@ def fetch_all_bucket_files(table):
                     data_scan.io,
                     manifest,
                     partition_evaluators[manifest.partition_spec_id],
-                    metrics_evaluator,
+                    residual_evaluators[manifest.partition_spec_id],
+                    data_scan._build_metrics_evaluator(),
                 )
                 for manifest in manifests
                 if data_scan._check_sequence_number(min_sequence_number, manifest)

--- a/deltacat/compute/converter/steps/convert.py
+++ b/deltacat/compute/converter/steps/convert.py
@@ -15,7 +15,9 @@ from deltacat.compute.converter.utils.io import (
 from deltacat.compute.converter.utils.converter_session_utils import (
     partition_value_record_to_partition_value_string,
 )
-
+from deltacat.compute.converter.pyiceberg.overrides import (
+    parquet_files_dict_to_iceberg_data_files,
+)
 from deltacat import logs
 
 logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
@@ -27,6 +29,8 @@ def convert(convert_input: ConvertInput):
     convert_task_index = convert_input.convert_task_index
     iceberg_table_warehouse_prefix = convert_input.iceberg_table_warehouse_prefix
     identifier_fields = convert_input.identifier_fields
+    table_io = convert_input.table_io
+    table_metadata = convert_input.table_metadata
     compact_small_files = convert_input.compact_small_files
     position_delete_for_multiple_data_files = (
         convert_input.position_delete_for_multiple_data_files
@@ -83,9 +87,9 @@ def convert(convert_input: ConvertInput):
             all_data_files=all_data_files_for_this_bucket,
             data_files_downloaded=applicable_data_files,
         )
+        logger.info(f"Got {len(data_files_to_dedupe)} files to dedupe.")
         pos_delete_after_dedupe = dedupe_data_files(
             data_file_to_dedupe=data_files_to_dedupe,
-            identify_column_name_concatenated=identifier_fields[0],
             identifier_columns=identifier_fields,
             merge_sort_column=sc._ORDERED_RECORD_IDX_COLUMN_NAME,
             s3_client_kwargs=s3_client_kwargs,
@@ -93,12 +97,25 @@ def convert(convert_input: ConvertInput):
         total_pos_delete_table.append(pos_delete_after_dedupe)
 
     total_pos_delete = pa.concat_tables(total_pos_delete_table)
+    logger.info(f"Total position delete produced:{len(total_pos_delete)}")
 
-    to_be_added_files_list = upload_table_with_retry(
+    to_be_added_files_list_parquet = upload_table_with_retry(
         table=total_pos_delete,
         s3_url_prefix=iceberg_table_warehouse_prefix_with_partition,
         s3_table_writer_kwargs={},
         s3_file_system=s3_file_system,
+    )
+
+    to_be_added_files_dict = defaultdict()
+    to_be_added_files_dict[partition_value] = to_be_added_files_list_parquet
+
+    logger.info(
+        f"Produced {len(to_be_added_files_list_parquet)} position delete files."
+    )
+    to_be_added_files_list = parquet_files_dict_to_iceberg_data_files(
+        io=table_io,
+        table_metadata=table_metadata,
+        files_dict=to_be_added_files_dict,
     )
 
     to_be_delete_files_dict = defaultdict()
@@ -107,9 +124,8 @@ def convert(convert_input: ConvertInput):
             equality_delete_file[1]
             for equality_delete_file in applicable_equality_delete_files
         ]
-    to_be_added_files_dict = defaultdict()
-    to_be_added_files_dict[partition_value] = to_be_added_files_list
-    return (to_be_delete_files_dict, to_be_added_files_dict)
+
+    return (to_be_delete_files_dict, to_be_added_files_list)
 
 
 def get_additional_applicable_data_files(all_data_files, data_files_downloaded):
@@ -129,8 +145,6 @@ def filter_rows_to_be_deleted(
             equality_delete_table[identifier_column],
         )
         position_delete_table = data_file_table.filter(equality_deletes)
-        logger.info(f"positional_delete_table:{position_delete_table.to_pydict()}")
-        logger.info(f"data_file_table:{data_file_table.to_pydict()}")
         logger.info(
             f"length_pos_delete_table, {len(position_delete_table)}, length_data_table:{len(data_file_table)}"
         )
@@ -216,7 +230,7 @@ def compute_pos_delete_with_limited_parallelism(
         s3_client_kwargs=s3_client_kwargs,
     )
     if not new_pos_delete_table:
-        logger.info("No records deleted based on equality delete converstion")
+        logger.info("No records deleted based on equality delete convertion")
 
     logger.info(
         f"Number of records to delete based on equality delete convertion:{len(new_pos_delete_table)}"

--- a/deltacat/compute/converter/steps/dedupe.py
+++ b/deltacat/compute/converter/steps/dedupe.py
@@ -4,11 +4,14 @@ import deltacat.compute.converter.utils.iceberg_columns as sc
 from deltacat.compute.converter.utils.io import (
     download_data_table_and_append_iceberg_columns,
 )
+import logging
+from deltacat import logs
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
 def dedupe_data_files(
     data_file_to_dedupe,
-    identify_column_name_concatenated,
     identifier_columns,
     merge_sort_column,
     s3_client_kwargs,
@@ -34,6 +37,8 @@ def dedupe_data_files(
 
     final_data_to_dedupe = pa.concat_tables(data_file_table)
 
+    logger.info(f"Length of pyarrow table to dedupe:{len(final_data_to_dedupe)}")
+
     record_idx_iterator = iter(range(len(final_data_to_dedupe)))
 
     # Append global record index to used as aggregate column
@@ -42,7 +47,7 @@ def dedupe_data_files(
     )
 
     final_data_table_indices = final_data_to_dedupe.group_by(
-        identify_column_name_concatenated, use_threads=False
+        sc._IDENTIFIER_COLUMNS_HASH_COLUMN_NAME, use_threads=False
     ).aggregate([(sc._GLOBAL_RECORD_IDX_COLUMN_NAME, "max")])
 
     pos_delete_indices = pc.invert(
@@ -57,6 +62,6 @@ def dedupe_data_files(
     final_data_table_to_delete = final_data_to_dedupe.filter(pos_delete_indices)
 
     final_data_table_to_delete = final_data_table_to_delete.drop(
-        [identify_column_name_concatenated, sc._GLOBAL_RECORD_IDX_COLUMN_NAME]
+        [sc._IDENTIFIER_COLUMNS_HASH_COLUMN_NAME, sc._GLOBAL_RECORD_IDX_COLUMN_NAME]
     )
     return final_data_table_to_delete

--- a/deltacat/compute/converter/utils/convert_task_options.py
+++ b/deltacat/compute/converter/utils/convert_task_options.py
@@ -71,7 +71,8 @@ def _get_task_options(
         task_opts["resources"] = ray_custom_resources
 
     task_opts["max_retries"] = 3
-
+    task_opts["num_cpus"] = 1
+    task_opts["resources"] = {"convert_task": 1}
     # List of possible botocore exceptions are available at
     # https://github.com/boto/botocore/blob/develop/botocore/exceptions.py
     task_opts["retry_exceptions"] = [RetryableError]

--- a/deltacat/compute/converter/utils/iceberg_columns.py
+++ b/deltacat/compute/converter/utils/iceberg_columns.py
@@ -80,3 +80,8 @@ def append_global_record_idx_column(
         pa.array(ordered_record_indices, _GLOBAL_RECORD_IDX_COLUMN_TYPE),
     )
     return table
+
+
+_IDENTIFIER_COLUMNS_HASH_COLUMN_NAME = _get_iceberg_col_name(
+    "identifier_columns_hashed"
+)

--- a/deltacat/compute/converter/utils/io.py
+++ b/deltacat/compute/converter/utils/io.py
@@ -1,7 +1,16 @@
+import logging
+from deltacat import logs
 import deltacat.compute.converter.utils.iceberg_columns as sc
 import daft
 from deltacat.utils.daft import _get_s3_io_config
 from daft import TimeUnit
+import pyarrow as pa
+from deltacat.utils.pyarrow import sliced_string_cast
+from deltacat.compute.converter.constants import IDENTIFIER_FIELD_DELIMITER
+
+import pyarrow.compute as pc
+
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
 def download_data_table_and_append_iceberg_columns(
@@ -12,20 +21,22 @@ def download_data_table_and_append_iceberg_columns(
     s3_client_kwargs,
 ):
     table = download_parquet_with_daft_hash_applied(
-        identify_columns=columns_to_download,
+        identifier_columns=columns_to_download,
         file=file,
         s3_client_kwargs=s3_client_kwargs,
     )
+
     if sc._FILE_PATH_COLUMN_NAME in additional_columns_to_append:
         table = sc.append_file_path_column(table, file.file_path)
     if sc._ORDERED_RECORD_IDX_COLUMN_NAME in additional_columns_to_append:
         record_idx_iterator = iter(range(len(table)))
         table = sc.append_record_idx_col(table, record_idx_iterator)
+
     return table
 
 
 def download_parquet_with_daft_hash_applied(
-    identify_columns, file, s3_client_kwargs, **kwargs
+    identifier_columns, file, s3_client_kwargs, **kwargs
 ):
 
     # TODO: Add correct read kwargs as in:
@@ -37,11 +48,44 @@ def download_parquet_with_daft_hash_applied(
 
     # TODO: Use Daft SHA1 hash instead to minimize probably of data corruption
     io_config = _get_s3_io_config(s3_client_kwargs=s3_client_kwargs)
-    df = daft.read_parquet(
+    df = daft_read_parquet(
         path=file.file_path,
         io_config=io_config,
         coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,
     )
-    df = df.select(daft.col(identify_columns[0]).hash())
-    arrow_table = df.to_arrow()
-    return arrow_table
+    hash_column = concatenate_hashed_identifier_columns(
+        df=df, identifier_columns=identifier_columns
+    )
+
+    table = pa.Table.from_arrays(
+        [hash_column], names=[sc._IDENTIFIER_COLUMNS_HASH_COLUMN_NAME]
+    )
+
+    return table
+
+
+def daft_read_parquet(path, io_config, coerce_int96_timestamp_unit):
+    df = daft.read_parquet(
+        path=path,
+        io_config=io_config,
+        coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,
+    )
+    return df
+
+
+def concatenate_hashed_identifier_columns(df, identifier_columns):
+    pk_hash_columns = []
+
+    for i in range(len(identifier_columns)):
+        pk_hash_column = df.select(daft.col(identifier_columns[i]).hash())
+        pk_hash_column_arrow = pk_hash_column.to_arrow()
+        # Converted int16 to string here
+        pk_hash_columns.append(
+            sliced_string_cast(pk_hash_column_arrow[identifier_columns[i]])
+        )
+    pk_hash_columns.append(IDENTIFIER_FIELD_DELIMITER)
+    pk_hash_columns_concatenated = pc.binary_join_element_wise(
+        *pk_hash_columns, null_handling="replace"
+    )
+
+    return pk_hash_columns_concatenated

--- a/deltacat/compute/converter/utils/s3u.py
+++ b/deltacat/compute/converter/utils/s3u.py
@@ -11,7 +11,7 @@ from deltacat.types.tables import (
     get_table_length,
     TABLE_CLASS_TO_SLICER_FUNC,
 )
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any
 from deltacat.exceptions import RetryableError
 from deltacat.storage import (
     DistributedDataset,
@@ -59,7 +59,7 @@ def upload_table_with_retry(
     max_records_per_file: Optional[int] = 4000000,
     s3_file_system=None,
     **s3_client_kwargs,
-) -> List[str]:
+):
     """
     Writes the given table to 1 or more S3 files and return Redshift
     manifest entries describing the uploaded files.
@@ -110,7 +110,16 @@ def upload_table_with_retry(
             )
     del block_write_path_provider
     write_paths = capture_object.write_paths()
-    return write_paths
+    s3_write_paths = []
+    for path in write_paths:
+        s3_write_path = construct_s3_url(path)
+        s3_write_paths.append(s3_write_path)
+    return s3_write_paths
+
+
+def construct_s3_url(path):
+    if path:
+        return f"s3://{path}"
 
 
 def upload_table(

--- a/deltacat/constants.py
+++ b/deltacat/constants.py
@@ -98,8 +98,8 @@ TXN_PART_SEPARATOR = "_"
 # Storage interface defaults
 # These defaults should be applied in catalog interface implementations
 # Storage interface implementations should be agnostic to defaults and require full information
-DEFAULT_CATALOG = "DEFAULT"
-DEFAULT_NAMESPACE = "DEFAULT"
+DEFAULT_CATALOG = "default"
+DEFAULT_NAMESPACE = "default"
 DEFAULT_TABLE_VERSION = "1"
 DEFAULT_STREAM_ID = "stream"
 DEFAULT_PARTITION_ID = "partition"

--- a/deltacat/tests/compute/converter/test_convert_session.py
+++ b/deltacat/tests/compute/converter/test_convert_session.py
@@ -12,14 +12,13 @@ from pyiceberg.types import (
 from pyiceberg.partitioning import PartitionSpec, PartitionField
 from pyiceberg.transforms import IdentityTransform
 import pyarrow as pa
+import daft
 
 from deltacat.compute.converter.steps.convert import convert
 from deltacat.compute.converter.model.convert_input import ConvertInput
 from deltacat.compute.converter.pyiceberg.overrides import (
     fetch_all_bucket_files,
-    parquet_files_dict_to_iceberg_data_files,
 )
-from collections import defaultdict
 from deltacat.compute.converter.utils.converter_session_utils import (
     group_all_files_to_each_bucket,
 )
@@ -244,6 +243,8 @@ def test_converter_drop_duplicates_success(
             convert_task_index=i,
             iceberg_table_warehouse_prefix="warehouse/default",
             identifier_fields=["primary_key"],
+            table_io=tbl.io,
+            table_metadata=tbl.metadata,
             compact_small_files=False,
             enforce_primary_key_uniqueness=True,
             position_delete_for_multiple_data_files=True,
@@ -273,38 +274,31 @@ def test_converter_drop_duplicates_success(
         [number_partitioned_array_3, primary_key_array_3], names=names
     )
 
+    daft_df_1 = daft.from_arrow(data_table_1)
+    daft_df_2 = daft.from_arrow(data_table_2)
+    daft_df_3 = daft.from_arrow(data_table_3)
+
     download_data_mock = mocker.patch(
-        "deltacat.compute.converter.utils.io.download_parquet_with_daft_hash_applied"
+        "deltacat.compute.converter.utils.io.daft_read_parquet"
     )
-    download_data_mock.side_effect = (data_table_1, data_table_2, data_table_3)
+    download_data_mock.side_effect = (daft_df_1, daft_df_2, daft_df_3)
 
     convert_ref = convert.remote(convert_input)
 
     to_be_deleted_files_list = []
-    to_be_added_files_dict_list = []
+
     convert_result = ray.get(convert_ref)
 
-    partition_value = convert_input.convert_input_files.partition_value
-
+    to_be_added_files_list = []
+    # Check if there're files to delete
     if convert_result[0]:
         to_be_deleted_files_list.extend(convert_result[0].values())
+    if convert_result[1]:
+        to_be_added_files_list.extend(convert_result[1])
 
-    file_location = convert_result[1][partition_value][0]
-    to_be_added_files = f"s3://{file_location}"
-
-    to_be_added_files_dict = defaultdict()
-    to_be_added_files_dict[partition_value] = [to_be_added_files]
-    to_be_added_files_dict_list.append(to_be_added_files_dict)
-
-    # 4. Commit position delete, delete equality deletes from table
-    new_position_delete_files = parquet_files_dict_to_iceberg_data_files(
-        io=tbl.io,
-        table_metadata=tbl.metadata,
-        files_dict_list=to_be_added_files_dict_list,
-    )
     commit_append_snapshot(
         iceberg_table=tbl,
-        new_position_delete_files=new_position_delete_files,
+        new_position_delete_files=to_be_added_files_list,
     )
     tbl.refresh()
 
@@ -414,6 +408,8 @@ def test_converter_pos_delete_read_by_spark_success(
             convert_task_index=i,
             iceberg_table_warehouse_prefix="warehouse/default",
             identifier_fields=["primary_key"],
+            table_io=tbl.io,
+            table_metadata=tbl.metadata,
             compact_small_files=False,
             enforce_primary_key_uniqueness=True,
             position_delete_for_multiple_data_files=True,
@@ -434,39 +430,30 @@ def test_converter_pos_delete_read_by_spark_success(
     names = ["primary_key"]
     data_table_3 = pa.Table.from_arrays([primary_key_array_3], names=names)
 
+    daft_df_1 = daft.from_arrow(data_table_1)
+    daft_df_2 = daft.from_arrow(data_table_2)
+    daft_df_3 = daft.from_arrow(data_table_3)
+
     download_data_mock = mocker.patch(
-        "deltacat.compute.converter.utils.io.download_parquet_with_daft_hash_applied"
+        "deltacat.compute.converter.utils.io.daft_read_parquet"
     )
-    download_data_mock.side_effect = (data_table_1, data_table_2, data_table_3)
+    download_data_mock.side_effect = (daft_df_1, daft_df_2, daft_df_3)
 
     convert_ref = convert.remote(convert_input)
 
     to_be_deleted_files_list = []
-    to_be_added_files_dict_list = []
+    to_be_added_files_list = []
     convert_result = ray.get(convert_ref)
-
-    partition_value = convert_input.convert_input_files.partition_value
 
     if convert_result[0]:
         to_be_deleted_files_list.extend(convert_result[0].values())
-
-    file_location = convert_result[1][partition_value][0]
-    to_be_added_files = f"s3://{file_location}"
-
-    to_be_added_files_dict = defaultdict()
-    to_be_added_files_dict[partition_value] = [to_be_added_files]
-    to_be_added_files_dict_list.append(to_be_added_files_dict)
+    if convert_result[1]:
+        to_be_added_files_list.extend(convert_result[1])
 
     # 4. Commit position delete, delete equality deletes from table
-    new_position_delete_files = parquet_files_dict_to_iceberg_data_files(
-        io=tbl.io,
-        table_metadata=tbl.metadata,
-        files_dict_list=to_be_added_files_dict_list,
-    )
-
     commit_append_snapshot(
         iceberg_table=tbl,
-        new_position_delete_files=new_position_delete_files,
+        new_position_delete_files=to_be_added_files_list,
     )
     tbl.refresh()
 
@@ -478,3 +465,177 @@ def test_converter_pos_delete_read_by_spark_success(
     ]
     all_pk_sorted = sorted(all_pk)
     assert all_pk_sorted == ["pk1", "pk2", "pk3", "pk4"]
+
+
+@pytest.mark.integration
+def test_converter_pos_delete_multiple_identifier_fields_success(
+    spark, session_catalog: RestCatalog, setup_ray_cluster, mocker
+) -> None:
+    """
+    Test for convert compute remote function happy case. Download file results are mocked.
+    """
+
+    # 1. Create Iceberg table
+    namespace = "default"
+    table_name = "table_converter_ray_pos_delete_multiple_identifier_fields"
+
+    identifier = f"{namespace}.{table_name}"
+
+    schema = Schema(
+        NestedField(
+            field_id=1, name="number_partitioned", field_type=LongType(), required=False
+        ),
+        NestedField(
+            field_id=2, name="primary_key1", field_type=StringType(), required=False
+        ),
+        NestedField(
+            field_id=3, name="primary_key2", field_type=LongType(), required=False
+        ),
+        schema_id=0,
+    )
+
+    partition_field_identity = PartitionField(
+        source_id=1,
+        field_id=101,
+        transform=IdentityTransform(),
+        name="number_partitioned",
+    )
+    partition_spec = PartitionSpec(partition_field_identity)
+
+    properties = dict()
+    properties["write.format.default"] = "parquet"
+    properties["write.delete.mode"] = "merge-on-read"
+    properties["write.update.mode"] = "merge-on-read"
+    properties["write.merge.mode"] = "merge-on-read"
+    properties["format-version"] = "2"
+
+    drop_table_if_exists(identifier, session_catalog)
+    session_catalog.create_table(
+        identifier,
+        schema=schema,
+        partition_spec=partition_spec,
+        properties=properties,
+    )
+
+    # 2. Use Spark to generate initial data files
+    tbl = session_catalog.load_table(identifier)
+
+    run_spark_commands(
+        spark,
+        [
+            f"""
+               INSERT INTO {identifier} VALUES (0, "pk1", 1), (0, "pk2", 2), (0, "pk3", 3)
+               """
+        ],
+    )
+    run_spark_commands(
+        spark,
+        [
+            f"""
+               INSERT INTO {identifier} VALUES (0, "pk1", 1), (0, "pk2", 2), (0, "pk3", 3)
+               """
+        ],
+    )
+    run_spark_commands(
+        spark,
+        [
+            f"""
+               INSERT INTO {identifier} VALUES (0, "pk4", 1), (0, "pk2", 3), (0, "pk3", 4)
+               """
+        ],
+    )
+    tbl.refresh()
+
+    # 3. Use convert.remote() function to compute position deletes
+    data_file_dict, equality_delete_dict, pos_delete_dict = fetch_all_bucket_files(tbl)
+
+    convert_input_files_for_all_buckets = group_all_files_to_each_bucket(
+        data_file_dict=data_file_dict,
+        equality_delete_dict=equality_delete_dict,
+        pos_delete_dict=pos_delete_dict,
+    )
+
+    s3_file_system = get_s3_file_system()
+    for i, one_bucket_files in enumerate(convert_input_files_for_all_buckets):
+        convert_input = ConvertInput.of(
+            convert_input_files=one_bucket_files,
+            convert_task_index=i,
+            iceberg_table_warehouse_prefix="warehouse/default",
+            identifier_fields=["primary_key1", "primary_key2"],
+            table_io=tbl.io,
+            table_metadata=tbl.metadata,
+            compact_small_files=False,
+            enforce_primary_key_uniqueness=True,
+            position_delete_for_multiple_data_files=True,
+            max_parallel_data_file_download=10,
+            s3_file_system=s3_file_system,
+            s3_client_kwargs={},
+        )
+
+    names = ["primary_key1", "primary_key2"]
+
+    primary_key1_array_1 = pa.array(["pk1", "pk2", "pk3"])
+    primary_key2_array_1 = pa.array([1, 2, 3])
+    data_table_1 = pa.Table.from_arrays(
+        [primary_key1_array_1, primary_key2_array_1], names=names
+    )
+
+    primary_key1_array_2 = pa.array(["pk1", "pk2", "pk3"])
+    primary_key2_array_2 = pa.array([1, 2, 3])
+    data_table_2 = pa.Table.from_arrays(
+        [primary_key1_array_2, primary_key2_array_2], names=names
+    )
+
+    primary_key1_array_3 = pa.array(["pk4", "pk2", "pk3"])
+    primary_key2_array_3 = pa.array([1, 3, 4])
+    data_table_3 = pa.Table.from_arrays(
+        [primary_key1_array_3, primary_key2_array_3], names=names
+    )
+
+    daft_df_1 = daft.from_arrow(data_table_1)
+    daft_df_2 = daft.from_arrow(data_table_2)
+    daft_df_3 = daft.from_arrow(data_table_3)
+
+    download_data_mock = mocker.patch(
+        "deltacat.compute.converter.utils.io.daft_read_parquet"
+    )
+    download_data_mock.side_effect = (daft_df_1, daft_df_2, daft_df_3)
+
+    convert_ref = convert.remote(convert_input)
+
+    to_be_deleted_files_list = []
+    to_be_added_files_list = []
+    convert_result = ray.get(convert_ref)
+
+    if convert_result[0]:
+        to_be_deleted_files_list.extend(convert_result[0].values())
+    if convert_result[1]:
+        to_be_added_files_list.extend(convert_result[1])
+
+    # 4. Commit position delete, delete equality deletes from table
+
+    commit_append_snapshot(
+        iceberg_table=tbl,
+        new_position_delete_files=to_be_added_files_list,
+    )
+    tbl.refresh()
+
+    # 5. Result assertion: Expected unique primary keys to be kept
+    pyiceberg_scan_table_rows = tbl.scan().to_arrow().to_pydict()
+    expected_result_tuple_list = [
+        ("pk1", 1),
+        ("pk2", 2),
+        ("pk2", 3),
+        ("pk3", 3),
+        ("pk3", 4),
+        ("pk4", 1),
+    ]
+    pk_combined_res = []
+    for pk1, pk2 in zip(
+        pyiceberg_scan_table_rows["primary_key1"],
+        pyiceberg_scan_table_rows["primary_key2"],
+    ):
+        pk_combined_res.append((pk1, pk2))
+
+    # Assert elements are same disregard ordering in list
+    assert sorted(pk_combined_res) == sorted(expected_result_tuple_list)

--- a/deltacat/tests/experimental/daft/test_deltacat_daft_integration.py
+++ b/deltacat/tests/experimental/daft/test_deltacat_daft_integration.py
@@ -67,7 +67,7 @@ class TestCatalogIntegration:
         assert table2.name == table_name
 
         # 3. With namespace. DeltaCAT used the default namespace since it was not provided
-        table3 = daft_catalog.get_table(Identifier("DEFAULT", table_name))
+        table3 = daft_catalog.get_table(Identifier("default", table_name))
         assert table3 is not None
         assert table3.name == table_name
 

--- a/deltacat/tests/storage/rivulet/test_dataset.py
+++ b/deltacat/tests/storage/rivulet/test_dataset.py
@@ -57,7 +57,7 @@ def test_dataset_creation_metadata_structure(tmp_path):
     dataset = Dataset(dataset_name="test_dataset", metadata_uri=str(tmp_path))
 
     assert dataset._metadata_folder.startswith(".riv-meta")
-    assert dataset._namespace == "DEFAULT"
+    assert dataset._namespace == "default"
     assert dataset.dataset_name == "test_dataset"
     assert dataset._metadata_path == str(tmp_path / ".riv-meta-test_dataset")
 


### PR DESCRIPTION
## Summary

This PR mainly includes two additions:
1. Adds support for concatenating multiple identifier hash column values to evaluate value equality when enforcing identifier column uniqueness.
2. Refactor parquet file to Iceberg data file conversion to be Ray distributed tasks. Observed that when testing with scale, Pyiceberg function `parquet_file_to_iceberg_data_file` calls `parquet.download_metadata` and `filesystem._get_file_info()` under the hood, which are performance bottlenecks. So refactor the conversion functions to be Ray distributed tasks.

## Rationale

Explain the reasoning behind the changes and their benefits to the project.

## Changes
1. Adding concatenating hash column value logic.
2. Unit tests for multiple identifier value test case.

## Impact

Discuss any potential impacts the changes may have on existing functionalities.

## Testing

Describe how the changes have been tested, including both automated and manual testing strategies.
If this is a bugfix, explain how the fix has been tested to ensure the bug is resolved without introducing new issues.

## Regression Risk

If this is a bugfix, assess the risk of regression caused by this fix and steps taken to mitigate it.

## Checklist

- [x] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
