### PR TITLE
Handle compacting an empty delta

### DIFF
--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -178,7 +178,9 @@ def _execute_compaction(
 
     if merged_delta:
         # Record information, logging, and return ExecutionCompactionResult
-        record_info_msg: str = f" Materialized records: {merged_delta.meta.record_count}"
+        record_info_msg: str = (
+            f" Materialized records: {merged_delta.meta.record_count}"
+        )
         logger.info(record_info_msg)
         compacted_delta: Delta = params.deltacat_storage.commit_delta(
             merged_delta,

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -27,16 +27,12 @@ from deltacat.compute.compactor_v2.deletes.delete_file_envelope import (
 from deltacat.storage import (
     Delta,
     DeltaLocator,
-    DeltaType,
     Manifest,
-    ManifestEntryList,
-    ManifestMeta,
     Partition,
 )
 from deltacat.compute.compactor.model.compact_partition_params import (
     CompactPartitionParams,
 )
-from deltacat.utils.common import current_time_ms
 from deltacat.utils.resources import (
     get_current_process_peak_memory_usage_in_bytes,
 )
@@ -160,6 +156,7 @@ def _execute_compaction(
     logger.info(f"Length of grouped uniform deltas is: {len(uniform_deltas_grouped)}")
     merge_result_list: List[MergeResult] = []
     compacted_partition = _stage_new_partition(params)
+    logger.info(f"Got staged compacted partition: {compacted_partition}")
     for uniform_deltas in uniform_deltas_grouped:
         # run hash and merge
         _run_hash_and_merge_result: List[MergeResult] = _run_hash_and_merge(
@@ -175,45 +172,30 @@ def _execute_compaction(
         merge_result_list.extend(_run_hash_and_merge_result)
     # process merge results
     process_merge_results: tuple[
-        Optional[Delta], list[MaterializeResult], dict
-    ] = _process_merge_results(params, merge_result_list, compaction_audit)
+        Delta, list[MaterializeResult], dict
+    ] = _process_merge_results(
+        params, merge_result_list, compaction_audit, compacted_partition
+    )
     merged_delta, mat_results, hb_id_to_entry_indices_range = process_merge_results
 
-    if merged_delta:
-        # Record information, logging, and return ExecutionCompactionResult
-        record_info_msg: str = (
-            f" Materialized records: {merged_delta.meta.record_count}"
-        )
-        logger.info(record_info_msg)
-    else:
-        # Avoid committing an empty delta
-        logger.info("No compacted delta found, committing an empty delta...")
-        merged_delta = Delta.of(
-            DeltaLocator.of(
-                compacted_partition.locator,
-                None,
-            ),
-            DeltaType.UPSERT,
-            ManifestMeta(),
-            {},
-            Manifest.of(ManifestEntryList()),
-        )
+    # Record information, logging, and return ExecutionCompactionResult
+    record_info_msg: str = f" Materialized records: {merged_delta.meta.record_count}"
+    logger.info(record_info_msg)
 
     compacted_delta: Delta = params.deltacat_storage.commit_delta(
         merged_delta,
         properties=kwargs.get("properties", {}),
         **params.deltacat_storage_kwargs,
     )
-    new_compacted_delta_locator: DeltaLocator = DeltaLocator.of(
-        compacted_partition.locator,
-        compacted_delta.stream_position,
-    )
 
     logger.info(f"Committed compacted delta: {compacted_delta}")
-
     compaction_end_time: float = time.monotonic()
     compaction_audit.set_compaction_time_in_seconds(
         compaction_end_time - compaction_start_time
+    )
+    new_compacted_delta_locator: DeltaLocator = DeltaLocator.of(
+        compacted_partition.locator,
+        compacted_delta.stream_position,
     )
     pyarrow_write_result: PyArrowWriteResult = PyArrowWriteResult.union(
         [m.pyarrow_write_result for m in mat_results]

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -27,7 +27,10 @@ from deltacat.compute.compactor_v2.deletes.delete_file_envelope import (
 from deltacat.storage import (
     Delta,
     DeltaLocator,
+    DeltaType,
     Manifest,
+    ManifestEntryList,
+    ManifestMeta,
     Partition,
 )
 from deltacat.compute.compactor.model.compact_partition_params import (
@@ -182,24 +185,32 @@ def _execute_compaction(
             f" Materialized records: {merged_delta.meta.record_count}"
         )
         logger.info(record_info_msg)
-        compacted_delta: Delta = params.deltacat_storage.commit_delta(
-            merged_delta,
-            properties=kwargs.get("properties", {}),
-            **params.deltacat_storage_kwargs,
-        )
-        new_compacted_delta_locator: DeltaLocator = DeltaLocator.of(
-            compacted_partition.locator,
-            compacted_delta.stream_position,
-        )
-
-        logger.info(f"Committed compacted delta: {compacted_delta}")
     else:
         # Avoid committing an empty delta
-        logger.info("No compacted delta found, skipping committing step...")
-        new_compacted_delta_locator: DeltaLocator = DeltaLocator.of(
-            compacted_partition.locator,
-            current_time_ms(),
+        logger.info("No compacted delta found, committing an empty delta...")
+        merged_delta = Delta.of(
+            DeltaLocator.of(
+                compacted_partition.locator,
+                None,
+            ),
+            DeltaType.UPSERT,
+            ManifestMeta(),
+            {},
+            Manifest.of(ManifestEntryList()),
         )
+
+    compacted_delta: Delta = params.deltacat_storage.commit_delta(
+        merged_delta,
+        properties=kwargs.get("properties", {}),
+        **params.deltacat_storage_kwargs,
+    )
+    new_compacted_delta_locator: DeltaLocator = DeltaLocator.of(
+        compacted_partition.locator,
+        compacted_delta.stream_position,
+    )
+
+    logger.info(f"Committed compacted delta: {compacted_delta}")
+
     compaction_end_time: float = time.monotonic()
     compaction_audit.set_compaction_time_in_seconds(
         compaction_end_time - compaction_start_time

--- a/deltacat/compute/compactor_v2/compaction_session.py
+++ b/deltacat/compute/compactor_v2/compaction_session.py
@@ -33,6 +33,7 @@ from deltacat.storage import (
 from deltacat.compute.compactor.model.compact_partition_params import (
     CompactPartitionParams,
 )
+from deltacat.utils.common import current_time_ms
 from deltacat.utils.resources import (
     get_current_process_peak_memory_usage_in_bytes,
 )
@@ -171,26 +172,35 @@ def _execute_compaction(
         merge_result_list.extend(_run_hash_and_merge_result)
     # process merge results
     process_merge_results: tuple[
-        Delta, list[MaterializeResult], dict
+        Optional[Delta], list[MaterializeResult], dict
     ] = _process_merge_results(params, merge_result_list, compaction_audit)
     merged_delta, mat_results, hb_id_to_entry_indices_range = process_merge_results
-    # Record information, logging, and return ExecutionCompactionResult
-    record_info_msg: str = f" Materialized records: {merged_delta.meta.record_count}"
-    logger.info(record_info_msg)
-    compacted_delta: Delta = params.deltacat_storage.commit_delta(
-        merged_delta,
-        properties=kwargs.get("properties", {}),
-        **params.deltacat_storage_kwargs,
-    )
 
-    logger.info(f"Committed compacted delta: {compacted_delta}")
+    if merged_delta:
+        # Record information, logging, and return ExecutionCompactionResult
+        record_info_msg: str = f" Materialized records: {merged_delta.meta.record_count}"
+        logger.info(record_info_msg)
+        compacted_delta: Delta = params.deltacat_storage.commit_delta(
+            merged_delta,
+            properties=kwargs.get("properties", {}),
+            **params.deltacat_storage_kwargs,
+        )
+        new_compacted_delta_locator: DeltaLocator = DeltaLocator.of(
+            compacted_partition.locator,
+            compacted_delta.stream_position,
+        )
+
+        logger.info(f"Committed compacted delta: {compacted_delta}")
+    else:
+        # Avoid committing an empty delta
+        logger.info("No compacted delta found, skipping committing step...")
+        new_compacted_delta_locator: DeltaLocator = DeltaLocator.of(
+            compacted_partition.locator,
+            current_time_ms(),
+        )
     compaction_end_time: float = time.monotonic()
     compaction_audit.set_compaction_time_in_seconds(
         compaction_end_time - compaction_start_time
-    )
-    new_compacted_delta_locator: DeltaLocator = DeltaLocator.of(
-        compacted_partition.locator,
-        compacted_delta.stream_position,
     )
     pyarrow_write_result: PyArrowWriteResult = PyArrowWriteResult.union(
         [m.pyarrow_write_result for m in mat_results]

--- a/deltacat/compute/compactor_v2/private/compaction_utils.py
+++ b/deltacat/compute/compactor_v2/private/compaction_utils.py
@@ -350,9 +350,10 @@ def _run_hash_and_merge(
     mutable_compaction_audit.set_records_deduped(total_dd_record_count.item())
     mutable_compaction_audit.set_records_deleted(total_deleted_record_count.item())
     record_info_msg: str = (
-        f"Hash bucket records: {total_hb_record_count},"
-        f" Deduped records: {total_dd_record_count}, "
-        f" Deleted records: {total_deleted_record_count}, "
+        f"Hash bucket records: {total_hb_record_count}, "
+        f"Input records: {total_input_records_count}, "
+        f"Deduped records: {total_dd_record_count}, "
+        f"Deleted records: {total_deleted_record_count}."
     )
     logger.info(record_info_msg)
     telemetry_this_round = telemetry_time_hb + telemetry_time_merge
@@ -560,7 +561,7 @@ def _process_merge_results(
     params: CompactPartitionParams,
     merge_results: List[MergeResult],
     mutable_compaction_audit: CompactionSessionAuditInfo,
-) -> tuple[Delta, List[MaterializeResult], dict]:
+) -> tuple[Optional[Delta], List[MaterializeResult], dict]:
     mat_results = []
     for merge_result in merge_results:
         mat_results.extend(merge_result.materialize_results)
@@ -602,12 +603,16 @@ def _process_merge_results(
         **params.s3_client_kwargs,
     )
     deltas: List[Delta] = [m.delta for m in mat_results]
-    # Note: An appropriate last stream position must be set
-    # to avoid correctness issue.
-    merged_delta: Delta = Delta.merge_deltas(
-        deltas,
-        stream_position=params.last_stream_position_to_compact,
-    )
+    if deltas:
+        # Note: An appropriate last stream position must be set
+        # to avoid correctness issue.
+        merged_delta: Optional[Delta] = Delta.merge_deltas(
+            deltas,
+            stream_position=params.last_stream_position_to_compact,
+        )
+    else:
+        logger.info("No deltas found to merge!")
+        merged_delta = None
 
     return merged_delta, mat_results, hb_id_to_entry_indices_range
 

--- a/deltacat/compute/compactor_v2/private/compaction_utils.py
+++ b/deltacat/compute/compactor_v2/private/compaction_utils.py
@@ -56,6 +56,7 @@ from deltacat.storage import (
 from deltacat.compute.compactor.model.compact_partition_params import (
     CompactPartitionParams,
 )
+from deltacat.utils.common import current_time_ms
 from deltacat.utils.ray_utils.concurrency import (
     invoke_parallel,
     task_resource_options_provider,
@@ -618,13 +619,14 @@ def _process_merge_results(
         merged_delta: Delta = Delta.of(
             DeltaLocator.of(
                 compacted_partition.locator,
-                None,
+                current_time_ms(),
             ),
             DeltaType.UPSERT,
             empty_manifest.meta,
             {},
             empty_manifest,
         )
+        logger.info(f"Created empty delta: {merged_delta}")
 
     return merged_delta, mat_results, hb_id_to_entry_indices_range
 

--- a/deltacat/compute/compactor_v2/private/compaction_utils.py
+++ b/deltacat/compute/compactor_v2/private/compaction_utils.py
@@ -49,6 +49,8 @@ from deltacat.storage import (
     DeltaLocator,
     Partition,
     Manifest,
+    ManifestEntryList,
+    ManifestMeta,
     Stream,
     StreamLocator,
 )
@@ -561,7 +563,8 @@ def _process_merge_results(
     params: CompactPartitionParams,
     merge_results: List[MergeResult],
     mutable_compaction_audit: CompactionSessionAuditInfo,
-) -> tuple[Optional[Delta], List[MaterializeResult], dict]:
+    compacted_partition: Partition,
+) -> tuple[Delta, List[MaterializeResult], dict]:
     mat_results = []
     for merge_result in merge_results:
         mat_results.extend(merge_result.materialize_results)
@@ -606,13 +609,23 @@ def _process_merge_results(
     if deltas:
         # Note: An appropriate last stream position must be set
         # to avoid correctness issue.
-        merged_delta: Optional[Delta] = Delta.merge_deltas(
+        merged_delta: Delta = Delta.merge_deltas(
             deltas,
             stream_position=params.last_stream_position_to_compact,
         )
     else:
-        logger.info("No deltas found to merge!")
-        merged_delta = None
+        logger.info("No deltas found to merge, returning an empty delta...")
+        empty_manifest = Manifest.of(ManifestEntryList())
+        merged_delta: Delta = Delta.of(
+            DeltaLocator.of(
+                compacted_partition.locator,
+                None,
+            ),
+            DeltaType.UPSERT,
+            empty_manifest.meta,
+            {},
+            empty_manifest,
+        )
 
     return merged_delta, mat_results, hb_id_to_entry_indices_range
 

--- a/deltacat/compute/compactor_v2/private/compaction_utils.py
+++ b/deltacat/compute/compactor_v2/private/compaction_utils.py
@@ -50,7 +50,6 @@ from deltacat.storage import (
     Partition,
     Manifest,
     ManifestEntryList,
-    ManifestMeta,
     Stream,
     StreamLocator,
 )


### PR DESCRIPTION
## Summary

This change handles the case where the delta results in no materialize results. In this case, committing the delta will be skipped in favor of directly writing back the RCF.

## Rationale

Empty deltas may occur, which will result in an assertion error during the merge deltas step while processing the merge results.

## Changes

List the major changes made in this pull request.

## Impact

Discuss any potential impacts the changes may have on existing functionalities.

## Testing

Describe how the changes have been tested, including both automated and manual testing strategies.
If this is a bugfix, explain how the fix has been tested to ensure the bug is resolved without introducing new issues.

## Regression Risk

If this is a bugfix, assess the risk of regression caused by this fix and steps taken to mitigate it.

## Checklist

- [ ] Unit tests covering the changes have been added
  - [ ] If this is a bugfix, regression tests have been added

- [x] E2E testing has been performed

## Additional Notes

Any additional information or context relevant to this PR.
