### PR TITLE
Added partition-level predicate pushdown for Iceberg

### DIFF
--- a/deltacat/experimental/storage/iceberg/iceberg_scan_planner.py
+++ b/deltacat/experimental/storage/iceberg/iceberg_scan_planner.py
@@ -1,16 +1,50 @@
-from typing import Optional
+import logging
+from typing import Optional, Any, Set
 
 from pyiceberg.catalog import Catalog
-from deltacat.storage.model.scan.push_down import Pushdown
+from pyiceberg.table import Table
+import deltacat.logs as logs
+
+from deltacat.storage.model.scan.push_down import Pushdown, PartitionFilter
 from deltacat.storage.model.scan.scan_plan import ScanPlan
 from deltacat.storage.model.scan.scan_task import FileScanTask, DataFile
 from deltacat.storage.util.scan_planner import ScanPlanner
 from deltacat.experimental.storage.iceberg.impl import _try_load_iceberg_table
+from deltacat.experimental.storage.iceberg.visitor import IcebergExpressionVisitor
+
+# Initialize DeltaCAT logger
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
 
 
 class IcebergScanPlanner(ScanPlanner):
     def __init__(self, catalog: Catalog):
         self.catalog = catalog
+        self.expression_visitor = IcebergExpressionVisitor()
+
+    @classmethod
+    def _collect_filter_fields(cls, expr: Any) -> Set[str]:
+        """
+        Collects all field names referenced in the filter expression.
+
+        Args:
+            expr: The expression to analyze
+
+        Returns:
+            Set of field names referenced in the expression
+        """
+        fields = set()
+        if hasattr(expr, "field"):
+            fields.add(expr.field)
+        if hasattr(expr, "left"):
+            fields.update(cls._collect_filter_fields(expr.left))
+        if hasattr(expr, "right"):
+            fields.update(cls._collect_filter_fields(expr.right))
+        if hasattr(expr, "expr"):
+            fields.update(cls._collect_filter_fields(expr.expr))
+        if hasattr(expr, "values"):
+            for value in expr.values:
+                fields.update(cls._collect_filter_fields(value))
+        return fields
 
     def create_scan_plan(
         self,
@@ -21,8 +55,75 @@ class IcebergScanPlanner(ScanPlanner):
         iceberg_table = _try_load_iceberg_table(
             self.catalog, namespace=namespace, table_name=table_name
         )
+
+        # TODO: implement row, column predicate pushdown to Iceberg
+
+        # Get the partition spec
+        partition_spec = iceberg_table.spec()
+
+        # Check if the table is partitioned
+        is_partitioned = len(partition_spec.fields) > 0
+
+        scan = iceberg_table.scan()
+        if is_partitioned:
+            if pushdown and pushdown.partition_filter:
+                filter_fields = self._collect_filter_fields(pushdown.partition_filter)
+                logger.info(
+                    f"Pushdown partition filter is enabled, converting to Iceberg. Fields discovered in filter: {', '.join(sorted(filter_fields))}"
+                )
+                # Handle partition filter if present, DeltaCAT only supports partition-level filters right now
+                iceberg_expression = self._convert_partition_filter(
+                    iceberg_table, pushdown.partition_filter
+                )
+                scan = scan.filter(iceberg_expression)
+
         file_scan_tasks = []
-        # TODO: implement predicate pushdown to Iceberg
-        for scan_task in iceberg_table.scan().plan_files():
+        for scan_task in scan.plan_files():
             file_scan_tasks.append(FileScanTask([DataFile(scan_task.file.file_path)]))
         return ScanPlan(file_scan_tasks)
+
+    @classmethod
+    def _validate_partition_references(
+        cls, expr: Any, partition_cols: Set[str]
+    ) -> None:
+        """
+        Validates that the expression only references partition columns.
+
+        Args:
+            expr: The expression to validate
+            partition_cols: Set of valid partition column names
+
+        Raises:
+            ValueError: If the expression references a non-partition column
+        """
+        if hasattr(expr, "field"):  # Reference type expression
+            if expr.field not in partition_cols:
+                raise ValueError(
+                    f"Filter references non-partition column: {expr.field}. "
+                    f"Partition columns are: {partition_cols}"
+                )
+        # Recursively validate nested expressions
+        if hasattr(expr, "left"):
+            cls._validate_partition_references(expr.left, partition_cols)
+        if hasattr(expr, "right"):
+            cls._validate_partition_references(expr.right, partition_cols)
+        if hasattr(expr, "expr"):
+            cls._validate_partition_references(expr.expr, partition_cols)
+        if hasattr(expr, "values"):
+            for value in expr.values:
+                cls._validate_partition_references(value, partition_cols)
+
+    def _convert_partition_filter(
+        self, table: Table, partition_filter: PartitionFilter
+    ):
+        """
+        Convert DeltaCAT partition filter to PyIceberg expression,
+        validating that only partition columns are referenced.
+        """
+        partition_cols = set(field.name for field in table.spec().fields)
+
+        # Validate before converting
+        self._validate_partition_references(partition_filter, partition_cols)
+
+        # Convert to PyIceberg expression
+        return self.expression_visitor.visit(partition_filter)

--- a/deltacat/experimental/storage/iceberg/visitor.py
+++ b/deltacat/experimental/storage/iceberg/visitor.py
@@ -1,0 +1,119 @@
+import logging
+from typing import Any
+
+import pyarrow
+from deltacat.storage.model.scan.push_down import PartitionFilter
+
+import deltacat.logs as logs
+from deltacat.storage.model.expression import Reference, Literal
+from deltacat.storage.model.expression.visitor import ExpressionVisitor
+from pyiceberg.expressions import (
+    And,
+    Or,
+    Not,
+    EqualTo,
+    NotEqualTo,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+    IsNull,
+    In,
+)
+
+# Initialize DeltaCAT logger
+logger = logs.configure_deltacat_logger(logging.getLogger(__name__))
+
+
+class IcebergExpressionVisitor(ExpressionVisitor[None, Any]):
+    """
+    Visitor that translates DeltaCAT expressions to PyIceberg expressions.
+    """
+
+    def visit(self, expr, context=None):
+        # Handle PartitionFilter by extracting and visiting the inner expression
+        if isinstance(expr, PartitionFilter):
+            return self.visit(expr.expr, context)
+        # Handle all other expressions using the parent's visit method
+        return super().visit(expr, context)
+
+    def visit_reference(self, expr: Reference, context=None) -> str:
+        return expr.field
+
+    def visit_literal(self, expr: Literal, context=None) -> Any:
+        # Convert PyArrow scalar to Python native type
+        return (
+            expr.value.as_py() if isinstance(expr.value, pyarrow.Scalar) else expr.value
+        )
+
+    def visit_and(self, expr, context=None):
+        left = self.visit(expr.left, context)
+        right = self.visit(expr.right, context)
+        return And(left, right)
+
+    def visit_or(self, expr, context=None):
+        left = self.visit(expr.left, context)
+        right = self.visit(expr.right, context)
+        return Or(left, right)
+
+    def visit_not(self, expr, context=None):
+        operand = self.visit(expr.operand, context)
+        return Not(operand)
+
+    def visit_equal(self, expr, context=None):
+        left = self.visit(expr.left, context)
+        right = self.visit(expr.right, context)
+        return EqualTo(left, right)
+
+    def visit_not_equal(self, expr, context=None):
+        left = self.visit(expr.left, context)
+        right = self.visit(expr.right, context)
+        return NotEqualTo(left, right)
+
+    def visit_greater_than(self, expr, context=None):
+        left = self.visit(expr.left, context)
+        right = self.visit(expr.right, context)
+        return GreaterThan(left, right)
+
+    def visit_greater_than_equal(self, expr, context=None):
+        left = self.visit(expr.left, context)
+        right = self.visit(expr.right, context)
+        return GreaterThanOrEqual(left, right)
+
+    def visit_less_than(self, expr, context=None):
+        left = self.visit(expr.left, context)
+        right = self.visit(expr.right, context)
+        return LessThan(left, right)
+
+    def visit_less_than_equal(self, expr, context=None):
+        left = self.visit(expr.left, context)
+        right = self.visit(expr.right, context)
+        return LessThanOrEqual(left, right)
+
+    def visit_is_null(self, expr, context=None):
+        operand = self.visit(expr.operand, context)
+        return IsNull(operand)
+
+    def visit_in(self, expr, context=None):
+        value = self.visit(expr.value, context)
+        values = [self.visit(v, context) for v in expr.values]
+        return In(value, values)
+
+    def visit_between(self, expr, context=None):
+        value = self.visit(expr.value, context)
+        lower = self.visit(expr.lower, context)
+        upper = self.visit(expr.upper, context)
+        return And(GreaterThanOrEqual(value, lower), LessThanOrEqual(value, upper))
+
+    # PyIceberg does not have a direct equivalent of LIKE
+    def visit_like(self, expr, context=None):
+        value = self.visit(expr.value, context)
+        pattern = self.visit(expr.pattern, context)
+        logger.warning(
+            f"LIKE operation is not supported in PyIceberg. Ignoring LIKE filter: {value} LIKE '{pattern}'. "
+            "This may result in more data being returned than expected."
+        )
+        # Return None or a default expression that won't filter anything
+        return (
+            None  # or return NotEqualTo(value, None)  # matches everything except NULL
+        )

--- a/deltacat/tests/experimental/storage/iceberg/test_visitor.py
+++ b/deltacat/tests/experimental/storage/iceberg/test_visitor.py
@@ -1,0 +1,178 @@
+import pytest
+import pyarrow as pa
+from datetime import date, datetime
+from unittest.mock import patch
+
+from deltacat.storage.model.expression import (
+    Reference,
+    Literal,
+    Equal,
+    NotEqual,
+    GreaterThan,
+    LessThan,
+    GreaterThanEqual,
+    LessThanEqual,
+    And,
+    Or,
+    Not,
+    In,
+    Between,
+    Like,
+    IsNull,
+)
+
+from deltacat.experimental.storage.iceberg.visitor import IcebergExpressionVisitor
+from pyiceberg.expressions import (
+    And as IceAnd,
+    Or as IceOr,
+    Not as IceNot,
+    EqualTo,
+    NotEqualTo,
+    GreaterThan as IceGreaterThan,
+    LessThan as IceLessThan,
+    GreaterThanOrEqual,
+    LessThanOrEqual,
+    IsNull as IceIsNull,
+    In as IceIn,
+)
+
+
+@pytest.fixture
+def iceberg_visitor():
+    return IcebergExpressionVisitor()
+
+
+class TestIcebergExpressionVisitor:
+    """
+    Tests for the PyIceberg expression visitor.
+    """
+
+    def test_references(self, iceberg_visitor):
+        """Tests that references are formatted correctly."""
+        assert iceberg_visitor.visit(Reference("partition_key")) == "partition_key"
+        assert iceberg_visitor.visit(Reference("year")) == "year"
+        assert (
+            iceberg_visitor.visit(Reference("complex_name_with_underscores"))
+            == "complex_name_with_underscores"
+        )
+
+    def test_string_literals(self, iceberg_visitor):
+        """Tests that string literals are properly quoted."""
+        assert iceberg_visitor.visit(Literal(pa.scalar("value"))) == "value"
+        assert (
+            iceberg_visitor.visit(Literal(pa.scalar("contains'quote")))
+            == "contains'quote"
+        )
+        assert iceberg_visitor.visit(Literal(pa.scalar(""))) == ""
+
+    def test_numeric_literals(self, iceberg_visitor):
+        """Tests that numeric literals are formatted correctly."""
+        assert iceberg_visitor.visit(Literal(pa.scalar(42))) == 42
+        assert iceberg_visitor.visit(Literal(pa.scalar(3.14))) == 3.14
+        assert iceberg_visitor.visit(Literal(pa.scalar(0))) == 0
+        assert iceberg_visitor.visit(Literal(pa.scalar(-10))) == -10
+
+    def test_boolean_literals(self, iceberg_visitor):
+        """Tests that boolean literals are formatted correctly."""
+        assert iceberg_visitor.visit(Literal(pa.scalar(True))) is True
+        assert iceberg_visitor.visit(Literal(pa.scalar(False))) is False
+
+    def test_date_timestamp_literals(self, iceberg_visitor):
+        """Tests that date and timestamp literals are formatted correctly."""
+        test_date = date(2023, 1, 15)
+        test_datetime = datetime(2023, 1, 15, 14, 30, 45)
+        assert iceberg_visitor.visit(Literal(pa.scalar(test_date))) == test_date
+        assert iceberg_visitor.visit(Literal(pa.scalar(test_datetime))) == test_datetime
+
+    def test_null_literal(self, iceberg_visitor):
+        """Tests that NULL values are formatted correctly."""
+        assert iceberg_visitor.visit(Literal(pa.scalar(None))) is None
+
+    def test_comparison_operators(self, iceberg_visitor):
+        """Tests comparison operators formatting."""
+        year_ref = Reference("year")
+        year_val = Literal(pa.scalar(2023))
+
+        assert isinstance(iceberg_visitor.visit(Equal(year_ref, year_val)), EqualTo)
+        assert isinstance(
+            iceberg_visitor.visit(NotEqual(year_ref, year_val)), NotEqualTo
+        )
+        assert isinstance(
+            iceberg_visitor.visit(GreaterThan(year_ref, year_val)), IceGreaterThan
+        )
+        assert isinstance(
+            iceberg_visitor.visit(LessThan(year_ref, year_val)), IceLessThan
+        )
+        assert isinstance(
+            iceberg_visitor.visit(GreaterThanEqual(year_ref, year_val)),
+            GreaterThanOrEqual,
+        )
+        assert isinstance(
+            iceberg_visitor.visit(LessThanEqual(year_ref, year_val)), LessThanOrEqual
+        )
+
+    def test_logical_operators(self, iceberg_visitor):
+        """Tests logical operators formatting."""
+        year_expr = Equal(Reference("year"), Literal(pa.scalar(2023)))
+        month_expr = Equal(Reference("month"), Literal(pa.scalar(1)))
+
+        assert isinstance(iceberg_visitor.visit(And(year_expr, month_expr)), IceAnd)
+        assert isinstance(iceberg_visitor.visit(Or(year_expr, month_expr)), IceOr)
+        assert isinstance(iceberg_visitor.visit(Not(year_expr)), IceNot)
+
+    def test_is_null(self, iceberg_visitor):
+        """Tests IS NULL formatting."""
+        assert isinstance(
+            iceberg_visitor.visit(IsNull(Reference("partition_key"))), IceIsNull
+        )
+
+    def test_in_operator(self, iceberg_visitor):
+        """Tests IN operator formatting."""
+        region_values = [
+            Literal(pa.scalar("us-east-1")),
+            Literal(pa.scalar("us-west-2")),
+            Literal(pa.scalar("eu-west-1")),
+        ]
+        in_expr = In(Reference("region"), region_values)
+        assert isinstance(iceberg_visitor.visit(in_expr), IceIn)
+
+    def test_between_operator(self, iceberg_visitor):
+        """Tests BETWEEN operator formatting."""
+        between_expr = Between(
+            Reference("month"), Literal(pa.scalar(1)), Literal(pa.scalar(3))
+        )
+        result = iceberg_visitor.visit(between_expr)
+        assert isinstance(result, IceAnd)
+        assert isinstance(result.left, GreaterThanOrEqual)
+        assert isinstance(result.right, LessThanOrEqual)
+
+    def test_like_operator(self, iceberg_visitor):
+        """Tests LIKE operator formatting, LIKE is not supported"""
+        like_expr = Like(Reference("filename"), Literal(pa.scalar("%data%.parquet")))
+
+        with patch(
+            "deltacat.experimental.storage.iceberg.visitor.logger"
+        ) as mock_logger:
+            result = iceberg_visitor.visit(like_expr)
+            assert result is None
+            mock_logger.warning.assert_called_once()
+            warning_message = mock_logger.warning.call_args[0][0]
+            assert "LIKE operation is not supported in PyIceberg" in warning_message
+
+    def test_complex_expression(self, iceberg_visitor):
+        """Tests a complex, nested expression."""
+        year_expr = Equal(Reference("year"), Literal(pa.scalar(2023)))
+        month_expr = Between(
+            Reference("month"), Literal(pa.scalar(1)), Literal(pa.scalar(3))
+        )
+        region_values = [
+            Literal(pa.scalar("us-east-1")),
+            Literal(pa.scalar("us-west-2")),
+        ]
+        region_expr = In(Reference("region"), region_values)
+        complex_expr = Or(And(year_expr, month_expr), region_expr)
+
+        result = iceberg_visitor.visit(complex_expr)
+        assert isinstance(result, IceOr)
+        assert isinstance(result.left, IceAnd)
+        assert isinstance(result.right, IceIn)


### PR DESCRIPTION
## Summary

Added partition-level predicate pushdown for Iceberg.

## Rationale

To-do

## Changes

Added a DeltaCAT to PyIceberg expression visitor to utilize PyIceberg APIs for partition-level predicate pushdown, along with corresponding test suites. Updated IcebergScanPlanner to use said APIs if applicable.

## Impact

Discuss any potential impacts the changes may have on existing functionalities.

## Testing

Unit tests, integration tests, etc all pass.

## Regression Risk

If this is a bugfix, assess the risk of regression caused by this fix and steps taken to mitigate it.

## Checklist

- [x] Unit tests covering the changes have been added
- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
