### PR TITLE
Patch version bump for `main` branch from 1.1.40 to 1.1.41

### DIFF
--- a/deltacat/__init__.py
+++ b/deltacat/__init__.py
@@ -44,7 +44,7 @@ from deltacat.types.tables import TableWriteMode
 
 deltacat.logs.configure_deltacat_logger(logging.getLogger(__name__))
 
-__version__ = "1.1.40"
+__version__ = "1.1.41"
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

Patch version bump from 1.1.40 to 1.1.41 on the `main` branch.

## Rationale

Follows the merge of #606 (placement group test fixes and dev dependency bumps). Bumping the patch version prepares the next release.

## Changes

- Updated `__version__` in `deltacat/__init__.py` from `"1.1.40"` to `"1.1.41"`

## Impact

None. Version string change only.

## Testing

No functional changes to test. CI passes.

## Regression Risk

None.

## Checklist
- [x] Unit tests covering the changes have been added
  - N/A — no functional changes
- [x] E2E testing has been performed

## Additional Notes

Standard patch version bump following #606.
