### PR TITLE
Updated merge key validation to allow PyArrow large_strings

### DIFF
--- a/deltacat/storage/model/schema.py
+++ b/deltacat/storage/model/schema.py
@@ -310,8 +310,8 @@ class Field(dict):
 
     @staticmethod
     def _validate_merge_key(field: pa.Field):
-        if not (pa.types.is_string(field.type) or pa.types.is_primitive(field.type)):
-            raise ValueError(f"Merge key {field} must be a primitive type.")
+        if not (pa.types.is_string(field.type) or pa.types.is_primitive(field.type) or pa.types.is_large_string(field.type)):
+            raise ValueError(f"Merge key {field} must be a primitive type or large string.")
         if pa.types.is_floating(field.type):
             raise ValueError(f"Merge key {field} cannot be floating point.")
 

--- a/deltacat/storage/model/schema.py
+++ b/deltacat/storage/model/schema.py
@@ -310,8 +310,15 @@ class Field(dict):
 
     @staticmethod
     def _validate_merge_key(field: pa.Field):
-        if not (pa.types.is_string(field.type) or pa.types.is_primitive(field.type) or pa.types.is_large_string(field.type)):
-            raise ValueError(f"Merge key {field} must be a primitive type or large string.")
+        # Note: large_strings were explicitly allowed for compatibility with PyIceberg Iceberg Schema to PyArrow converter
+        if not (
+            pa.types.is_string(field.type)
+            or pa.types.is_primitive(field.type)
+            or pa.types.is_large_string(field.type)
+        ):
+            raise ValueError(
+                f"Merge key {field} must be a primitive type or large string."
+            )
         if pa.types.is_floating(field.type):
             raise ValueError(f"Merge key {field} cannot be floating point.")
 


### PR DESCRIPTION
## Summary
Updated merge key validation to allow PyArrow large_strings

## Rationale

Reading Iceberg table yielded error due to merge key field type, no real reason to exclude large_strings. 

## Changes

Updated _validate_merge_key to allow PyArrow large_strings as well. 

## Impact

## Testing

Unit testing, build passed.

## Regression Risk

N/A

## Checklist

- [x] Unit tests covering the changes have been added

- [x] E2E testing has been performed

## Additional Notes

Related issues/context:
https://github.com/apache/iceberg-python/issues/1128
https://github.com/apache/iceberg-python/pull/929#issuecomment-2239084293 
