### PR TITLE
Rudimentary catalog init refactoring to use a config file

### DIFF
--- a/deltacat/catalog/model/catalog.py
+++ b/deltacat/catalog/model/catalog.py
@@ -231,7 +231,7 @@ def init(
     if catalogs and config_path is None:
         # Only dump if the catalogs are config-backed
         try:
-            dump_catalogs_to_yaml(catalogs)
+            _dump_catalogs_to_yaml(catalogs)
         except TypeError:
             logger.debug(
                 "Skipping dumping catalogs to YAML: non-CatalogProperties inner"
@@ -432,7 +432,7 @@ def put_catalog(
         existing_catalogs[name] = catalog
 
         # Now write back full merged dictionary
-        dump_catalogs_to_yaml(existing_catalogs, single_if_default=False)
+        _dump_catalogs_to_yaml(existing_catalogs, single_if_default=False)
 
     except Exception as e:
         logger.warning(f"Failed to persist catalog {name} to config file: {e}")
@@ -440,7 +440,7 @@ def put_catalog(
     return catalog
 
 
-def dump_catalogs_to_yaml(
+def _dump_catalogs_to_yaml(
     catalogs: Union[
         Dict[str, Union[Catalog, CatalogProperties]], Catalog, CatalogProperties
     ],

--- a/deltacat/catalog/model/catalog.py
+++ b/deltacat/catalog/model/catalog.py
@@ -2,16 +2,19 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from types import ModuleType
 
 from typing import Any, Dict, List, Optional, Union
 from functools import partial
 import ray
+import yaml
 
 from deltacat import logs
 from deltacat.catalog.main import impl as dcat
 from deltacat.catalog.model.properties import CatalogProperties
-from deltacat.constants import DEFAULT_CATALOG
+from deltacat.constants import DEFAULT_CATALOG, DELTACAT_CONFIG_PATH
+from deltacat.utils.config_loader import load_catalog_configs_from_yaml
 
 all_catalogs: Optional[ray.actor.ActorHandle] = None
 
@@ -182,6 +185,7 @@ def init(
     ray_init_args: Dict[str, Any] = {},
     *,
     force=False,
+    config_path: Optional[str] = None,
 ) -> Optional[ray.runtime.BaseContext]:
     """
     Initialize DeltaCAT catalogs.
@@ -201,6 +205,37 @@ def init(
     if is_initialized() and not force:
         logger.warning("DeltaCAT already initialized.")
         return None
+
+    # If catalogs are provided and a config_path is also provided, raise ValueError
+    if catalogs and config_path is not None:
+        raise ValueError(
+            "Cannot provide both `catalogs` and `config_path`. Please provide "
+            "only one of these parameters."
+        )
+    # If no catalogs provided but a config_path exists, load configs from file
+    if not catalogs and config_path is not None:
+        catalogs = load_catalog_configs_from_yaml(config_path=config_path)
+
+    # If neither catalogs nor config_path provided → try default location
+    if not catalogs and config_path is None:
+        cfg_path = Path(DELTACAT_CONFIG_PATH).expanduser()
+        if cfg_path.exists():
+            logger.info(f"Loading catalog configs from default path: {cfg_path}")
+            catalogs = load_catalog_configs_from_yaml(str(cfg_path))
+        else:
+            logger.info(
+                "No catalogs specified and no config file found at default path."
+            )
+
+    # If catalogs provided but no config_path exists, create a config file
+    if catalogs and config_path is None:
+        # Only dump if the catalogs are config-backed
+        try:
+            dump_catalogs_to_yaml(catalogs)
+        except TypeError:
+            logger.debug(
+                "Skipping dumping catalogs to YAML: non-CatalogProperties inner"
+            )
 
     # initialize ray (and ignore reinitialization errors)
     ray_init_args["ignore_reinit_error"] = True
@@ -324,7 +359,8 @@ def put_catalog(
 ) -> Catalog:
     """
     Add a named catalog to the global map of named catalogs. Initializes
-    DeltaCAT if not already initialized.
+    DeltaCAT if not already initialized, and persists the catalog
+    set to DELTACAT_CONFIG_PATH (merge if exists).
 
     Args:
         name: Name of the catalog.
@@ -351,35 +387,116 @@ def put_catalog(
         catalog = Catalog(**kwargs)
     if name is None:
         raise ValueError("Catalog name cannot be None")
-
-    # Initialize, if necessary
+    # Initialize if necessary
     if not is_initialized():
-        # We are initializing a single catalog - make it the default
         if not default:
             logger.info(
                 f"Calling put_catalog with set_as_default=False, "
-                f"but still setting Catalog {catalog} as default since it is "
+                f"but still setting Catalog {catalog} as default since it's "
                 f"the only catalog."
             )
         init({name: catalog}, ray_init_args=ray_init_args)
-        return catalog
+    else:
+        # Fail if requested
+        if fail_if_exists:
+            try:
+                get_catalog(name)
+                raise ValueError(
+                    f"Failed to put catalog {name} because it already exists "
+                    f"and fail_if_exists={fail_if_exists}"
+                )
+            except ValueError as e:
+                if "not found" not in str(e):
+                    raise
+                # Doesn't exist → safe to add
 
-    # Fail if fail_if_exists and catalog already exists
-    if fail_if_exists:
-        try:
-            get_catalog(name)
-            # If we get here, catalog exists - raise error
-            raise ValueError(
-                f"Failed to put catalog {name} because it already exists and "
-                f"fail_if_exists={fail_if_exists}"
-            )
-        except ValueError as e:
-            if "not found" not in str(e):
-                # Re-raise if it's not a "catalog not found" error
-                raise
-            # If catalog doesn't exist, continue normally
-            pass
+        # Register in memory
+        ray.get(all_catalogs.put.remote(name, catalog, default))
 
-    # Add the catalog (which may overwrite existing if fail_if_exists=False)
-    ray.get(all_catalogs.put.remote(name, catalog, default))
+    # --- Persist to disk (merge behavior) ---
+    try:
+        cfg_path = Path(DELTACAT_CONFIG_PATH).expanduser()
+        existing_catalogs = {}
+
+        if cfg_path.exists():
+            try:
+                loaded = load_catalog_configs_from_yaml(str(cfg_path))
+                # Wrap into Catalog so dump_catalogs_to_yaml can handle uniformly
+                existing_catalogs = {
+                    n: Catalog(config=props) for n, props in loaded.items()
+                }
+            except Exception as e:
+                logger.warning(f"Failed to load existing catalog config file: {e}")
+
+        # Merge / overwrite with the new catalog
+        existing_catalogs[name] = catalog
+
+        # Now write back full merged dictionary
+        dump_catalogs_to_yaml(existing_catalogs, single_if_default=False)
+
+    except Exception as e:
+        logger.warning(f"Failed to persist catalog {name} to config file: {e}")
+
     return catalog
+
+
+def dump_catalogs_to_yaml(
+    catalogs: Union[
+        Dict[str, Union[Catalog, CatalogProperties]], Catalog, CatalogProperties
+    ],
+    *,
+    single_if_default: bool = True,
+) -> None:
+    """
+    Write Catalog configs (Catalogs or CatalogProperties) to YAML.
+
+    - Supports Dict[str, Catalog], Dict[str, CatalogProperties],
+      a single Catalog, or a single CatalogProperties.
+    - If single_if_default=True and only one entry ("default"),
+      emit a flat config instead of mapping.
+    """
+    from pathlib import Path
+
+    def props_to_dict(inner: Any) -> dict:
+        if isinstance(inner, CatalogProperties):
+            return {
+                "root": getattr(inner, "root", None),
+                "filesystem": None,
+                "storage": None,
+            }
+        elif isinstance(inner, dict):  # for test mocks
+            return inner
+        else:
+            raise TypeError(
+                f"Cannot dump config: expected CatalogProperties or dict, got {type(inner)}"
+            )
+
+    # Normalize to {name: CatalogProperties}
+    if isinstance(catalogs, Catalog):
+        catalogs = {"default": catalogs.inner}
+    elif isinstance(catalogs, CatalogProperties):
+        catalogs = {"default": catalogs}
+    elif isinstance(catalogs, dict):
+        normalized = {}
+        for name, obj in catalogs.items():
+            if isinstance(obj, Catalog):
+                normalized[name] = obj.inner
+            elif isinstance(obj, CatalogProperties):
+                normalized[name] = obj
+            else:
+                raise TypeError(f"Unsupported catalog type: {type(obj)}")
+        catalogs = normalized
+    else:
+        raise TypeError(f"Unsupported catalogs type: {type(catalogs)}")
+
+    # Handle default flattening
+    if single_if_default and set(catalogs.keys()) == {"default"}:
+        data = props_to_dict(catalogs["default"])
+    else:
+        data = {name: props_to_dict(props) for name, props in catalogs.items()}
+
+    # Write YAML
+    config_path = Path(DELTACAT_CONFIG_PATH).expanduser()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with config_path.open("w") as f:
+        yaml.safe_dump(data, f, sort_keys=False)

--- a/deltacat/catalog/model/catalog.py
+++ b/deltacat/catalog/model/catalog.py
@@ -237,6 +237,28 @@ def init(
                 "Skipping dumping catalogs to YAML: non-CatalogProperties inner"
             )
 
+        # Normalize everything to Dict[str, Catalog] ---
+        if isinstance(catalogs, Catalog):
+            # single Catalog object
+            catalogs = {DEFAULT_CATALOG: catalogs}
+        elif isinstance(catalogs, dict):
+            normalized = {}
+            for name, obj in catalogs.items():
+                if isinstance(obj, Catalog):
+                    normalized[name] = obj
+                elif isinstance(obj, CatalogProperties):
+                    # Wrap in a Catalog
+                    normalized[name] = Catalog(config=obj)
+                else:
+                    raise TypeError(
+                        f"Unsupported object type in catalogs dict: {type(obj)}"
+                    )
+            catalogs = normalized
+        else:
+            raise TypeError(
+                f"Expected a Catalog or dict[str, Catalog|CatalogProperties], but got {type(catalogs)}"
+            )
+
     # initialize ray (and ignore reinitialization errors)
     ray_init_args["ignore_reinit_error"] = True
     context = ray.init(**ray_init_args)
@@ -350,7 +372,7 @@ def pop_catalog(name: str) -> Optional[Catalog]:
     # --- Persist removal to disk ---
     try:
         cfg_path = Path(DELTACAT_CONFIG_PATH).expanduser()
-        if cfg_path.exists():
+        if cfg_path.exists() and cfg_path.stat().st_size > 0:  # empty file check
             try:
                 # Load existing config
                 loaded = load_catalog_configs_from_yaml(str(cfg_path))
@@ -441,7 +463,7 @@ def put_catalog(
         cfg_path = Path(DELTACAT_CONFIG_PATH).expanduser()
         existing_catalogs = {}
 
-        if cfg_path.exists():
+        if cfg_path.exists() and cfg_path.stat().st_size > 0:  # empty file check
             try:
                 loaded = load_catalog_configs_from_yaml(str(cfg_path))
                 # Wrap into Catalog so dump_catalogs_to_yaml can handle uniformly
@@ -465,7 +487,9 @@ def put_catalog(
 
 def _dump_catalogs_to_yaml(
     catalogs: Union[
-        Dict[str, Union["Catalog", CatalogProperties]], "Catalog", CatalogProperties
+        Dict[str, Union["Catalog", CatalogProperties]],
+        "Catalog",
+        CatalogProperties,
     ],
     *,
     single_if_default: bool = True,
@@ -473,21 +497,29 @@ def _dump_catalogs_to_yaml(
     """
     Write Catalog configs (Catalogs or CatalogProperties) to YAML.
 
-    - Supports Dict[str, Catalog], Dict[str, CatalogProperties],
-      a single Catalog, or a single CatalogProperties.
-    - If single_if_default=True and only one entry ("default"),
-      emit a flat config instead of mapping.
+    Supports:
+        - Dict[str, Catalog]
+        - Dict[str, CatalogProperties]
+        - single Catalog
+        - single CatalogProperties
+
+    Always normalizes to {name: dict-of-primitive-keys}
     """
 
-    # Normalize to {name: CatalogProperties}
+    # Normalize inputs into { str: CatalogProperties }
     if isinstance(catalogs, Catalog):
         catalogs = {"default": catalogs.inner}
     elif isinstance(catalogs, CatalogProperties):
         catalogs = {"default": catalogs}
     elif isinstance(catalogs, dict):
-        normalized = {}
+        normalized: Dict[str, CatalogProperties] = {}
         for name, obj in catalogs.items():
             if isinstance(obj, Catalog):
+                if not isinstance(obj.inner, CatalogProperties):
+                    raise TypeError(
+                        f"Catalog.inner must be CatalogProperties for dumping, "
+                        f"got {type(obj.inner)}"
+                    )
                 normalized[name] = obj.inner
             elif isinstance(obj, CatalogProperties):
                 normalized[name] = obj
@@ -497,16 +529,16 @@ def _dump_catalogs_to_yaml(
     else:
         raise TypeError(f"Unsupported catalogs type: {type(catalogs)}")
 
-    # Handle default flattening
+    # Serialize all values to primitive dicts
     if single_if_default and set(catalogs.keys()) == {"default"}:
         data = CatalogProperties.ensure_serializable(catalogs["default"])
     else:
         data = {
-            name: CatalogProperties.ensure_serializable(obj)
-            for name, obj in catalogs.items()
+            name: CatalogProperties.ensure_serializable(props)
+            for name, props in catalogs.items()
         }
 
-    # Write YAML
+    # Write out to YAML
     config_path = Path(DELTACAT_CONFIG_PATH).expanduser()
     config_path.parent.mkdir(parents=True, exist_ok=True)
     with config_path.open("w") as f:

--- a/deltacat/catalog/model/catalog.py
+++ b/deltacat/catalog/model/catalog.py
@@ -341,10 +341,33 @@ def pop_catalog(name: str) -> Optional[Catalog]:
         The removed catalog, or None if not found.
     """
     global all_catalogs
-
     if not all_catalogs:
         return None
+
+    # Remove from in-memory actor
     catalog = ray.get(all_catalogs.pop.remote(name))
+
+    # --- Persist removal to disk ---
+    try:
+        cfg_path = Path(DELTACAT_CONFIG_PATH).expanduser()
+        if cfg_path.exists():
+            try:
+                # Load existing config
+                loaded = load_catalog_configs_from_yaml(str(cfg_path))
+                # Wrap into Catalog so _dump_catalogs_to_yaml works uniformly
+                existing_catalogs = {
+                    n: Catalog(config=props) for n, props in loaded.items()
+                }
+                if name in existing_catalogs:
+                    del existing_catalogs[name]
+
+                    # Now write full merged dictionary back to disk
+                    _dump_catalogs_to_yaml(existing_catalogs, single_if_default=False)
+            except Exception as e:
+                logger.warning(f"Failed to update catalog config file after pop: {e}")
+    except Exception as e:
+        logger.warning(f"Failed to persist catalog removal {name} to config file: {e}")
+
     return catalog
 
 

--- a/deltacat/catalog/model/catalog.py
+++ b/deltacat/catalog/model/catalog.py
@@ -442,7 +442,7 @@ def put_catalog(
 
 def _dump_catalogs_to_yaml(
     catalogs: Union[
-        Dict[str, Union[Catalog, CatalogProperties]], Catalog, CatalogProperties
+        Dict[str, Union["Catalog", CatalogProperties]], "Catalog", CatalogProperties
     ],
     *,
     single_if_default: bool = True,
@@ -455,21 +455,6 @@ def _dump_catalogs_to_yaml(
     - If single_if_default=True and only one entry ("default"),
       emit a flat config instead of mapping.
     """
-    from pathlib import Path
-
-    def props_to_dict(inner: Any) -> dict:
-        if isinstance(inner, CatalogProperties):
-            return {
-                "root": getattr(inner, "root", None),
-                "filesystem": None,
-                "storage": None,
-            }
-        elif isinstance(inner, dict):  # for test mocks
-            return inner
-        else:
-            raise TypeError(
-                f"Cannot dump config: expected CatalogProperties or dict, got {type(inner)}"
-            )
 
     # Normalize to {name: CatalogProperties}
     if isinstance(catalogs, Catalog):
@@ -491,9 +476,12 @@ def _dump_catalogs_to_yaml(
 
     # Handle default flattening
     if single_if_default and set(catalogs.keys()) == {"default"}:
-        data = props_to_dict(catalogs["default"])
+        data = CatalogProperties.ensure_serializable(catalogs["default"])
     else:
-        data = {name: props_to_dict(props) for name, props in catalogs.items()}
+        data = {
+            name: CatalogProperties.ensure_serializable(obj)
+            for name, obj in catalogs.items()
+        }
 
     # Write YAML
     config_path = Path(DELTACAT_CONFIG_PATH).expanduser()

--- a/deltacat/catalog/model/properties.py
+++ b/deltacat/catalog/model/properties.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Any
+from typing import Optional, Any, Union, Dict
 import urllib.parse
 
 import os
@@ -145,6 +145,52 @@ class CatalogProperties:
         else:
             # Relative path - prepend the s3:// scheme
             return f"{self._original_scheme}://{path}"
+
+    @staticmethod
+    def from_serializable(config: Union[Dict[str, Any], None]) -> "CatalogProperties":
+        """
+        Deserialize a config (from YAML, dict, etc.) into a CatalogProperties.
+
+        This method can handle:
+          1. A full dict-of-properties (root, filesystem, storage)
+          2. A 'primitive-only' dict (Case 1 from YAML) — still allowed
+
+        Args:
+            config: A mapping of properties.
+
+        Returns:
+            A CatalogProperties instance.
+
+        Raises:
+            ValueError: For invalid input types or malformed configs.
+        """
+        if config is None:
+            raise ValueError("Cannot construct CatalogProperties from None")
+
+        if not isinstance(config, dict):
+            raise ValueError(
+                f"Expected dict for CatalogProperties deserialization, "
+                f"got {type(config)}"
+            )
+
+        # Validation: all values must be serializable primitives or lists
+        if all(
+            isinstance(v, (str, int, float, bool, type(None), list))
+            for v in config.values()
+        ):
+            # Accept it directly
+            return CatalogProperties(**config)
+
+        # Otherwise, assume it’s a property mapping { key -> value }
+        expected_keys = {"root", "filesystem", "storage"}
+        for key in config:
+            if key not in expected_keys:
+                raise ValueError(
+                    f"Unrecognized CatalogProperties key '{key}'. "
+                    f"Expected one of {expected_keys}"
+                )
+
+        return CatalogProperties(**config)
 
     def __str__(self):
         return (

--- a/deltacat/catalog/model/properties.py
+++ b/deltacat/catalog/model/properties.py
@@ -146,6 +146,41 @@ class CatalogProperties:
             # Relative path - prepend the s3:// scheme
             return f"{self._original_scheme}://{path}"
 
+    def to_serializable(self) -> Dict[str, Any]:
+        """
+        Convert this CatalogProperties instance into a serializable dictionary,
+        suitable for dumping to YAML or JSON.
+
+        Returns:
+            dict of primitive config values.
+        """
+        return {
+            "root": getattr(self, "root", None),
+            # Non-serializable fields -> we serialize as None for now.
+            "filesystem": None,
+            "storage": None,
+        }
+
+    @staticmethod
+    def ensure_serializable(
+        obj: Union["CatalogProperties", Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """
+        Helper: normalize a CatalogProperties or dict-like (e.g. mock configs)
+        into a serializable dictionary. This allows tests/mocks to supply dicts
+        instead of CatalogProperties.
+        """
+        if isinstance(obj, CatalogProperties):
+            return obj.to_serializable()
+        elif isinstance(obj, dict):
+            # Assume dict is already serializable
+            return obj
+        else:
+            raise TypeError(
+                f"Unsupported type for serialization: {type(obj)}. "
+                f"Expected CatalogProperties or dict."
+            )
+
     @staticmethod
     def from_serializable(config: Union[Dict[str, Any], None]) -> "CatalogProperties":
         """

--- a/deltacat/constants.py
+++ b/deltacat/constants.py
@@ -45,6 +45,8 @@ DELTACAT_ROOT = env_string(
     "",
 )
 
+DELTACAT_CONFIG_PATH = env_string("DELTACAT_CONFIG_PATH", "~/.deltacat/config.yaml")
+
 # CLI Args
 METAFILE_FORMAT_JSON = "json"
 METAFILE_FORMAT_MSGPACK = "msgpack"

--- a/deltacat/tests/catalog/test_catalogs.py
+++ b/deltacat/tests/catalog/test_catalogs.py
@@ -4,6 +4,7 @@ import shutil
 import uuid
 from unittest import mock
 import os
+import yaml
 
 from deltacat.catalog import (
     CatalogProperties,
@@ -151,6 +152,49 @@ class TestCatalogsIntegration:
         default_catalog = get_catalog()
         assert default_catalog.impl == MockCatalogImpl
         assert default_catalog.inner["kwargs"]["id"] == 2
+
+    def test_init_with_config_yaml(self, tmp_path, reset_catalogs):
+        """
+        Test initializing Catalogs from a YAML config file.
+        CatalogProperties will infer filesystem and storage, so we don't
+        put actual Python objects in the YAML.
+        - load_catalog_configs_from_yaml returns a dict[str, CatalogProperties],
+        so we provide one entry keyed by a catalog name.
+        - get_catalog() with no arguments should always return the *default*
+        catalog, even if multiple catalogs are loaded. In this case we only
+        provide one catalog ("test_catalog"), so it should automatically
+        become the default.
+        """
+        # YAML data compatible with CatalogProperties
+        config_data = {
+            "test-catalog": {
+                "root": str(tmp_path),  # path for catalog metadata/data
+                "filesystem": None,  # leave None; CatalogProperties will infer filesystem
+                "storage": None,  # leave None; CatalogProperties will infer storage
+            }
+        }
+
+        # Write the YAML config file
+        config_path = tmp_path / "config.yaml"
+        with open(config_path, "w") as f:
+            yaml.dump(config_data, f)
+
+        # Initialize from the YAML config
+        init(config_path=str(config_path), force=True)
+
+        # Retrieve the default catalog (returns CatalogProperties directly)
+        catalog_props = get_catalog()  # no args → default "test-catalog"
+
+        # Should be a CatalogProperties instance
+        assert isinstance(catalog_props, CatalogProperties)
+        assert catalog_props.root == str(tmp_path)
+
+        # filesystem and storage are inferred by CatalogProperties; check types
+        import pyarrow.fs
+
+        assert isinstance(catalog_props.filesystem, pyarrow.fs.FileSystem)
+        # TODO: If storage has a default class, check its type here
+        # assert isinstance(inner.storage, ExpectedStorageClass)
 
     def test_put_catalog(self, reset_catalogs):
         """Test adding a catalog after initialization."""

--- a/deltacat/tests/catalog/test_catalogs.py
+++ b/deltacat/tests/catalog/test_catalogs.py
@@ -15,7 +15,9 @@ from deltacat.catalog import (
     init_local,
     is_initialized,
     put_catalog,
+    pop_catalog,
 )
+import deltacat.catalog as catalogs
 from deltacat.experimental.catalog.iceberg import impl as IcebergCatalog
 from pyiceberg.catalog import Catalog as PyIcebergCatalog
 
@@ -29,17 +31,13 @@ class MockCatalogImpl:
     @staticmethod
     def initialize(config, *args, **kwargs):
         # Return some state that the catalog would normally maintain
-        return {
-            "initialized": True,
-            "config": config,
-            "args": args,
-            "kwargs": kwargs,
-        }
+        return CatalogProperties(root=kwargs.get("root", "/tmp/test"))
 
 
 @pytest.fixture(scope="function")
 def reset_catalogs():
     clear_catalogs()
+    catalogs.all_catalogs = None  # reset the global actor reference
 
 
 class TestCatalog:
@@ -47,16 +45,15 @@ class TestCatalog:
 
     def test_catalog_constructor(self):
         """Test that the Catalog constructor correctly initializes with the given implementation."""
-        catalog = Catalog(impl=MockCatalogImpl)
+        # Construct a catalog with our MockCatalogImpl
+        catalog = Catalog(impl=MockCatalogImpl, root="/tmp/test")
 
-        assert catalog.impl == MockCatalogImpl
+        # The catalog should store the impl we passed
+        assert catalog.impl is MockCatalogImpl
 
-        # Check that inner state was correctly initialized
-        # This just asserts that kwargs were plumbed through from Catalog constructor
-        assert catalog.inner["initialized"]
-        assert catalog.inner["config"] is None
-        assert catalog.inner["args"] == ()
-        assert catalog.inner["kwargs"] == {}
+        # The inner state should be a CatalogProperties instance
+        assert isinstance(catalog.inner, CatalogProperties)
+        assert catalog.inner.root == "/tmp/test"
 
     def test_iceberg_factory_method(self):
         """Test the iceberg factory method correctly creates an Iceberg catalog."""
@@ -85,13 +82,9 @@ class TestCatalogsIntegration:
     @classmethod
     def setup_class(cls):
         cls.temp_dir = tempfile.mkdtemp()
-        # Other tests are going to have initialized ray catalog. Initialize here to ensure
-        # that when this test class is run individuall it mimicks running with other tests
-        catalog = Catalog(impl=MockCatalogImpl)
-        init(
-            catalog,
-            force=True,
-        )
+        # Initialize a catalog so tests start with Ray running
+        catalog = Catalog(impl=MockCatalogImpl, root=cls.temp_dir)
+        init(catalog, force=True)
 
     @classmethod
     def teardown_class(cls):
@@ -99,166 +92,105 @@ class TestCatalogsIntegration:
             shutil.rmtree(cls.temp_dir)
 
     def test_init_single_catalog(self, reset_catalogs):
-        """Test initializing a single catalog."""
-
-        catalog = Catalog(impl=MockCatalogImpl)
-
-        # Initialize with a single catalog and Ray init args including the namespace
+        catalog = Catalog(impl=MockCatalogImpl, root="/tmp/catalog1")
         init(catalog, force=True)
-
         assert is_initialized()
-
-        # Get the default catalog and check it's the same one we initialized with
-        retrieved_catalog = get_catalog()
-        assert retrieved_catalog.impl == MockCatalogImpl
-        assert retrieved_catalog.inner["initialized"]
+        retrieved = get_catalog()
+        assert isinstance(retrieved.inner, CatalogProperties)
+        assert retrieved.inner.root == "/tmp/catalog1"
 
     def test_init_multiple_catalogs(self, reset_catalogs):
-        """Test initializing multiple catalogs."""
-        # Create catalogs
-        catalog1 = Catalog(impl=MockCatalogImpl, id=1)
-        catalog2 = Catalog(impl=MockCatalogImpl, id=2)
-
-        # Initialize with multiple catalogs and Ray init args including the namespace
-        catalogs_dict = {"catalog1": catalog1, "catalog2": catalog2}
-        init(catalogs_dict, force=True)
-
+        catalog1 = Catalog(impl=MockCatalogImpl, root="/tmp/catalog1")
+        catalog2 = Catalog(impl=MockCatalogImpl, root="/tmp/catalog2")
+        init({"c1": catalog1, "c2": catalog2}, force=True)
         assert is_initialized()
-
-        # Get catalogs by name and check they're the same ones we initialized with
-        retrieved_catalog1 = get_catalog("catalog1")
-        assert retrieved_catalog1.impl == MockCatalogImpl
-        assert retrieved_catalog1.inner["kwargs"]["id"] == 1
-
-        retrieved_catalog2 = get_catalog("catalog2")
-        assert retrieved_catalog2.impl == MockCatalogImpl
-        assert retrieved_catalog2.inner["kwargs"]["id"] == 2
+        r1 = get_catalog("c1")
+        r2 = get_catalog("c2")
+        assert r1.inner.root == "/tmp/catalog1"
+        assert r2.inner.root == "/tmp/catalog2"
 
     def test_init_with_default_catalog_name(self, reset_catalogs):
-        """Test initializing with a specified default catalog name."""
-        # Create catalogs
-        catalog1 = Catalog(impl=MockCatalogImpl, id=1)
-        catalog2 = Catalog(impl=MockCatalogImpl, id=2)
-
-        # Initialize with multiple catalogs and specify a default
-        catalogs_dict = {"catalog1": catalog1, "catalog2": catalog2}
-        init(
-            catalogs_dict,
-            default="catalog2",
-            force=True,
-        )
-
-        # Get the default catalog and check it's catalog2
-        default_catalog = get_catalog()
-        assert default_catalog.impl == MockCatalogImpl
-        assert default_catalog.inner["kwargs"]["id"] == 2
+        catalog1 = Catalog(impl=MockCatalogImpl, root="/tmp/catalog1")
+        catalog2 = Catalog(impl=MockCatalogImpl, root="/tmp/catalog2")
+        init({"c1": catalog1, "c2": catalog2}, default="c2", force=True)
+        default_cat = get_catalog()
+        assert default_cat.inner.root == "/tmp/catalog2"
 
     def test_init_with_config_yaml(self, tmp_path, reset_catalogs):
-        """
-        Test initializing Catalogs from a YAML config file.
-        CatalogProperties will infer filesystem and storage, so we don't
-        put actual Python objects in the YAML.
-        - load_catalog_configs_from_yaml returns a dict[str, CatalogProperties],
-        so we provide one entry keyed by a catalog name.
-        - get_catalog() with no arguments should always return the *default*
-        catalog, even if multiple catalogs are loaded. In this case we only
-        provide one catalog ("test_catalog"), so it should automatically
-        become the default.
-        """
-        # YAML data compatible with CatalogProperties
         config_data = {
             "test-catalog": {
-                "root": str(tmp_path),  # path for catalog metadata/data
-                "filesystem": None,  # leave None; CatalogProperties will infer filesystem
-                "storage": None,  # leave None; CatalogProperties will infer storage
+                "root": str(tmp_path),
+                "filesystem": None,
+                "storage": None,
             }
         }
-
-        # Write the YAML config file
         config_path = tmp_path / "config.yaml"
         with open(config_path, "w") as f:
-            yaml.dump(config_data, f)
-
-        # Initialize from the YAML config
+            yaml.safe_dump(config_data, f)
         init(config_path=str(config_path), force=True)
-
-        # Retrieve the default catalog (returns CatalogProperties directly)
-        catalog_props = get_catalog()  # no args → default "test-catalog"
-
-        # Should be a CatalogProperties instance
+        catalog_props = get_catalog()
         assert isinstance(catalog_props, CatalogProperties)
         assert catalog_props.root == str(tmp_path)
-
-        # filesystem and storage are inferred by CatalogProperties; check types
         import pyarrow.fs
 
         assert isinstance(catalog_props.filesystem, pyarrow.fs.FileSystem)
-        # TODO: If storage has a default class, check its type here
-        # assert isinstance(inner.storage, ExpectedStorageClass)
+
+    def test_init_with_catalogs_and_config_path_raises(self, reset_catalogs):
+        cat = Catalog(impl=MockCatalogImpl, root="/tmp/test")
+        with pytest.raises(ValueError):
+            init({"c": cat}, config_path="dummy.yml", force=True)
 
     def test_put_catalog(self, reset_catalogs):
-        """Test adding a catalog after initialization."""
-        # Initialize with a single catalog
-        catalog1 = Catalog(impl=MockCatalogImpl, id=1)
-        catalog2 = Catalog(impl=MockCatalogImpl, id=2)
-        init({"catalog1": catalog1}, force=True)
-
-        # Add a second catalog
-        put_catalog("catalog2", catalog2)
-
-        # Check both catalogs are available
-        retrieved_catalog1 = get_catalog("catalog1")
-        assert retrieved_catalog1.inner["kwargs"]["id"] == 1
-
-        retrieved_catalog2 = get_catalog("catalog2")
-        assert retrieved_catalog2.inner["kwargs"]["id"] == 2
+        c1 = Catalog(impl=MockCatalogImpl, root="/tmp/catalog1")
+        c2 = Catalog(impl=MockCatalogImpl, root="/tmp/catalog2")
+        init({"c1": c1}, force=True)
+        put_catalog("c2", c2)
+        r1 = get_catalog("c1")
+        r2 = get_catalog("c2")
+        assert r1.inner.root == "/tmp/catalog1"
+        assert r2.inner.root == "/tmp/catalog2"
 
     def test_put_catalog_that_already_exists(self, reset_catalogs):
-        catalog = Catalog(impl=MockCatalogImpl, id=1)
-        catalog2 = Catalog(impl=MockCatalogImpl, id=2)
-        put_catalog(
-            "test_catalog",
-            catalog,
-            id=1,
-        )
-
-        # Try to add another catalog with the same name. Should not error
-        put_catalog(
-            "test_catalog",
-            catalog2,
-        )
-
-        retrieved_catalog = get_catalog("test_catalog")
-        assert retrieved_catalog.inner["kwargs"]["id"] == 2
-
-        # If fail_if_exists, put call should fail
+        c1 = Catalog(impl=MockCatalogImpl, root="/tmp/catalog1")
+        c2 = Catalog(impl=MockCatalogImpl, root="/tmp/catalog2")
+        put_catalog("test_catalog", c1)
+        put_catalog("test_catalog", c2)  # overwrite allowed
+        retrieved = get_catalog("test_catalog")
+        assert retrieved.inner.root == "/tmp/catalog2"
         with pytest.raises(ValueError):
-            put_catalog(
-                "test_catalog",
-                catalog,
-                fail_if_exists=True,
-            )
+            put_catalog("test_catalog", c1, fail_if_exists=True)
+
+    def test_put_catalog_persists_merge_to_yaml(self, reset_catalogs, mocker, tmp_path):
+        fake_cat = Catalog(impl=MockCatalogImpl, root="/tmp/fake")
+        cfg_path = tmp_path / "deltacat.yml"
+        mocker.patch("deltacat.constants.DELTACAT_CONFIG_PATH", str(cfg_path))
+        mocker.patch("deltacat.catalog.is_initialized", return_value=True)
+        mocker.patch(
+            "deltacat.catalog.get_catalog", side_effect=ValueError("not found")
+        )
+        dump_mock = mocker.patch(
+            "deltacat.catalog.model.catalog._dump_catalogs_to_yaml"
+        )
+        catalogs.all_catalogs = mocker.MagicMock()
+        put_catalog("foo", fake_cat)
+        dump_mock.assert_called()
 
     def test_get_catalog_nonexistent(self, reset_catalogs):
-        """Test that trying to get a nonexistent catalog raises an error."""
-        # Initialize with a catalog
-        catalog = Catalog(impl=MockCatalogImpl)
-        init({"test_catalog": catalog}, force=True)
-
-        # Try to get a nonexistent catalog
+        cat = Catalog(impl=MockCatalogImpl, root="/tmp/catalog")
+        init({"test_catalog": cat}, force=True)
         with pytest.raises(ValueError):
-            get_catalog("nonexistent")
+            get_catalog("nope")
 
     def test_get_catalog_no_default(self, reset_catalogs):
-        """Test that trying to get the default catalog when none is set raises an error."""
-        # Initialize with multiple catalogs but no default
-        catalog1 = Catalog(impl=MockCatalogImpl, id=1)
-        catalog2 = Catalog(impl=MockCatalogImpl, id=2)
-        init({"catalog1": catalog1, "catalog2": catalog2}, force=True)
-
-        # Try to get the default catalog
+        c1 = Catalog(impl=MockCatalogImpl, root="/tmp/catalog1")
+        c2 = Catalog(impl=MockCatalogImpl, root="/tmp/catalog2")
+        init({"c1": c1, "c2": c2}, force=True)
         with pytest.raises(ValueError):
             get_catalog()
+
+    def test_pop_catalog_returns_none_if_not_initialized(self, reset_catalogs):
+        catalogs.all_catalogs = None
+        assert pop_catalog("whatever") is None
 
     def test_init_local(self, reset_catalogs):
         """Test that init_local() creates a default local catalog."""

--- a/deltacat/tests/conftest.py
+++ b/deltacat/tests/conftest.py
@@ -1,6 +1,10 @@
 import tempfile
+from pathlib import Path
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
+
+from deltacat import constants
 from deltacat.catalog import CatalogProperties
 from deltacat.tests.test_utils.filesystem import temp_dir_autocleanup
 
@@ -23,3 +27,30 @@ def keep_temp_dir():
 @pytest.fixture
 def temp_catalog_properties(temp_dir):
     return CatalogProperties(root=temp_dir)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def temp_deltacat_config_path():
+
+    """
+    Force all tests to write their catalog configs to a temporary YAML file,
+    rather than the developer's real DELTACAT_CONFIG_PATH.
+    """
+    tmpfile = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False)
+    print(">> Using temp config path:", tmpfile.name)
+    tmpfile.close()
+
+    mp = MonkeyPatch()
+    mp.setenv("DELTACAT_CONFIG_PATH", tmpfile.name)
+
+    # Also patch the constants module
+    constants.DELTACAT_CONFIG_PATH = tmpfile.name
+
+    yield tmpfile.name
+
+    # Undo patches and cleanup
+    mp.undo()
+    try:
+        Path(tmpfile.name).unlink()
+    except FileNotFoundError:
+        pass

--- a/deltacat/utils/config_loader.py
+++ b/deltacat/utils/config_loader.py
@@ -26,22 +26,13 @@ def load_catalog_configs_from_yaml(config_path: str) -> Dict[str, CatalogPropert
             f"Invalid YAML format in {config_path}. "
             f"Expected a dict, got {type(config_data)}"
         )
+    # Case 1: dict of named configs (every value is itself a dict)
+    if all(isinstance(v, dict) for v in config_data.values()):
+        return {
+            name: CatalogProperties.from_serializable(props)
+            for name, props in config_data.items()
+        }
 
-    # Case 1: single unnamed config
+    # Case 2: single unnamed config
     # e.g. {"type": "iceberg", "uri": "...", "warehouse": "prod"}
-    if all(
-        isinstance(v, (str, int, float, bool, type(None))) or isinstance(v, list)
-        for v in config_data.values()
-    ):
-        return {"default": CatalogProperties(**config_data)}
-
-    # Case 2: top-level dict of name -> dict-of-properties
-    catalogs: Dict[str, CatalogProperties] = {}
-    for name, props in config_data.items():
-        if not isinstance(props, dict):
-            raise ValueError(
-                f"Config for catalog '{name}' must be a mapping, got {type(props)}"
-            )
-        catalogs[name] = CatalogProperties(**props)
-
-    return catalogs
+    return {"default": CatalogProperties.from_serializable(config_data)}

--- a/deltacat/utils/config_loader.py
+++ b/deltacat/utils/config_loader.py
@@ -1,0 +1,47 @@
+import yaml
+from typing import Dict
+
+from deltacat.catalog.model.properties import CatalogProperties
+
+
+def load_catalog_configs_from_yaml(config_path: str) -> Dict[str, CatalogProperties]:
+    """
+    Load one or more catalog configs from a YAML file.
+
+    The YAML can either be:
+      1. A single unnamed config (a dict of properties) -> wrapped as {"default": CatalogProperties}
+      2. A dictionary of named configs: name -> property-mapping
+
+    Args:
+        config_path: Path to the YAML config file.
+
+    Returns:
+        Dict[str, CatalogProperties]: Mapping of Catalog name -> CatalogProperties.
+    """
+    with open(config_path, "r") as f:
+        config_data = yaml.safe_load(f)
+
+    if not isinstance(config_data, dict):
+        raise ValueError(
+            f"Invalid YAML format in {config_path}. "
+            f"Expected a dict, got {type(config_data)}"
+        )
+
+    # Case 1: single unnamed config
+    # e.g. {"type": "iceberg", "uri": "...", "warehouse": "prod"}
+    if all(
+        isinstance(v, (str, int, float, bool, type(None))) or isinstance(v, list)
+        for v in config_data.values()
+    ):
+        return {"default": CatalogProperties(**config_data)}
+
+    # Case 2: top-level dict of name -> dict-of-properties
+    catalogs: Dict[str, CatalogProperties] = {}
+    for name, props in config_data.items():
+        if not isinstance(props, dict):
+            raise ValueError(
+                f"Config for catalog '{name}' must be a mapping, got {type(props)}"
+            )
+        catalogs[name] = CatalogProperties(**props)
+
+    return catalogs


### PR DESCRIPTION
## Summary

Added using config.yaml file as a second choice option to initialize DeltaCAT catalog instead of relying on .init() call passing in parameters explicitly. 

## Rationale

To reduce tasks for users and expose less internal mechanisms.
## Changes

- Created config.yaml parser for initialize()
- Wrote according test
## Impact

Only adds possible functionality, backwards-compatible. 
## Testing

make test

## Checklist

- [x] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

## Additional Notes

Next steps will be to create enums and expand existing catalog types. ex. Iceberg