### PR TITLE
Updated rolling log file appenders to have 64MiB cutoff and compress …

### DIFF
--- a/deltacat/logs.py
+++ b/deltacat/logs.py
@@ -1,3 +1,4 @@
+import gzip
 import logging
 import os
 import json
@@ -33,8 +34,8 @@ DEFAULT_LOG_FORMAT = {
     "filename": "filename",
     "lineno": "lineno",
 }
-DEFAULT_MAX_BYTES_PER_LOG = 2 ^ 20 * 256  # 256 MiB
-DEFAULT_BACKUP_COUNT = 0
+DEFAULT_MAX_BYTES_PER_LOG = 2 ^ 20 * 64  # Default 64 MiB
+DEFAULT_BACKUP_COUNT = 10  # Default 10 backup files
 
 
 class JsonFormatter(logging.Formatter):
@@ -166,6 +167,24 @@ def _add_logger_handler(logger: Logger, handler: Handler) -> Logger:
     return logger
 
 
+# Subclass to compress last N log files
+class CompressingRotatingFileHandler(handlers.RotatingFileHandler):
+    """Rotating file handler that gzips rolled logs after rotation."""
+
+    def doRollover(self):
+        super().doRollover()
+
+        if self.backupCount > 0:
+            for i in range(self.backupCount, 0, -1):
+                sfn = f"{self.baseFilename}.{i}"
+                dfn = f"{sfn}.gz"
+                if os.path.exists(sfn) and not os.path.exists(dfn):
+                    with open(sfn, "rb") as f_in, open(dfn, "wb") as f_out:
+                        with gzip.GzipFile(fileobj=f_out, mode="wb") as gz_out:
+                            gz_out.writelines(f_in)
+                    os.remove(sfn)
+
+
 def _create_rotating_file_handler(
     log_directory: str,
     log_base_file_name: str,
@@ -182,7 +201,7 @@ def _create_rotating_file_handler(
     assert log_directory, "log directory is required"
     log_dir_path = pathlib.Path(log_directory)
     log_dir_path.mkdir(parents=True, exist_ok=True)
-    handler = handlers.RotatingFileHandler(
+    handler = CompressingRotatingFileHandler(
         os.path.join(log_directory, log_base_file_name),
         maxBytes=max_bytes_per_log_file,
         backupCount=backup_count,

--- a/deltacat/tests/_io/test_file_object_store.py
+++ b/deltacat/tests/_io/test_file_object_store.py
@@ -106,6 +106,17 @@ class TestFileObjectStore(unittest.TestCase):
         "deltacat.io.file_object_store.os.remove",
     )
     def test_delete_many_sanity(self, mock_remove):
+        import sys
+        import importlib
+
+        # Drop any stale module that may have been imported earlier with a mocked os
+        sys.modules.pop("deltacat.io.file_object_store", None)
+
+        # Now reload it fresh so it binds to the current, real os
+        import deltacat.io.file_object_store as fstore
+
+        importlib.reload(fstore)
+
         from deltacat.io.file_object_store import FileObjectStore
 
         object_store = FileObjectStore(dir_path="")

--- a/deltacat/tests/test_logs.py
+++ b/deltacat/tests/test_logs.py
@@ -224,3 +224,63 @@ class TestJsonFormatter(unittest.TestCase):
         )
         self.assertFalse(ray.is_initialized())
         self.assertNotIn("ray_runtime_context", json.loads(result))
+
+
+class TestCompressingRotatingFileHandler(unittest.TestCase):
+    """Tests for the custom rolling, compressing log handler."""
+
+    def setUp(self):
+        import tempfile
+        import pathlib
+
+        self.tmpdir = pathlib.Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _logger_with_handler(self, **kwargs):
+        import logging
+        from deltacat.logs import CompressingRotatingFileHandler
+
+        handler = CompressingRotatingFileHandler(self.tmpdir / "test.log", **kwargs)
+        logger = logging.getLogger(f"test_{id(handler)}")
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        return logger, handler
+
+    def test_rollover_and_compression(self):
+        import gzip
+
+        logger, handler = self._logger_with_handler(maxBytes=200, backupCount=1)
+
+        for _ in range(50):
+            logger.info("a" * 50)
+        handler.close()
+
+        gz_files = list(self.tmpdir.glob("*.gz"))
+        self.assertTrue(gz_files, "Expected at least one compressed file")
+
+        for path in gz_files:
+            with gzip.open(path, "rt") as f:
+                text = f.read()
+            self.assertIn("a", text)
+
+    def test_backup_count_limit(self):
+        logger, handler = self._logger_with_handler(maxBytes=200, backupCount=2)
+        for _ in range(200):
+            logger.info("b" * 50)
+        handler.close()
+
+        gz_files = list(self.tmpdir.glob("*.gz"))
+        self.assertLessEqual(len(gz_files), 2)
+
+    def test_configured_logger_uses_custom_handler(self):
+        import logging
+        from deltacat import logs
+
+        logger = logging.getLogger(f"configured_test_{id(self)}")
+        adapter = logs.configure_deltacat_logger(logger)
+        handler_types = {type(h).__name__ for h in adapter.logger.handlers}
+        self.assertIn("CompressingRotatingFileHandler", handler_types)


### PR DESCRIPTION
## Summary

Updated rolling log file appenders to use cutoff size 64MiB per log, archive and compress the last 10 files. Added according unit tests. 

+ Also had to add manual fix to clear stale module in test_file_object_store because 1/6 tests kept failing when the whole unit test suite is run(likely stale patches carrying over). 

## Rationale

Limiting log file growth. 

## Changes

- Updated log file size limit
- Added log file compression
- Unit tests

## Testing

Test suites

## Regression Risk

If this is a bugfix, assess the risk of regression caused by this fix and steps taken to mitigate it.

## Checklist

- [ x] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [ ] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
