### PR TITLE
chore: upgrade daft version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # In short, if you change it here, PLEASE also change it in setup.py.
 aws-embedded-metrics == 3.2.0
 boto3 ~= 1.34
-getdaft >= 0.4.11
+daft >= 0.4.13
 intervaltree == 3.1.0
 msgpack ~= 1.0.7
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
         # any changes here should also be reflected in requirements.txt
         "aws-embedded-metrics == 3.2.0",
         "boto3 ~= 1.34",
-        "getdaft >= 0.4.11",
+        "daft >= 0.4.13",
         "intervaltree == 3.1.0",
         "numpy == 1.21.5",
         "pandas == 1.3.5",


### PR DESCRIPTION
## Summary

bump up daft version to 0.4.13 which is compatible with AL2.

## Test
- e2e Iceberg read example works